### PR TITLE
feat: image reads, system prompt in transcript, rules in system prompt

### DIFF
--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -302,9 +302,13 @@
 	.comment-gutter {
 		position: relative;
 		flex-shrink: 0;
-		width: 220px;
-		min-width: 220px;
-		max-width: 220px;
+		/* Keep in sync with `.plain-editor-shell.has-comment-gutter`'s
+		 * third grid column in TiptapEditor.svelte. Compromise between
+		 * the original 220px (felt too wide collapsed) and 180px (too
+		 * narrow for an expanded thread with code paths / long URLs). */
+		width: 200px;
+		min-width: 200px;
+		max-width: 200px;
 		height: 100%;
 		padding: 0 10px 20px;
 		box-sizing: border-box;

--- a/src/lib/components/OutlinePane.svelte
+++ b/src/lib/components/OutlinePane.svelte
@@ -138,6 +138,16 @@
 	});
 
 	let totalRounds = $derived(allRounds.reduce((n, g) => n + g.rounds.length, 0));
+	/** True when every review sub-section (edits, comments, proposed rules,
+	 * proposed hooks) has nothing to show. Drives the empty-state header
+	 * — without it the lower-right pane is just a blank surface and there's
+	 * no label telling the user what this space is for. */
+	let nothingPending = $derived(
+		totalRounds === 0 &&
+			pendingRuleProposals.length === 0 &&
+			pendingHookProposals.length === 0 &&
+			allComments.every((g) => g.threads.every((t) => seenIds.has(t.id)))
+	);
 
 	function basename(path: string): string {
 		return path.split('/').pop() ?? path;
@@ -340,17 +350,17 @@
 						<div class="pending-actions" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="presentation">
 							{#if isActiveTab}
 								<button class="btn-accept" onclick={() => onAccept?.(round.id)}>
-									<Check size={12} />Accept
+									<Check size={11} />Accept
 								</button>
 							{:else}
 								<span class="action-note" title="Switch to this file to accept/reject">Open file to review</span>
 							{/if}
 							{#if isActiveTab}
 								<button class="btn-reject" onclick={() => onReject?.(round.id)}>
-									<X size={12} />Reject
+									<X size={11} />Reject
 								</button>
 								<button class="btn-retry" onclick={() => openRetryFeedback(round.id)}>
-									<RotateCcw size={12} />Retry with feedback
+									<RotateCcw size={11} />Retry with feedback
 								</button>
 							{/if}
 						</div>
@@ -455,6 +465,16 @@
 					</div>
 				</div>
 			{/each}
+		</div>
+	{/if}
+
+	{#if showReview && nothingPending}
+		<div class="section">
+			<div class="section-header">
+				<Sparkles size={12} />
+				Pending agent suggestions
+			</div>
+			<div class="empty">No agent suggestions yet.</div>
 		</div>
 	{/if}
 </div>
@@ -654,16 +674,26 @@
 	.hook-matcher-tag { font-family: 'SF Mono', 'Menlo', monospace; font-size: 10px; color: var(--text-faint); padding: 1px 0; }
 	.hook-command { font-family: 'SF Mono', 'Menlo', monospace; font-size: 11.5px; color: var(--text); line-height: 1.4; margin-bottom: 6px; word-break: break-word; }
 	.pending-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+	/* Fill the card width so the actions don't bunch up on the left.
+	 * Accept + Reject share a balanced top row; "Retry with feedback"
+	 * gets its own full-width row below (basis 100% forces the wrap),
+	 * keeping it clearly labelled without crowding the primary actions.
+	 * Two-button cards (rule / hook proposals) just get even halves. */
+	.pending-actions .btn-accept,
+	.pending-actions .btn-reject { flex: 1 1 0; }
+	.pending-actions .btn-retry { flex: 1 1 100%; }
 	.btn-accept, .btn-reject, .btn-retry, .btn-secondary {
-		flex: 1 1 0;
-		display: flex;
+		flex: 0 1 auto;
+		display: inline-flex;
 		align-items: center;
 		justify-content: center;
 		gap: 4px;
-		padding: 5px 8px;
+		padding: 3px 8px;
 		border-radius: 4px;
-		font-size: 12px;
+		font-size: 11px;
 		font-weight: 500;
+		line-height: 1.4;
+		white-space: nowrap;
 		cursor: pointer;
 		border: 1px solid var(--border-light);
 		background: var(--bg-elevated);

--- a/src/lib/components/SessionViewer.svelte
+++ b/src/lib/components/SessionViewer.svelte
@@ -610,7 +610,7 @@
 							{/if}
 						</div>
 					{/if}
-					{#each events as ev, i}
+						{#each events as ev, i}
 						{#if visibleIndices[i] !== false}
 							{@const result = ev._result}
 							{@const resultError = ev._resultError}

--- a/src/lib/editor-extensions.ts
+++ b/src/lib/editor-extensions.ts
@@ -6,6 +6,7 @@ import HardBreak from '@tiptap/extension-hard-break';
 import Collaboration from '@tiptap/extension-collaboration';
 import type { Extensions } from '@tiptap/core';
 import type * as Y from 'yjs';
+import { USER_ORIGIN } from '$lib/shared/ydoc-codec';
 
 /** Plain-text extension set: minimal schema (doc, paragraph, text, hard-break).
  * Every file — including `.md` / `.markdown` / `.mdx` — is rendered as source
@@ -26,13 +27,26 @@ export function plainBaseExtensions(options?: { placeholder?: string }): Extensi
 
 /** Collaborative wrapper: attaches ySyncPlugin + yUndoPlugin to the editor
  * and binds them to the supplied Y.Doc's `default` XmlFragment. Always plain
- * text — see `plainBaseExtensions` for why. */
+ * text — see `plainBaseExtensions` for why.
+ *
+ * `yUndoOptions.trackedOrigins` is additive: y-prosemirror's yUndoPlugin
+ * always tracks `ySyncPluginKey` (so local typing stays undoable) and
+ * concatenates whatever we pass here. Including `USER_ORIGIN` makes the
+ * server-side accept / reject / reject-all transactions undoable from
+ * the client — ctrl+z after an Accept reverts the text edit AND
+ * resurrects the just-deleted pending review card in one step (they're
+ * applied in a single `ydoc.transact(..., USER_ORIGIN)`, so the
+ * UndoManager treats them as one stack entry). */
 export function collaborativeExtensions(
 	ydoc: Y.Doc,
 	options?: { placeholder?: string }
 ): Extensions {
 	return [
 		...plainBaseExtensions(options),
-		Collaboration.configure({ document: ydoc, field: 'default' })
+		Collaboration.configure({
+			document: ydoc,
+			field: 'default',
+			yUndoOptions: { trackedOrigins: [USER_ORIGIN] }
+		})
 	];
 }

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -19,6 +19,8 @@
 		findStep,
 		type FindState
 	} from './find-overlay';
+	import { MediaOverlay } from './media-overlay';
+	import { handleEditorPaste, handleEditorDrop } from './media-paste';
 	import FindBar from '$lib/components/FindBar.svelte';
 	import PreviewButton from '$lib/components/PreviewButton.svelte';
 	import CommentGutter from '$lib/components/CommentGutter.svelte';
@@ -74,7 +76,17 @@
 	editorFontScale.subscribe((v) => (fontScale = v));
 	let softWrap = $state(false);
 	editorSoftWrap.subscribe((v) => (softWrap = v));
-	let plainLineRows = $state<string[]>(['1']);
+	/** Per-paragraph row entries for the line gutter. Each row carries a
+	 * label and an absolute `top` offset (px) from the editor content's
+	 * top. Absolute positioning lets the gutter follow paragraphs through
+	 * any vertical space introduced by media-overlay widgets, diff
+	 * decorations, or soft-wrap continuations — `1` stays next to its
+	 * markdown line even when a 360px image widget sits below it. */
+	let plainLineRows = $state<Array<{ label: string; top: number }>>([{ label: '1', top: 0 }]);
+	/** Total content height the gutter must span; without this, the gutter
+	 * collapses to 0 (children are absolutely positioned) and the
+	 * border-right disappears. */
+	let plainGutterMinHeight = $state(0);
 	let hasPendingProposal = false;
 	let pointerSelecting = false;
 	let shouldFocusFeedbackInput = false;
@@ -99,7 +111,8 @@
 	let feedbackInput = $state('');
 	/** Routing mode for the current feedback submission. `auto` lets the
 	 * agent decide comment vs. edit; `edit` forces an edit_doc call;
-	 * `discuss` forces a post_comment call. Resets to `auto` whenever the
+	 * `discuss` forces a reply_to_comment call on the user-opened thread.
+	 * Resets to `auto` whenever the
 	 * popup closes so each feedback session starts fresh. */
 	let feedbackMode = $state<FeedbackMode>('auto');
 
@@ -277,7 +290,7 @@
 			? `The user flagged this passage with feedback "${label}"`
 			: `The user flagged this passage as "${label}"`;
 		const threadHint = threadId
-			? ` A thread is already open for this feedback (thread_id="${threadId}"). If you comment, use post_comment with that thread_id — do not open a new thread.`
+			? ` A thread is already open for this feedback (thread_id="${threadId}"). If you reply, use reply_to_comment with that thread_id. You cannot open new threads.`
 			: '';
 		return `${prefix}. ${tag} ${verb} it: "${passage}"${threadHint}`;
 	}
@@ -402,62 +415,36 @@
 		]);
 	}
 
-	function logicalPlainLineCount(): number {
-		if (!editor) return 1;
-		let count = 0;
-		editor.state.doc.forEach((node) => {
-			if (node.content.size === 0) {
-				count += 1;
-				return;
-			}
-			let blockLines = 1;
-			node.forEach((child) => {
-				if (child.type?.name === 'hardBreak') blockLines += 1;
-			});
-			count += blockLines;
-		});
-		return Math.max(1, count);
-	}
-
 	function syncPlainLineRows() {
 		if (!editor) return;
 		const contentEl = editor.view.dom as HTMLElement | null;
-		const lineHeight = contentEl
-			? parseFloat(getComputedStyle(contentEl).lineHeight || '0')
-			: 0;
-		if (hasPendingProposal && contentEl && lineHeight) {
-			const totalRows = Math.max(1, Math.round(contentEl.getBoundingClientRect().height / lineHeight));
-			plainLineRows = Array.from({ length: totalRows }, (_, i) => String(i + 1));
-			return;
-		}
-		const logicalCount = logicalPlainLineCount();
-		if (!softWrap) {
-			plainLineRows = Array.from({ length: logicalCount }, (_, i) => String(i + 1));
-			return;
-		}
-		const paragraphs = contentEl
-			? Array.from(contentEl.querySelectorAll(':scope > p'))
-			: [];
-		if (paragraphs.length === 0) {
-			plainLineRows = Array.from({ length: logicalCount }, (_, i) => String(i + 1));
-			return;
-		}
-		if (!contentEl) {
-			plainLineRows = Array.from({ length: logicalCount }, (_, i) => String(i + 1));
-			return;
-		}
+		if (!contentEl) return;
+		const lineHeight = parseFloat(getComputedStyle(contentEl).lineHeight || '0');
 		if (!lineHeight) {
-			plainLineRows = Array.from({ length: logicalCount }, (_, i) => String(i + 1));
+			plainLineRows = [{ label: '1', top: 0 }];
 			return;
 		}
-		const rows: string[] = [];
-		paragraphs.forEach((paragraph, index) => {
-			const height = paragraph.getBoundingClientRect().height;
-			const visualRows = Math.max(1, Math.round(height / lineHeight));
-			rows.push(String(index + 1));
-			for (let i = 1; i < visualRows; i += 1) rows.push('');
+		const paragraphs = Array.from(
+			contentEl.querySelectorAll(':scope > p')
+		) as HTMLElement[];
+		const contentRect = contentEl.getBoundingClientRect();
+		if (paragraphs.length === 0) {
+			plainLineRows = [{ label: '1', top: 0 }];
+			plainGutterMinHeight = Math.max(lineHeight, contentRect.height);
+			return;
+		}
+		// Number every paragraph at its actual top — labels stay sequential
+		// (1, 2, 3, …) even when a media-overlay thumbnail or diff ghost
+		// pushes paragraph N+1 hundreds of pixels down. Absolute positioning
+		// is the only way to do this; a flow column with 1.45em pitch
+		// breaks the moment any block-level chrome between paragraphs
+		// adds height the gutter doesn't know about.
+		const contentTop = contentRect.top;
+		plainLineRows = paragraphs.map((paragraph, index) => {
+			const rect = paragraph.getBoundingClientRect();
+			return { label: String(index + 1), top: Math.max(0, rect.top - contentTop) };
 		});
-		plainLineRows = rows.length > 0 ? rows : ['1'];
+		plainGutterMinHeight = Math.max(lineHeight, contentRect.height);
 	}
 
 	function schedulePlainLineSync() {
@@ -517,15 +504,13 @@
 	let currentRoundsList: Array<{ id: string; beforeMd?: string; afterMd?: string }> = [];
 	pendingReviewRounds.subscribe((v) => {
 		allRoundsTiny = v.length > 0 && v.every((r) => r.kind === 'tiny');
-		// Show only the EARLIEST pending round's diff at a time. Rounds
-		// accept FIFO (per the OutlinePane Accept logic), so the visible
-		// diff corresponds 1:1 to the round that's actually clickable —
-		// the inline ✓ on any block in this overlay refers to "this
-		// edit" with no ambiguity. After the user accepts, baseline
-		// auto-updates (reviewBaseline subscribes to the post-accept
-		// live Y.Doc text) and the next pending round becomes the new
-		// visible diff.
-		currentProposalText = v.length > 0 ? v[0].afterMd ?? null : null;
+		// Compose the full pending stack in the overlay: baseline is
+		// rounds[0].beforeMd (via reviewBaseline) and the proposal is the
+		// last round's afterMd (all ops applied in order). The inline ✓
+		// still accepts only rounds[0] (FIFO); after accept the next
+		// round becomes visible.
+		currentProposalText =
+			v.length > 0 ? (v[v.length - 1].afterMd ?? null) : null;
 		currentRoundsList = v;
 		hasPendingProposal = v.length > 0;
 		schedulePlainLineSync();
@@ -790,12 +775,15 @@
 				DiffOverlay,
 				CommentOverlay,
 				CelebrationOverlay,
-				FindOverlay
+				FindOverlay,
+				MediaOverlay
 			],
 			// Collaboration provides initial content from the Y.Doc; do NOT
 			// pass a string `content` here (doing so would wipe the Y.Doc).
 			editorProps: {
 				attributes: { class: 'tiptap-content tiptap-plain' },
+				handlePaste: (view, event) => handleEditorPaste(view, event).handled,
+				handleDrop: (view, event) => handleEditorDrop(view, event as DragEvent).handled,
 				handleKeyDown: (_view, event) => {
 					// Cmd/Ctrl+F opens the find bar. Block the browser's
 					// native find dialog so we own the in-doc search UX.
@@ -1037,9 +1025,13 @@
 		class:soft-wrap-enabled={softWrap}
 		class:has-comment-gutter={threadsForTab.some((t) => !t.resolved)}
 	>
-		<div class="plain-line-gutter" aria-hidden="true">
-			{#each plainLineRows as line}
-				<div class="plain-line-number">{line}</div>
+		<div
+			class="plain-line-gutter"
+			aria-hidden="true"
+			style:min-height="{plainGutterMinHeight}px"
+		>
+			{#each plainLineRows as row}
+				<div class="plain-line-number" style:top="{row.top}px">{row.label}</div>
 			{/each}
 		</div>
 		<div class="tiptap-editor plain-mode" class:soft-wrap-enabled={softWrap} bind:this={element}></div>
@@ -1077,9 +1069,9 @@
 					].join('\n');
 					const trigger =
 						`The user replied on comment thread "${t.id}" on this tab. ` +
-						`Decide whether to reply on the same thread (call post_comment with thread_id "${t.id}") or, ` +
+						`Decide whether to reply on the same thread (call reply_to_comment with thread_id "${t.id}") or, ` +
 						`if the user's reply is now a clear edit request, call edit_doc instead. ` +
-						`Do NOT open a new thread for this reply.\n\n` +
+						`You cannot open new threads.\n\n` +
 						`Anchor passage: "${t.anchor.quote}"\n` +
 						`User's latest reply: "${replyText}"\n` +
 						`Full thread (latest reply included):\n${transcript}`;
@@ -1236,7 +1228,7 @@
 		min-width: 0;
 		overflow-y: auto;
 		/* Tighter right padding when there's no comment gutter — the gutter
-		 * column adds ~220px of breathing room on the right when comments
+		 * column adds ~180px of breathing room on the right when comments
 		 * exist, so the wrapper itself doesn't need much. Without comments
 		 * we still want a small gap so prose doesn't kiss the right edge. */
 		padding: 48px 12px 48px 32px;
@@ -1262,21 +1254,29 @@
 		/* Third column reserved for the right-side comment gutter so
 		 * thread cards sit in a stable column beside the editor rather
 		 * than floating over the prose. Width matches CommentGutter's
-		 * fixed inner width. */
-		grid-template-columns: 52px minmax(0, 1fr) 220px;
+		 * fixed inner width — keep this and the `.comment-gutter` rule
+		 * in CommentGutter.svelte in sync. */
+		grid-template-columns: 52px minmax(0, 1fr) 200px;
 	}
 	.plain-editor-shell.soft-wrap-enabled {
 		width: 100%;
 	}
 	.plain-line-gutter {
+		position: relative;
 		align-self: start;
-		padding: 2px 12px 0 0;
+		/* No padding: when children are absolutely positioned, gutter
+		 * padding doesn't reserve visual space for them — instead the
+		 * number itself owns its right inset (so it stops short of the
+		 * border) and its width (so multi-digit and single-digit numbers
+		 * right-align consistently). Padding-top would also offset all
+		 * line numbers down because their `top` values are measured from
+		 * the editor's content top, not from this padding edge. */
+		padding: 0;
 		border-right: 1px solid var(--border-light);
 		color: var(--text-faint);
 		font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 		font-size: calc(15px * var(--font-scale, 1));
 		line-height: 1.45;
-		text-align: right;
 		user-select: none;
 		pointer-events: none;
 		/* Match prose canvas (--bg). Never mix bg-surface with `transparent`:
@@ -1284,7 +1284,18 @@
 		background: var(--bg);
 	}
 	.plain-line-number {
+		position: absolute;
+		right: 0;
+		/* Match the old flow-column geometry exactly: each number block
+		 * spans the gutter's content area (40px) with a 12px right inset
+		 * so the digit stops well before the column rule. Fixed width +
+		 * `text-align: right` keeps single- and multi-digit numbers
+		 * right-aligned consistently. */
+		width: 40px;
+		padding-right: 12px;
+		box-sizing: border-box;
 		height: 1.45em;
+		text-align: right;
 	}
 	.tiptap-editor :global(.tiptap-content) {
 		max-width: 680px;
@@ -1530,17 +1541,18 @@
 	.tiptap-editor :global(.diff-accept-pill) {
 		display: inline-flex;
 		align-items: center;
-		justify-content: center;
-		width: 22px;
-		height: 22px;
-		padding: 0;
+		gap: 4px;
+		padding: 1px 8px 1px 6px;
 		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 10.5px;
+		font-weight: 500;
+		letter-spacing: 0.02em;
 		color: var(--diff-added-color);
 		background: var(--bg-elevated);
 		border: 1px solid color-mix(in srgb, var(--diff-added-color) 35%, var(--border-light));
 		border-radius: 999px;
 		cursor: pointer;
-		line-height: 1;
+		line-height: 1.4;
 		opacity: 0.85;
 		transition: background 120ms ease, border-color 120ms ease, color 120ms ease, opacity 120ms ease;
 	}
@@ -1551,6 +1563,7 @@
 	}
 	.tiptap-editor :global(.diff-accept-pill svg) {
 		display: block;
+		flex: none;
 	}
 	.tiptap-editor :global(.diff-removed) {
 		color: var(--diff-removed-color);
@@ -1565,6 +1578,15 @@
 		--diff-final-opacity: 0.72;
 		opacity: 0.72;
 		animation: diffFadeIn 320ms ease-out both;
+		position: relative;
+	}
+	/* Word-level modified paragraph: no color or strikethrough — the
+	 * paragraph reads as normal editable text and only the changed tokens
+	 * are decorated. `position: relative` is the sole effect, so the
+	 * absolutely-positioned inline "Show diff" pill anchors to this
+	 * paragraph's right margin instead of the editor edge. */
+	.tiptap-editor :global(.tiptap-plain p.diff-modified-line),
+	.tiptap-editor :global(.diff-modified-line) {
 		position: relative;
 	}
 	/* Ghost strikethrough widget for agent removals. The removed text isn't
@@ -1890,5 +1912,232 @@
 		background: color-mix(in srgb, var(--action-color) 10%, transparent);
 		border-color: var(--action-color);
 		color: var(--action-color);
+	}
+	/* Media overlay widgets — Substack-style inline previews layered on
+	 * top of plain markdown source. The thumbnail variant is a block
+	 * decoration that appears after a host paragraph; the card variant
+	 * is the body of the floating hover tooltip (`.media-link-tooltip`,
+	 * which lives in document.body). The card styles MUST be top-level
+	 * `:global` rather than scoped under `.tiptap-editor` because the
+	 * tooltip is rendered outside the editor's DOM tree — scoping under
+	 * `.tiptap-editor` would silently fail to apply, leaving the og
+	 * image to render at its native (often gigantic) size. */
+	:global(.media-widget) {
+		display: block;
+		margin: 6px 0 12px;
+		user-select: none;
+		max-width: 680px;
+	}
+	:global(.media-image-widget) {
+		display: block;
+		max-width: 100%;
+	}
+	:global(.media-thumb) {
+		display: block;
+		max-width: 100%;
+		max-height: 360px;
+		border-radius: 6px;
+		border: 1px solid var(--border-light);
+		background: var(--bg-surface);
+		object-fit: contain;
+		object-position: left center;
+		animation: media-fade-in 240ms ease-out both;
+	}
+	:global(.media-thumb-error) {
+		padding: 10px 12px;
+		border-radius: 6px;
+		border: 1px dashed var(--border-light);
+		background: var(--bg-surface);
+		color: var(--text-faint);
+		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 12px;
+	}
+	:global(.media-thumb-error-label) {
+		font-style: italic;
+	}
+	/* Link card. Row layout: image left, body right. Falls back to a
+	 * body-only card when og:image is missing. */
+	:global(.media-card-widget) {
+		display: flex;
+		gap: 12px;
+		align-items: stretch;
+		padding: 12px;
+		border: 1px solid var(--border-light);
+		border-radius: 8px;
+		background: var(--bg-elevated);
+		text-decoration: none;
+		color: inherit;
+		font-family: 'Inter', -apple-system, sans-serif;
+		min-height: 88px;
+		max-width: 560px;
+		transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+		animation: media-fade-in 240ms ease-out both;
+	}
+	:global(.media-card-widget:hover) {
+		border-color: color-mix(in srgb, var(--accent) 35%, var(--border-light));
+		background: var(--bg-hover);
+	}
+	:global(.media-card-image) {
+		flex: 0 0 88px;
+		width: 88px;
+		height: 88px;
+		overflow: hidden;
+		border-radius: 4px;
+		background: var(--bg-surface);
+	}
+	:global(.media-card-image img) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+	:global(.media-card-body) {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		gap: 4px;
+	}
+	:global(.media-card-title) {
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--text);
+		line-height: 1.35;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	:global(.media-card-desc) {
+		font-size: 12.5px;
+		color: var(--text-muted);
+		line-height: 1.4;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	:global(.media-card-host) {
+		font-size: 10.5px;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		margin-top: auto;
+	}
+	:global(.media-card-minimal) {
+		font-size: 12px;
+		color: var(--text-muted);
+		font-style: italic;
+		align-self: center;
+	}
+	/* Skeleton for the og card while metadata is fetching. The shimmer
+	 * gradient sweeps left-to-right; same hue as the surrounding chrome
+	 * so it reads as "loading" not "broken". */
+	:global(.media-card-skeleton) {
+		display: flex;
+		gap: 12px;
+		flex: 1;
+		min-width: 0;
+	}
+	:global(.media-card-skeleton-image) {
+		flex: 0 0 88px;
+		width: 88px;
+		height: 88px;
+		border-radius: 4px;
+		background: linear-gradient(
+			90deg,
+			var(--bg-surface) 0%,
+			var(--bg-hover) 50%,
+			var(--bg-surface) 100%
+		);
+		background-size: 200% 100%;
+		animation: media-shimmer 1.4s linear infinite;
+	}
+	:global(.media-card-skeleton-body) {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		justify-content: center;
+	}
+	:global(.media-card-skeleton-line) {
+		height: 10px;
+		border-radius: 3px;
+		background: linear-gradient(
+			90deg,
+			var(--bg-surface) 0%,
+			var(--bg-hover) 50%,
+			var(--bg-surface) 100%
+		);
+		background-size: 200% 100%;
+		animation: media-shimmer 1.4s linear infinite;
+	}
+	@keyframes media-shimmer {
+		from { background-position: 200% 0; }
+		to { background-position: -200% 0; }
+	}
+	@keyframes media-fade-in {
+		from { opacity: 0; transform: translateY(-2px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+	/* Inline URL mark — classic web-link affordance: accent color + solid
+	 * underline. Plain-text editor philosophy says don't mutate the
+	 * source, but visually styling URLs as links is the universal cue
+	 * that they're interactive. Hovering surfaces a floating og-card
+	 * tooltip (`.media-link-tooltip` below) — the mark stays clickable
+	 * looking even when you're not hovering. */
+	.tiptap-editor :global(.media-link-inline) {
+		color: var(--accent);
+		text-decoration: underline;
+		text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+		cursor: pointer;
+	}
+	.tiptap-editor :global(.media-link-inline:hover) {
+		text-decoration-color: var(--accent);
+	}
+	/* Floating hover tooltip. Lives in document.body (outside the editor's
+	 * scroll container) so position: fixed coordinates work without being
+	 * clipped, and so it stacks above any other editor chrome. Uses the
+	 * same `.media-card-widget` chrome the standalone-line cards use, so
+	 * the visual language is consistent — just smaller and lifted. */
+	:global(.media-link-tooltip) {
+		position: fixed;
+		z-index: 200;
+		max-width: 360px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.16));
+		animation: media-tooltip-in 160ms ease-out both;
+	}
+	:global(.media-link-tooltip .media-card-widget) {
+		max-width: 360px;
+		min-height: 0;
+		padding: 10px;
+		background: var(--bg-elevated);
+	}
+	:global(.media-link-tooltip .media-card-image) {
+		flex: 0 0 64px;
+		width: 64px;
+		height: 64px;
+	}
+	:global(.media-link-tooltip .media-card-title) {
+		font-size: 13px;
+	}
+	:global(.media-link-tooltip .media-card-desc) {
+		font-size: 11.5px;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+	}
+	:global(.media-link-tooltip .media-card-host) {
+		font-size: 10px;
+	}
+	@keyframes media-tooltip-in {
+		from { opacity: 0; transform: translateY(-3px); }
+		to { opacity: 1; transform: translateY(0); }
 	}
 </style>

--- a/src/lib/editor/char-index.ts
+++ b/src/lib/editor/char-index.ts
@@ -20,6 +20,13 @@ export interface CharIndex {
 	plainText: string;
 }
 
+/** Plain text for one top-level paragraph, matching `serializeYDoc` /
+ * `buildParagraphElements`: hard breaks become `\n` inside the line. */
+export function paragraphPlainText(node: PMNode): string {
+	if (node.content.size === 0) return '';
+	return node.textBetween(0, node.content.size, '\n', '');
+}
+
 const cache = new WeakMap<PMNode, CharIndex>();
 
 export function buildCharIndex(doc: PMNode): CharIndex {
@@ -38,6 +45,11 @@ export function buildCharIndex(doc: PMNode): CharIndex {
 			for (let i = 0; i < text.length; i += 1) {
 				positions.push(pos + i);
 			}
+		} else if (node.type.name === 'hardBreak') {
+			// Match `paragraphPlainText` / Y.Doc serialization so word-level
+			// diff decorations land on the correct inline positions.
+			segments.push('\n');
+			positions.push(pos);
 		}
 		return true;
 	});

--- a/src/lib/editor/diff-overlay.ts
+++ b/src/lib/editor/diff-overlay.ts
@@ -4,7 +4,9 @@ import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
 import { diffLines, diffWords } from 'diff';
 import type { Annotation } from '$lib/types';
 import { buildReviewDiffPreview, normalizeReviewText } from '$lib/review-diff';
-import { buildCharIndex } from './char-index';
+import { wordDiff, type DiffPart as WordDiffPart } from '$lib/diff';
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { buildCharIndex, paragraphPlainText } from './char-index';
 
 /** Memoize diffWords / diffLines by their string inputs. The diff inputs
  * (baseline + proposedText) only change when the review state changes,
@@ -37,6 +39,31 @@ function cachedDiff(
 		// Evict the oldest entry (Map iteration order is insertion order).
 		const oldest = cache.keys().next().value;
 		if (oldest !== undefined) cache.delete(oldest);
+	}
+	return out;
+}
+
+/** Memoized per-paragraph word diff. Keyed on the (before, after) string
+ * pair, same LRU discipline as `cachedDiff`. A modified paragraph's
+ * inputs only change when the user types into THAT paragraph (the
+ * before-line is fixed for the round, the after-text is the live
+ * paragraph), so typing elsewhere reuses the cached result. The cap is a
+ * little larger because a single round can touch several paragraphs. */
+const wordDiffCache = new Map<string, WordDiffPart[]>();
+const WORD_DIFF_CACHE_MAX = 32;
+function cachedWordDiff(before: string, after: string): WordDiffPart[] {
+	const key = `${before.length}|${before}\x00${after}`;
+	const hit = wordDiffCache.get(key);
+	if (hit) {
+		wordDiffCache.delete(key);
+		wordDiffCache.set(key, hit);
+		return hit;
+	}
+	const out = wordDiff(before, after);
+	wordDiffCache.set(key, out);
+	if (wordDiffCache.size > WORD_DIFF_CACHE_MAX) {
+		const oldest = wordDiffCache.keys().next().value;
+		if (oldest !== undefined) wordDiffCache.delete(oldest);
 	}
 	return out;
 }
@@ -107,8 +134,14 @@ function toggleDiffBlock(view: EditorView, blockId: string) {
 /** Selectors that mark a DOM node as part of the diff overlay — clicks
  * on these should redirect to the nearest real (un-struck, non-widget)
  * paragraph so the user can actually type. */
+// NOTE: `.diff-added` is intentionally NOT listed. In the word-level
+// modified-paragraph path it decorates *real, editable* doc text, so a
+// click on it must place the caret normally rather than being redirected
+// around a diff block. `.diff-removed-inline` (the inline removal ghost)
+// is likewise omitted so a click near it lands in the host paragraph via
+// PM's default handling instead of jumping to a sibling.
 const DIFF_NODE_SELECTOR =
-	'.diff-added-line, .diff-removed-line, .diff-added, .diff-removed-widget';
+	'.diff-added-line, .diff-removed-line, .diff-removed-widget';
 
 function isDiffNode(el: Element | null): boolean {
 	return !!el?.matches?.(DIFF_NODE_SELECTOR);
@@ -304,7 +337,7 @@ export const DiffOverlay = Extension.create({
 								const parts = cachedDiff(diffWordsCache, baselinePlain, targetPlain, diffWords);
 
 								if (proposedText !== null && proposedText !== undefined && isPlainText) {
-									const paragraphs = paragraphRanges(state.doc);
+									const paragraphs = buildParagraphTextIndex(state.doc);
 									const lineParts = cachedDiff(
 										diffLinesCache,
 										normalizeReviewText(baseline),
@@ -325,7 +358,33 @@ export const DiffOverlay = Extension.create({
 										addedLines: string[];
 									}
 									const blocks: DiffBlock[] = [];
+									// `baselineLineIdx` tracks the running BEFORE line
+									// index. The editor doc holds the BEFORE text while
+									// a review is pending (the agent only pushes a
+									// review round; the proposed text isn't applied to
+									// the Y.Doc until Accept), so a removed line's live
+									// paragraph is `paragraphs[baselineLineIdx]`.
 									let baselineLineIdx = 0;
+									interface ModifiedPara {
+										id: string;
+										para: ParagraphTextSpan;
+										afterText: string;
+										/** `true` when the live paragraph text has
+										 * diverged from the baseline line (the user
+										 * typed into this paragraph since the
+										 * snapshot). We skip inline word-level
+										 * decorations in that case — they'd strike
+										 * chars the user just typed — but still emit
+										 * the pill so the user can see a proposal
+										 * exists, and reveal the proposed line as a
+										 * green ghost block on expand. */
+										stale: boolean;
+										/** The baseline line for the pill's change
+										 * count when `stale`. (Inline path computes
+										 * from `para.text`.) */
+										baselineText: string;
+									}
+									const modified: ModifiedPara[] = [];
 									let currentBlock: DiffBlock | null = null;
 									function ensureBlock(): DiffBlock {
 										if (currentBlock) return currentBlock;
@@ -347,7 +406,69 @@ export const DiffOverlay = Extension.create({
 										blocks.push(currentBlock);
 										currentBlock = null;
 									}
-									for (const part of lineParts) {
+									for (let i = 0; i < lineParts.length; i++) {
+										const part = lineParts[i];
+										const next = lineParts[i + 1];
+										// A removed run immediately followed by an added
+										// run is a replacement. When the line counts
+										// match 1:1, each pair is a paragraph modified
+										// in place → render a word-level inline diff
+										// instead of striking the whole paragraph, so a
+										// near-identical edit no longer looks like a
+										// wholesale rewrite (mirrors buildReviewDiffPreview).
+										if (part.removed && next?.added) {
+											const removedLines = splitLogicalLines(part.value);
+											const addedLines = splitLogicalLines(next.value);
+											const canModifyInPlace =
+												removedLines.length === addedLines.length &&
+												removedLines.every(
+													(line, k) => line !== '' && addedLines[k] !== ''
+												);
+											if (canModifyInPlace) {
+												flushBlock();
+												for (let j = 0; j < removedLines.length; j++) {
+													// Doc holds the BEFORE text → the
+													// removed line's live paragraph is at
+													// the BEFORE line index.
+													const beforeIdx = baselineLineIdx + j;
+													const para = paragraphs[beforeIdx];
+													if (!para) {
+														// No live paragraph to host the
+														// inline diff (shouldn't happen for
+														// a clean replacement) — fall back
+														// to a block so the proposed text
+														// is still visible.
+														ensureBlock().addedLines.push(addedLines[j]);
+														continue;
+													}
+													// `reviewBaseline` is captured at sync
+													// time and doesn't update as the user
+													// types. If the live paragraph has
+													// diverged from the baseline line, the
+													// user is actively editing this exact
+													// paragraph — a word-level diff against
+													// `para.text` would mark the chars they
+													// just typed as "removed". Mark the
+													// entry stale; the renderer emits the
+													// pill + a green ghost block on expand,
+													// but no inline strikes.
+													const stale = para.text !== removedLines[j];
+													modified.push({
+														id: `mod:${beforeIdx}`,
+														para,
+														afterText: addedLines[j],
+														stale,
+														baselineText: removedLines[j]
+													});
+												}
+												baselineLineIdx += removedLines.length;
+												i += 1; // consumed `next` (the added run)
+												continue;
+											}
+											// Non-1:1 replacement: fall through and let
+											// the generic removed/added branches build a
+											// block, exactly as before this change.
+										}
 										const lines = splitLogicalLines(part.value);
 										if (part.added) {
 											const block = ensureBlock();
@@ -453,6 +574,89 @@ export const DiffOverlay = Extension.create({
 												)
 											);
 										}
+									}
+
+									// ── Modified-in-place paragraphs ───────────────
+									// Word-level inline diff. The doc holds the BEFORE
+									// text, so removed tokens are struck on the real
+									// text (always shown, length-neutral) and the
+									// proposed (added) tokens are ghost widgets revealed
+									// only when the per-paragraph pill is expanded. No
+									// whole-paragraph strikethrough.
+									for (const m of modified) {
+										const expanded = expandedBlocks.has(m.id);
+										let changeGroups: number;
+										if (m.stale) {
+											// User has been typing into this paragraph
+											// since `reviewBaseline` was captured —
+											// inline strikes against `para.text` would
+											// hit the chars they just typed. Count
+											// changes from the baseline line instead,
+											// and render the proposal as a green ghost
+											// block beneath the paragraph on expand.
+											changeGroups = countWordDiffGroups(
+												m.baselineText,
+												m.afterText
+											);
+											if (changeGroups > 0 && expanded) {
+												const className = allRoundsTiny
+													? 'diff-added-line diff-added-line-tiny'
+													: 'diff-added-line';
+												const value = m.afterText;
+												decorations.push(
+													Decoration.widget(
+														m.para.pos + m.para.nodeSize,
+														(view, getPos) =>
+															createAddedLineWidget(view, getPos, value, className),
+														{
+															side: 1,
+															ignoreSelection: true,
+															key: `staleadd:${m.id}`
+														}
+													)
+												);
+											}
+										} else {
+											changeGroups = renderModifiedParagraph(
+												decorations,
+												m.para,
+												m.afterText,
+												expanded,
+												addedClass
+											);
+										}
+										if (changeGroups <= 0) continue;
+										// Positioning-only class (no color / strike):
+										// makes the paragraph the containing block for
+										// the absolutely-positioned inline pill below.
+										// Deliberately NOT in DIFF_NODE_SELECTOR — the
+										// paragraph stays normal editable text.
+										decorations.push(
+											Decoration.node(
+												m.para.pos,
+												m.para.pos + m.para.nodeSize,
+												{ class: 'diff-modified-line' }
+											)
+										);
+										decorations.push(
+											Decoration.widget(
+												m.para.pos + m.para.nodeSize - 1,
+												(view) =>
+													createDiffTogglePill(
+														view,
+														m.id,
+														changeGroups,
+														expanded,
+														true,
+														'tokens'
+													),
+												{
+													side: 1,
+													ignoreSelection: true,
+													key: `pill:${m.id}:${expanded}`
+												}
+											)
+										);
 									}
 								} else if (proposedText !== null && proposedText !== undefined) {
 									let baselineIdx = 0;
@@ -616,21 +820,175 @@ function splitLogicalLines(value: string): string[] {
 	return lines.length > 0 ? lines : [''];
 }
 
-function paragraphRanges(doc: any): Array<{ pos: number; nodeSize: number }> {
-	const ranges: Array<{ pos: number; nodeSize: number }> = [];
-	doc.forEach((node: any, offset: number) => {
-		ranges.push({ pos: offset, nodeSize: node.nodeSize });
+/** One top-level paragraph of the live doc, with the slice of the
+ * plain-text char index it occupies. `text` is the paragraph's literal
+ * content (in plain-text mode this is the raw markdown line). `charStart`
+ * / `charEnd` index into the same flat `charPositions` / `plainText` that
+ * `buildCharIndex` produces — there are no separators between paragraphs,
+ * so paragraph N's chars are `[charStart, charEnd)`. */
+interface ParagraphTextSpan {
+	pos: number;
+	nodeSize: number;
+	charStart: number;
+	charEnd: number;
+	text: string;
+	/** PM position for each char in `text` (same order as paragraphPlainText). */
+	localCharPositions: number[];
+}
+
+/** Map each character of a paragraph to its document position. Kept local
+ * to the paragraph so word-level diff decorations never read the global
+ * char index (which jumps across block boundaries and can leave only the
+ * first character of a token decorated). */
+function buildLocalCharPositions(paraNode: PMNode, paraPos: number): number[] {
+	const positions: number[] = [];
+	paraNode.forEach((child, offset) => {
+		const base = paraPos + 1 + offset;
+		if (child.isText && child.text) {
+			for (let i = 0; i < child.text.length; i += 1) {
+				positions.push(base + i);
+			}
+		} else if (child.type.name === 'hardBreak') {
+			positions.push(base);
+		}
 	});
-	return ranges;
+	return positions;
+}
+
+function buildParagraphTextIndex(doc: PMNode): ParagraphTextSpan[] {
+	const out: ParagraphTextSpan[] = [];
+	let running = 0;
+	doc.forEach((node, offset) => {
+		const text = paragraphPlainText(node);
+		out.push({
+			pos: offset,
+			nodeSize: node.nodeSize,
+			charStart: running,
+			charEnd: running + text.length,
+			text,
+			localCharPositions: buildLocalCharPositions(node, offset)
+		});
+		running += text.length;
+	});
+	return out;
 }
 
 function resolveParagraphWidgetPos(
 	docEnd: number,
-	paragraphs: Array<{ pos: number; nodeSize: number }>,
+	paragraphs: ParagraphTextSpan[],
 	lineIdx: number
 ): number {
 	if (lineIdx < paragraphs.length) return paragraphs[lineIdx].pos;
 	return docEnd;
+}
+
+/** PM position for a proposed-token ghost inside a modified paragraph. */
+function ghostPosLocal(para: ParagraphTextSpan, cursor: number): number {
+	const local = para.localCharPositions;
+	if (cursor < local.length) return local[cursor];
+	return para.pos + para.nodeSize - 1;
+}
+
+/** Count the number of distinct change groups (maximal runs of
+ * non-`same` parts) in a word diff. Used by the stale-modified path,
+ * which needs the pill's count but skips the inline decorations. */
+function countWordDiffGroups(before: string, after: string): number {
+	let groups = 0;
+	let inChange = false;
+	for (const p of cachedWordDiff(before, after)) {
+		if (p.type === 'same') {
+			inChange = false;
+			continue;
+		}
+		if (!inChange) {
+			groups += 1;
+			inChange = true;
+		}
+	}
+	return groups;
+}
+
+/** Render one paragraph that was modified in place as a word-level
+ * inline diff.
+ *
+ * While a review is pending the editor doc still holds the BEFORE text
+ * (the agent only pushes a review round; the proposed text isn't applied
+ * to the Y.Doc until Accept). So `para.text` is the original line and
+ * `afterText` is the proposed replacement. Per word-diff token:
+ *   - removed (in the doc, not in the proposal) → inline strikethrough
+ *     on the real text. Always shown — it's existing content, so the
+ *     decoration is length-neutral, and it gives the reviewer the
+ *     "what's going away" signal at a glance.
+ *   - added (in the proposal, not in the doc) → green ghost span, shown
+ *     only when `expanded`, so the collapsed view stays length-neutral
+ *     and uncluttered until the reader opens the pill.
+ *   - same → no decoration.
+ *
+ * Returns the number of distinct change groups (drives the pill count).
+ */
+function renderModifiedParagraph(
+	decorations: Decoration[],
+	para: ParagraphTextSpan,
+	afterText: string,
+	expanded: boolean,
+	addedClass: string
+): number {
+	const parts = cachedWordDiff(para.text, afterText);
+	const charPositions = para.localCharPositions;
+	let cursor = 0;
+	let changeGroups = 0;
+	let inChange = false;
+	for (const p of parts) {
+		if (p.type === 'same') {
+			inChange = false;
+			cursor += p.text.length;
+			continue;
+		}
+		if (!inChange) {
+			changeGroups += 1;
+			inChange = true;
+		}
+		if (p.type === 'removed') {
+			// Real text in the doc — strike just these tokens (not the
+			// whole paragraph). Length-neutral, so it's always rendered.
+			applyInlineClassRange(
+				decorations,
+				charPositions,
+				cursor,
+				cursor + p.text.length,
+				'diff-removed'
+			);
+			cursor += p.text.length;
+		} else if (expanded) {
+			// Proposed text is NOT in the doc; show it as a green ghost
+			// at the position it would occupy. contenteditable=false and
+			// its class is intentionally absent from DIFF_NODE_SELECTOR
+			// so a click near it lands in this paragraph normally instead
+			// of being redirected.
+			const widgetPos = ghostPosLocal(para, cursor);
+			const value = p.text;
+			decorations.push(
+				Decoration.widget(
+					widgetPos,
+					() => {
+						const span = document.createElement('span');
+						span.className = addedClass;
+						span.textContent = value;
+						span.setAttribute('contenteditable', 'false');
+						return span;
+					},
+					{
+						side: -1,
+						ignoreSelection: true,
+						key: `modadd:${para.pos}:${cursor}:${value}`
+					}
+				)
+			);
+			// Do NOT advance `cursor`: proposed text occupies no space in
+			// the BEFORE paragraph that's currently in the doc.
+		}
+	}
+	return changeGroups;
 }
 
 function createAddedLineWidget(
@@ -660,7 +1018,8 @@ function createDiffTogglePill(
 	blockId: string,
 	addedCount: number,
 	expanded: boolean,
-	inline: boolean
+	inline: boolean,
+	mode: 'lines' | 'tokens' = 'lines'
 ): HTMLElement {
 	const wrapper = document.createElement(inline ? 'span' : 'div');
 	wrapper.className = inline
@@ -671,10 +1030,20 @@ function createDiffTogglePill(
 	const toggleBtn = document.createElement('button');
 	toggleBtn.type = 'button';
 	toggleBtn.className = expanded ? 'diff-toggle-pill expanded' : 'diff-toggle-pill';
-	toggleBtn.textContent = expanded ? 'Hide' : `Show (+${addedCount})`;
-	toggleBtn.title = expanded
-		? 'Hide proposed replacement'
-		: `Show proposed replacement (+${addedCount} line${addedCount === 1 ? '' : 's'})`;
+	if (mode === 'tokens') {
+		// Modified-in-place paragraph: the count is the number of
+		// changed word groups within that paragraph, not a line count.
+		const plural = addedCount === 1 ? '' : 's';
+		toggleBtn.textContent = expanded ? 'Hide diff' : `Show diff · ${addedCount}`;
+		toggleBtn.title = expanded
+			? 'Hide the word-level diff'
+			: `Show the word-level diff (${addedCount} change${plural} in this paragraph)`;
+	} else {
+		toggleBtn.textContent = expanded ? 'Hide' : `Show (+${addedCount})`;
+		toggleBtn.title = expanded
+			? 'Hide proposed replacement'
+			: `Show proposed replacement (+${addedCount} line${addedCount === 1 ? '' : 's'})`;
+	}
 	toggleBtn.addEventListener('mousedown', (e) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -700,6 +1069,7 @@ function createDiffTogglePill(
 		<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 			<polyline points="20 6 9 17 4 12"></polyline>
 		</svg>
+		<span>Accept diff</span>
 	`;
 	acceptBtn.addEventListener('mousedown', (e) => {
 		e.preventDefault();

--- a/src/lib/editor/media-overlay.ts
+++ b/src/lib/editor/media-overlay.ts
@@ -1,0 +1,684 @@
+/**
+ * Media overlay — Substack-style inline previews for the plain-markdown
+ * editor.
+ *
+ * Same architectural shape as `diff-overlay.ts` / `comment-overlay.ts`:
+ * a ProseMirror plugin that READS the live doc and emits widget
+ * decorations. It never mutates content, never adds nodes, never alters
+ * the markdown source. The Y.Doc stays plain text.
+ *
+ * Three render modes:
+ *
+ *   1. Image thumbnail. Triggered by any `![alt](src)` token anywhere in
+ *      a paragraph (or a bare image-extension URL on its own line). A
+ *      block widget is appended after the host paragraph and renders an
+ *      `<img>` (max ~360px tall). Workspace-relative paths route through
+ *      `/api/preview`; http(s) URLs hit the host directly.
+ *
+ *   2. Inline link mark. Every absolute URL anywhere in paragraph text
+ *      gets a `Decoration.inline` with class `media-link-inline` and a
+ *      `data-url` attribute — a subtle dotted underline signals the
+ *      affordance.
+ *
+ *   3. Hover-card tooltip. A floating element (`document.body`) listens
+ *      for `mouseover` on inline link marks and renders an og card
+ *      tooltip near the hovered link. og metadata is fetched lazily via
+ *      `/api/opengraph` and cached in plugin state; while loading, the
+ *      tooltip shows a skeleton, and on fetch failure it shows a
+ *      minimal domain-only chrome.
+ *
+ * Composition with diff/comment/find/celebration overlays:
+ *   - Image widgets are block widgets AFTER the paragraph; inline link
+ *     marks are inline decorations ON existing text. Neither shares a
+ *     DOM slot with diff word/line decorations.
+ *   - When the agent rewrites a URL during a review round, the diff
+ *     overlay paints the strike+highlight on the markdown text and the
+ *     inline mark follows the live URL — hovering the new URL during
+ *     review shows what you'd be accepting.
+ */
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+import type { Node as PMNode } from '@tiptap/pm/model';
+
+interface ImageToken {
+	readonly kind: 'image';
+	readonly src: string;
+	readonly alt: string;
+}
+
+interface CardToken {
+	readonly kind: 'card';
+	readonly url: string;
+	/** Markdown link text, or the URL itself when the line is a bare URL.
+	 * Used as a fallback title while og data is loading or has failed. */
+	readonly fallbackTitle: string;
+}
+
+type MediaToken = ImageToken | CardToken;
+
+interface ParagraphMedia {
+	/** PM position immediately AFTER the host paragraph node — where the
+	 * block widget renders. Stays consistent across keystrokes because
+	 * the scan re-runs on every doc change. */
+	readonly insertAt: number;
+	/** Stable per-paragraph id so the widget DOM survives keystroke-level
+	 * decoration set rebuilds without flicker. The id is derived from
+	 * the paragraph's plain text + index, which is fine because two
+	 * paragraphs with identical text and the same ordinal position
+	 * really are interchangeable from the widget's POV. */
+	readonly key: string;
+	readonly tokens: readonly MediaToken[];
+}
+
+type OgState =
+	| { readonly kind: 'loading' }
+	| {
+			readonly kind: 'loaded';
+			readonly title: string | null;
+			readonly description: string | null;
+			readonly image: string | null;
+			readonly siteName: string | null;
+	  }
+	| { readonly kind: 'error' };
+
+/** An http(s) URL detected in paragraph text — its PM range and the
+ * canonicalized URL string. Drives an inline `.media-link-inline`
+ * decoration; hovering the decoration triggers a floating og-card
+ * tooltip (see the plugin view below). Inline links don't get block
+ * cards — those are reserved for own-line standalone URLs (Substack
+ * convention) — but the hover preview gives a low-friction "what's
+ * behind this link" affordance for inline references. */
+interface InlineLink {
+	readonly from: number;
+	readonly to: number;
+	readonly url: string;
+}
+
+interface MediaOverlayState {
+	readonly paragraphs: readonly ParagraphMedia[];
+	readonly inlineLinks: readonly InlineLink[];
+	/** og fetch results keyed by URL. Survives across transactions so a
+	 * fetch that resolves three keystrokes after it was started still
+	 * lands on the right card. */
+	readonly ogByUrl: ReadonlyMap<string, OgState>;
+	/** Bumped whenever ogByUrl gains a new entry, so the `decorations`
+	 * call below sees a different state object identity and PM rebuilds
+	 * the widget set. */
+	readonly version: number;
+}
+
+const mediaKey = new PluginKey<MediaOverlayState>('mediaOverlay');
+
+/** Match any `![alt](src)` in a paragraph. The src capture stops at the
+ * first `)` so a parenthesized title (e.g. `![](foo (1).png)`) won't
+ * round-trip — markdown itself doesn't really support nested parens
+ * here anyway, so this matches what the rest of the toolchain would
+ * accept. */
+const IMAGE_MD_RE = /!\[([^\]]*)\]\(([^)]+)\)/g;
+/** Bare URL alone on a line. Used only to detect when a standalone
+ * link's URL has an image extension — those still produce a thumbnail
+ * widget. Non-image standalone URLs are handled by the inline mark +
+ * hover tooltip path; no block card. */
+const STANDALONE_BARE_URL_RE = /^\s*(https?:\/\/\S+?)\s*$/;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg|bmp|avif)(\?.*)?$/i;
+
+/** Per-paragraph scan cache. ProseMirror does structural sharing, so an
+ * unchanged paragraph node retains its identity across transactions —
+ * a WeakMap on the node lets us skip the regex pass for paragraphs the
+ * user didn't touch. Same trick the diff overlay uses for word diffs. */
+const scanCache = new WeakMap<PMNode, MediaToken[]>();
+
+function scanParagraphTokens(node: PMNode): MediaToken[] {
+	const cached = scanCache.get(node);
+	if (cached) return cached;
+	const text = node.textContent;
+	const tokens: MediaToken[] = [];
+	if (text) {
+		// Inline images: any number per paragraph. Each match becomes one
+		// thumbnail widget; multiple thumbnails stack vertically below
+		// the line (rare in practice — usually one image per line).
+		IMAGE_MD_RE.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = IMAGE_MD_RE.exec(text)) !== null) {
+			const src = match[2].trim();
+			if (src) tokens.push({ kind: 'image', alt: match[1] ?? '', src });
+		}
+		// Bare image URL on its own line — still produces a thumbnail
+		// widget. Non-image standalone URLs deliberately do NOT produce
+		// block cards: the inline `.media-link-inline` decoration plus
+		// the hover tooltip cover that case more lightly. Empty space
+		// below a URL line was visually heavier than the link warranted.
+		if (tokens.length === 0) {
+			const bareMatch = text.match(STANDALONE_BARE_URL_RE);
+			if (bareMatch) {
+				const url = bareMatch[1].trim();
+				if (IMAGE_EXT_RE.test(url)) {
+					tokens.push({ kind: 'image', alt: '', src: url });
+				}
+			}
+		}
+	}
+	scanCache.set(node, tokens);
+	return tokens;
+}
+
+/** Walk the doc once and collect, for each top-level paragraph, the
+ * tokens that should produce widgets and the position to attach them. */
+function scanDoc(doc: PMNode): ParagraphMedia[] {
+	const out: ParagraphMedia[] = [];
+	let pos = 0;
+	for (let i = 0; i < doc.childCount; i += 1) {
+		const child = doc.child(i);
+		const childPos = pos;
+		const childEnd = childPos + child.nodeSize;
+		// Plain-text editor only has paragraph nodes at the top level, but
+		// guard anyway — anything non-paragraph (a stray block from a
+		// future schema change) just gets skipped.
+		if (child.type.name === 'paragraph') {
+			const tokens = scanParagraphTokens(child);
+			if (tokens.length > 0) {
+				out.push({
+					insertAt: childEnd,
+					key: `${i}:${child.textContent.length}:${tokens.map(tokenKey).join('|')}`,
+					tokens
+				});
+			}
+		}
+		pos = childEnd;
+	}
+	return out;
+}
+
+/** Walk every text node in the doc and pick out absolute URLs. Different
+ * granularity from `scanDoc`: that runs per paragraph for block widgets,
+ * this runs per text node for inline marks — a single paragraph can host
+ * many inline URLs and we need PM positions for each. */
+const INLINE_URL_RE = /https?:\/\/[^\s<>"'()]+/g;
+/** Trailing punctuation that's almost never part of a URL but commonly
+ * tails one in prose: "see https://example.com." should highlight the
+ * URL only, not the period. */
+const URL_TRAILING_TRIM_RE = /[.,;:!?)\]}]+$/;
+
+function scanInlineLinks(doc: PMNode): InlineLink[] {
+	const out: InlineLink[] = [];
+	doc.descendants((node, pos) => {
+		if (!node.isText || !node.text) return true;
+		const text = node.text;
+		INLINE_URL_RE.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = INLINE_URL_RE.exec(text)) !== null) {
+			const raw = match[0];
+			const trimmed = raw.replace(URL_TRAILING_TRIM_RE, '');
+			if (!trimmed) continue;
+			const from = pos + match.index;
+			const to = from + trimmed.length;
+			out.push({ from, to, url: trimmed });
+		}
+		return true;
+	});
+	return out;
+}
+
+function tokenKey(token: MediaToken): string {
+	if (token.kind === 'image') return `img:${token.src}`;
+	return `card:${token.url}`;
+}
+
+/** Resolve an image src for use in an `<img>` tag. http(s) URLs and
+ * data: URIs go straight through; anything else is treated as a
+ * workspace-relative path and routed through `/api/preview`. */
+function resolveImageSrc(src: string): string {
+	if (/^(https?:|data:|blob:)/i.test(src)) return src;
+	return `/api/preview?path=${encodeURIComponent(src)}`;
+}
+
+/** Pull the visible domain off a URL for the card footer. Strips `www.`
+ * because Substack does and it reads cleaner. Returns the raw URL on
+ * parse failure (shouldn't happen — we filtered to http(s) upstream). */
+function pickHostname(url: string): string {
+	try {
+		const host = new URL(url).hostname;
+		return host.replace(/^www\./, '');
+	} catch {
+		return url;
+	}
+}
+
+/** Build the thumbnail widget DOM. Non-editable, non-selectable, sized
+ * to a comfortable max so a giant image doesn't dominate the editor. */
+function renderImageWidget(token: ImageToken): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'media-widget media-image-widget';
+	wrap.setAttribute('contenteditable', 'false');
+	const img = document.createElement('img');
+	img.className = 'media-thumb';
+	img.loading = 'lazy';
+	img.alt = token.alt;
+	img.src = resolveImageSrc(token.src);
+	img.draggable = false;
+	// On 404 / decode error, fade the chrome so the user knows the image
+	// isn't loading. The markdown source stays exactly as they wrote it.
+	img.addEventListener('error', () => {
+		wrap.classList.add('media-thumb-error');
+		const note = document.createElement('div');
+		note.className = 'media-thumb-error-label';
+		note.textContent = `Couldn't load ${token.src}`;
+		wrap.replaceChildren(note);
+	});
+	wrap.appendChild(img);
+	return wrap;
+}
+
+/** Build the og card widget DOM. Renders a skeleton when og data is
+ * still loading; renders the resolved card otherwise. The same DOM
+ * node is replaced on each state change via `key` (set as a data
+ * attribute) so PM doesn't recycle a stale skeleton when the fetch
+ * resolves. */
+function renderCardWidget(token: CardToken, og: OgState): HTMLElement {
+	const wrap = document.createElement('a');
+	wrap.className = 'media-widget media-card-widget';
+	wrap.setAttribute('contenteditable', 'false');
+	wrap.setAttribute('href', token.url);
+	wrap.setAttribute('target', '_blank');
+	wrap.setAttribute('rel', 'noreferrer noopener');
+	wrap.dataset.state = og.kind;
+
+	if (og.kind === 'loading') {
+		wrap.appendChild(buildCardSkeleton(token));
+		return wrap;
+	}
+	if (og.kind === 'error') {
+		// Fall back to a tiny chrome that just shows the domain — the
+		// markdown line itself is still a plain link, so we don't need
+		// to be loud here.
+		const minimal = document.createElement('div');
+		minimal.className = 'media-card-minimal';
+		minimal.textContent = pickHostname(token.url);
+		wrap.appendChild(minimal);
+		return wrap;
+	}
+
+	const data = og;
+	const title = data.title || token.fallbackTitle || pickHostname(token.url);
+	const description = data.description ?? '';
+	const hostname = data.siteName || pickHostname(token.url);
+
+	if (data.image) {
+		const imgWrap = document.createElement('div');
+		imgWrap.className = 'media-card-image';
+		const img = document.createElement('img');
+		img.src = data.image;
+		img.alt = '';
+		img.loading = 'lazy';
+		img.draggable = false;
+		img.addEventListener('error', () => imgWrap.remove());
+		imgWrap.appendChild(img);
+		wrap.appendChild(imgWrap);
+	}
+
+	const body = document.createElement('div');
+	body.className = 'media-card-body';
+
+	const titleEl = document.createElement('div');
+	titleEl.className = 'media-card-title';
+	titleEl.textContent = title;
+	body.appendChild(titleEl);
+
+	if (description) {
+		const descEl = document.createElement('div');
+		descEl.className = 'media-card-desc';
+		descEl.textContent = description;
+		body.appendChild(descEl);
+	}
+
+	const hostEl = document.createElement('div');
+	hostEl.className = 'media-card-host';
+	hostEl.textContent = hostname;
+	body.appendChild(hostEl);
+
+	wrap.appendChild(body);
+	return wrap;
+}
+
+function buildCardSkeleton(token: CardToken): HTMLElement {
+	const skeleton = document.createElement('div');
+	skeleton.className = 'media-card-skeleton';
+	const block = document.createElement('div');
+	block.className = 'media-card-skeleton-image';
+	skeleton.appendChild(block);
+	const lines = document.createElement('div');
+	lines.className = 'media-card-skeleton-body';
+	for (const width of ['62%', '88%', '40%']) {
+		const line = document.createElement('div');
+		line.className = 'media-card-skeleton-line';
+		line.style.width = width;
+		lines.appendChild(line);
+	}
+	skeleton.appendChild(lines);
+	const hostEl = document.createElement('div');
+	hostEl.className = 'media-card-host';
+	hostEl.textContent = pickHostname(token.url);
+	skeleton.appendChild(hostEl);
+	return skeleton;
+}
+
+function buildDecorations(state: MediaOverlayState, doc: PMNode): DecorationSet {
+	const decorations: Decoration[] = [];
+	for (const para of state.paragraphs) {
+		// Defensive bounds check — `insertAt` was correct at scan time but
+		// any drift between scan and decoration paint (concurrent agent
+		// edit, undo) would otherwise throw inside PM.
+		if (para.insertAt > doc.content.size) continue;
+		for (let i = 0; i < para.tokens.length; i += 1) {
+			const token = para.tokens[i];
+			const widgetKey = `${para.key}#${i}`;
+			if (token.kind === 'image') {
+				decorations.push(
+					Decoration.widget(para.insertAt, () => renderImageWidget(token), {
+						side: 1,
+						key: widgetKey,
+						ignoreSelection: true
+					})
+				);
+			} else {
+				const og = state.ogByUrl.get(token.url) ?? { kind: 'loading' };
+				decorations.push(
+					Decoration.widget(para.insertAt, () => renderCardWidget(token, og), {
+						side: 1,
+						// Keying on og state means the widget node is re-built
+						// when the fetch resolves — no manual DOM patching.
+						key: `${widgetKey}@${og.kind}`,
+						ignoreSelection: true
+					})
+				);
+			}
+		}
+	}
+	// Inline link marks. Both safe attributes (`class`, `data-url`) make
+	// it trivially easy for the view-level hover handler to find the
+	// hovered link's URL without any extra plugin state lookups.
+	for (const link of state.inlineLinks) {
+		if (link.from < 0 || link.to > doc.content.size) continue;
+		decorations.push(
+			Decoration.inline(link.from, link.to, {
+				class: 'media-link-inline',
+				'data-url': link.url
+			})
+		);
+	}
+	if (decorations.length === 0) return DecorationSet.empty;
+	return DecorationSet.create(doc, decorations);
+}
+
+/** Side-channel for the view plugin: which URLs need a fetch right now.
+ * Includes both standalone-line cards (block widgets) and inline link
+ * marks — the latter so the hover tooltip is instant when the user
+ * actually hovers. Pre-fetching means the first hover never sits on
+ * the loading skeleton. */
+function pickPendingUrls(state: MediaOverlayState): string[] {
+	const want = new Set<string>();
+	for (const para of state.paragraphs) {
+		for (const token of para.tokens) {
+			if (token.kind === 'card') want.add(token.url);
+		}
+	}
+	for (const link of state.inlineLinks) {
+		want.add(link.url);
+	}
+	const pending: string[] = [];
+	for (const url of want) {
+		if (!state.ogByUrl.has(url)) pending.push(url);
+	}
+	return pending;
+}
+
+interface OgFetchedMeta {
+	readonly type: 'og-fetched';
+	readonly url: string;
+	readonly value: Exclude<OgState, { kind: 'loading' }>;
+}
+
+export const MediaOverlay = Extension.create({
+	name: 'mediaOverlay',
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<MediaOverlayState>({
+				key: mediaKey,
+				state: {
+					init: (_config, instance): MediaOverlayState => ({
+						paragraphs: scanDoc(instance.doc),
+						inlineLinks: scanInlineLinks(instance.doc),
+						ogByUrl: new Map(),
+						version: 0
+					}),
+					apply(tr, prev): MediaOverlayState {
+						const meta = tr.getMeta(mediaKey) as OgFetchedMeta | undefined;
+						let next = prev;
+						if (tr.docChanged) {
+							// `tr.doc` is the post-transaction doc — same as the
+							// in-flight newState's doc but doesn't require us to
+							// rely on partial-state semantics during construction.
+							next = {
+								...next,
+								paragraphs: scanDoc(tr.doc),
+								inlineLinks: scanInlineLinks(tr.doc)
+							};
+						}
+						if (meta?.type === 'og-fetched') {
+							const ogByUrl = new Map(next.ogByUrl);
+							ogByUrl.set(meta.url, meta.value);
+							next = { ...next, ogByUrl, version: next.version + 1 };
+						}
+						return next;
+					}
+				},
+				props: {
+					decorations(state) {
+						const s = mediaKey.getState(state);
+						if (!s) return null;
+						return buildDecorations(s, state.doc);
+					}
+				},
+				view(view: EditorView) {
+					/** Fire fetches for any URL we don't yet have og data for.
+					 * The plugin state's `ogByUrl` map answers "do we have
+					 * data?"; a local `fired` Set guards against double-firing
+					 * during the in-flight window before the fetch resolves
+					 * and writes into `ogByUrl`. While `fired` says yes but
+					 * `ogByUrl` says no, `decorations()` falls back to the
+					 * `loading` skeleton — that's the correct UX. */
+					const fired = new Set<string>();
+					const fireFetches = (currentView: EditorView) => {
+						const s = mediaKey.getState(currentView.state);
+						if (!s) return;
+						for (const url of pickPendingUrls(s)) {
+							if (fired.has(url)) continue;
+							fired.add(url);
+							void fetchOgInto(currentView, url);
+						}
+					};
+					// Initial pass once the editor mounts — the constructor
+					// can't dispatch transactions, so do it on the next tick.
+					queueMicrotask(() => fireFetches(view));
+
+					// Hover-tooltip wiring. One persistent floating element
+					// outside the editor's DOM tree (so the editor's overflow
+					// + scroll boundaries can't clip it) gets shown/hidden
+					// over inline `.media-link-inline` decorations. Hover
+					// in: brief delay, then fetch og + render card. Hover
+					// out: brief delay before hiding so the user can move
+					// the cursor INTO the tooltip without it vanishing.
+					const tooltip = document.createElement('div');
+					tooltip.className = 'media-link-tooltip';
+					tooltip.style.display = 'none';
+					document.body.appendChild(tooltip);
+					let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+					let hideTimer: ReturnType<typeof setTimeout> | null = null;
+					let activeUrl: string | null = null;
+
+					const positionTooltip = (anchor: DOMRect) => {
+						const margin = 8;
+						const vw = window.innerWidth;
+						const vh = window.innerHeight;
+						// Render once invisibly to measure, then position with
+						// final coords. Otherwise a tooltip near the right edge
+						// would overshoot the viewport before we can clamp it.
+						tooltip.style.visibility = 'hidden';
+						tooltip.style.display = 'block';
+						const rect = tooltip.getBoundingClientRect();
+						let left = anchor.left;
+						let top = anchor.bottom + margin;
+						if (left + rect.width > vw - margin) left = vw - margin - rect.width;
+						if (left < margin) left = margin;
+						if (top + rect.height > vh - margin) {
+							const above = anchor.top - margin - rect.height;
+							if (above >= margin) top = above;
+							else top = Math.max(margin, vh - margin - rect.height);
+						}
+						tooltip.style.left = `${left}px`;
+						tooltip.style.top = `${top}px`;
+						tooltip.style.visibility = 'visible';
+					};
+
+					const renderTooltip = (url: string) => {
+						const s = mediaKey.getState(view.state);
+						const og = s?.ogByUrl.get(url) ?? { kind: 'loading' as const };
+						tooltip.replaceChildren(
+							renderCardWidget({ kind: 'card', url, fallbackTitle: url }, og)
+						);
+					};
+
+					const showTooltip = (target: HTMLElement, url: string) => {
+						if (hideTimer) {
+							clearTimeout(hideTimer);
+							hideTimer = null;
+						}
+						activeUrl = url;
+						renderTooltip(url);
+						positionTooltip(target.getBoundingClientRect());
+						// Kick off og fetch if we don't yet have data — the
+						// hover may be the first time anyone asked about
+						// this URL (e.g., a long doc where we never scrolled
+						// past it on initial mount).
+						if (!fired.has(url)) {
+							fired.add(url);
+							void fetchOgInto(view, url);
+						}
+					};
+
+					const hideTooltip = () => {
+						tooltip.style.display = 'none';
+						activeUrl = null;
+					};
+
+					const onMouseOver = (event: MouseEvent) => {
+						const target = (event.target as HTMLElement | null)?.closest(
+							'.media-link-inline'
+						) as HTMLElement | null;
+						if (!target) return;
+						const url = target.dataset.url;
+						if (!url) return;
+						if (hoverTimer) clearTimeout(hoverTimer);
+						hoverTimer = setTimeout(() => showTooltip(target, url), 280);
+					};
+
+					const onMouseOut = (event: MouseEvent) => {
+						const fromLink = (event.target as HTMLElement | null)?.closest(
+							'.media-link-inline'
+						) as HTMLElement | null;
+						if (!fromLink) return;
+						const related = event.relatedTarget as HTMLElement | null;
+						// Moving from the link into the tooltip itself or back
+						// into the SAME link span (mouseout fires on each
+						// child-element boundary inside a marked range): keep
+						// it open. Only fire the hide timer when the cursor
+						// has actually left this link.
+						if (related && tooltip.contains(related)) return;
+						if (related && fromLink.contains(related)) return;
+						const relatedLink = related?.closest?.('.media-link-inline') as
+							| HTMLElement
+							| null;
+						if (relatedLink && relatedLink.dataset.url === fromLink.dataset.url) {
+							return;
+						}
+						if (hoverTimer) {
+							clearTimeout(hoverTimer);
+							hoverTimer = null;
+						}
+						if (hideTimer) clearTimeout(hideTimer);
+						hideTimer = setTimeout(hideTooltip, 180);
+					};
+
+					tooltip.addEventListener('mouseenter', () => {
+						if (hideTimer) {
+							clearTimeout(hideTimer);
+							hideTimer = null;
+						}
+					});
+					tooltip.addEventListener('mouseleave', () => {
+						if (hideTimer) clearTimeout(hideTimer);
+						hideTimer = setTimeout(hideTooltip, 120);
+					});
+
+					view.dom.addEventListener('mouseover', onMouseOver);
+					view.dom.addEventListener('mouseout', onMouseOut);
+
+					return {
+						update(currentView, prevState) {
+							const before = mediaKey.getState(prevState);
+							const after = mediaKey.getState(currentView.state);
+							if (before === after) return;
+							fireFetches(currentView);
+							// If a tooltip is open and the og fetch we were
+							// waiting for just landed, re-render in place so
+							// the skeleton flips to the resolved card.
+							if (activeUrl) renderTooltip(activeUrl);
+						},
+						destroy() {
+							fired.clear();
+							if (hoverTimer) clearTimeout(hoverTimer);
+							if (hideTimer) clearTimeout(hideTimer);
+							view.dom.removeEventListener('mouseover', onMouseOver);
+							view.dom.removeEventListener('mouseout', onMouseOut);
+							tooltip.remove();
+						}
+					};
+				}
+			})
+		];
+	}
+});
+
+/** og fetch + dispatch. Runs outside the PM transaction lifecycle —
+ * the resolve dispatch is what makes the card flip from skeleton to
+ * loaded chrome. */
+async function fetchOgInto(view: EditorView, url: string): Promise<void> {
+	let value: Exclude<OgState, { kind: 'loading' }>;
+	try {
+		const response = await fetch(`/api/opengraph?url=${encodeURIComponent(url)}`);
+		const data = await response.json();
+		if (data && typeof data === 'object' && 'error' in data) {
+			value = { kind: 'error' };
+		} else {
+			value = {
+				kind: 'loaded',
+				title: typeof data?.title === 'string' ? data.title : null,
+				description: typeof data?.description === 'string' ? data.description : null,
+				image: typeof data?.image === 'string' ? data.image : null,
+				siteName: typeof data?.siteName === 'string' ? data.siteName : null
+			};
+		}
+	} catch {
+		value = { kind: 'error' };
+	}
+	if (!view.dom) return;
+	try {
+		view.dispatch(
+			view.state.tr.setMeta(mediaKey, { type: 'og-fetched', url, value } satisfies OgFetchedMeta)
+		);
+	} catch {
+		/* editor destroyed mid-fetch; nothing to update */
+	}
+}
+

--- a/src/lib/editor/media-paste.ts
+++ b/src/lib/editor/media-paste.ts
@@ -1,0 +1,230 @@
+/**
+ * Media paste / drop helpers — Substack-style transforms for the
+ * plain-markdown editor.
+ *
+ * The editor is intentionally plain text: there are no image nodes, no
+ * link cards, no rich content in the doc. Pasting visual media must
+ * lower into markdown source. The visual side (thumbnails, og cards)
+ * is then layered back on top by `media-overlay.ts`.
+ *
+ * Behavior matrix:
+ *
+ *   | Input                                        | Markdown inserted        |
+ *   | -------------------------------------------- | ------------------------ |
+ *   | Image file (clipboard or drop)               | `![](assets/<id>.<ext>)` |
+ *   | URL ending in image extension                | `![](url)`               |
+ *   | URL pasted with text selected                | `[selected](url)`        |
+ *   | URL pasted on empty line                     | `url` (overlay carries)  |
+ *   | URL pasted inline in prose                   | `url` (default paste)    |
+ *   | Plain text                                   | (default paste)          |
+ *
+ * The "URL on empty line" case relies on `media-overlay.ts`'s standalone
+ * bare-URL detection — pasting just the URL is enough, no special
+ * insertion needed.
+ */
+import type { EditorView } from '@tiptap/pm/view';
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg|bmp|avif)(\?.*)?$/i;
+/** Permissive URL matcher for paste-time triage. Anchored: the entire
+ * pasted text must be one URL. We allow any non-whitespace tail so
+ * Wikipedia-style links with `(...)` and query strings still register. */
+const URL_RE = /^https?:\/\/\S+$/;
+
+/** Allowed image MIME prefixes for paste/drop. We accept the same set
+ * the workspace gallery does plus svg, since svg is a perfectly legit
+ * blog asset. */
+const ACCEPTED_MIME_RE = /^image\/(png|jpe?g|gif|webp|svg(?:\+xml)?|bmp|avif)$/i;
+
+/** Workspace-relative directory for inserted images. Created on demand
+ * by `POST /api/files` (which mkdir's parents). */
+const ASSET_DIR = 'assets';
+
+interface InsertOptions {
+	readonly view: EditorView;
+	readonly markdown: string;
+	/** When true (drop case), `at` is provided and the editor selection
+	 * isn't replaced. When false (paste case), the current selection is
+	 * replaced by the inserted markdown. */
+	readonly at?: number;
+}
+
+function insertText({ view, markdown, at }: InsertOptions): void {
+	const { state } = view;
+	const tr =
+		typeof at === 'number' ? state.tr.insertText(markdown, at) : state.tr.insertText(markdown);
+	view.dispatch(tr.scrollIntoView());
+}
+
+/** Sniff a clipboard or drag DataTransfer for the first attached image
+ * file. Returns the file or null. We don't try to be clever about
+ * multiple-file pastes — most platforms only emit one anyway, and
+ * concatenating several unrelated images at the same caret position
+ * isn't a useful UX. */
+function pickFirstImageFile(dataTransfer: DataTransfer | null): File | null {
+	if (!dataTransfer) return null;
+	const files = dataTransfer.files;
+	for (let i = 0; i < files.length; i += 1) {
+		const file = files[i];
+		if (ACCEPTED_MIME_RE.test(file.type)) return file;
+	}
+	// `items` covers the clipboard case where `files` is sometimes empty
+	// even though an image is attached (Chrome on macOS for screenshots).
+	const items = dataTransfer.items;
+	if (items) {
+		for (let i = 0; i < items.length; i += 1) {
+			const item = items[i];
+			if (item.kind === 'file' && ACCEPTED_MIME_RE.test(item.type)) {
+				const file = item.getAsFile();
+				if (file) return file;
+			}
+		}
+	}
+	return null;
+}
+
+/** Pull an image extension off a MIME type, falling back to a generic
+ * `bin` so we never silently drop the file on disk with no extension. */
+function pickExtension(file: File): string {
+	const fromName = file.name.match(/\.([a-z0-9]+)$/i)?.[1];
+	if (fromName) return fromName.toLowerCase();
+	const mime = file.type.toLowerCase();
+	if (mime === 'image/jpeg') return 'jpg';
+	if (mime === 'image/svg+xml') return 'svg';
+	const subtype = mime.split('/')[1];
+	return (subtype || 'bin').replace(/\W/g, '');
+}
+
+/** Random 6-character base36 suffix; collisions per second per workspace
+ * are vanishingly rare. The timestamp prefix keeps assets sorted by
+ * insertion order in a directory listing. */
+function buildAssetPath(file: File): string {
+	const ext = pickExtension(file);
+	const stamp = new Date()
+		.toISOString()
+		.replace(/[-:T]/g, '')
+		.replace(/\..+$/, '');
+	const rand = Math.random().toString(36).slice(2, 8);
+	const safeBase = file.name
+		.replace(/\.[^.]+$/, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 32);
+	const stem = safeBase ? `${stamp}-${safeBase}-${rand}` : `${stamp}-${rand}`;
+	return `${ASSET_DIR}/${stem}.${ext}`;
+}
+
+/** Read a Blob into a base64 string suitable for `POST /api/files`'s
+ * base64 encoding. Skips the `data:` prefix that `FileReader` adds. */
+async function blobToBase64(file: Blob): Promise<string> {
+	const buffer = await file.arrayBuffer();
+	const bytes = new Uint8Array(buffer);
+	let binary = '';
+	const chunk = 0x8000;
+	// Chunk to avoid `Maximum call stack size exceeded` on large images
+	// — `String.fromCharCode(...bytes)` blows the stack at ~64 KB args.
+	for (let i = 0; i < bytes.length; i += chunk) {
+		const slice = bytes.subarray(i, i + chunk);
+		binary += String.fromCharCode(...slice);
+	}
+	return btoa(binary);
+}
+
+interface SaveResult {
+	readonly path: string;
+}
+
+async function saveImageToWorkspace(file: File): Promise<SaveResult | null> {
+	const path = buildAssetPath(file);
+	try {
+		const base64 = await blobToBase64(file);
+		const response = await fetch('/api/files', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ path, kind: 'file', content: base64, encoding: 'base64' })
+		});
+		if (!response.ok) return null;
+		return { path };
+	} catch {
+		return null;
+	}
+}
+
+/** Hand-off for image paste/drop. Inserts a placeholder while the
+ * upload is in flight, then swaps in the final markdown reference once
+ * the file lands on disk. We use a placeholder rather than blocking
+ * the dispatch because the upload is async and we don't want to freeze
+ * the editor while a 5MB screenshot encodes. */
+async function handleImageFile(view: EditorView, file: File, at?: number): Promise<void> {
+	const result = await saveImageToWorkspace(file);
+	if (!result) {
+		console.error('[docwriter] failed to save pasted image to workspace');
+		return;
+	}
+	insertText({ view, markdown: `![](${result.path})`, at });
+}
+
+/** Returns true when the event's clipboard / drag carried something we
+ * handled (image file, transformed URL). When true, the caller must
+ * call `event.preventDefault()` and return `true` from PM's hook so PM
+ * skips its default paste/drop logic. */
+export interface MediaPasteResult {
+	readonly handled: boolean;
+}
+
+export function handleEditorPaste(view: EditorView, event: ClipboardEvent): MediaPasteResult {
+	const data = event.clipboardData;
+	if (!data) return { handled: false };
+
+	const imageFile = pickFirstImageFile(data);
+	if (imageFile) {
+		event.preventDefault();
+		void handleImageFile(view, imageFile);
+		return { handled: true };
+	}
+
+	const text = data.getData('text/plain').trim();
+	if (!text || !URL_RE.test(text)) return { handled: false };
+
+	// Image URL → render as inline image markdown so the media overlay
+	// shows a thumbnail. No download for v1.
+	if (IMAGE_EXT_RE.test(text)) {
+		event.preventDefault();
+		insertText({ view, markdown: `![](${text})` });
+		return { handled: true };
+	}
+
+	const { state } = view;
+	const { selection } = state;
+	const hasSelection = !selection.empty;
+	if (hasSelection) {
+		// Wrap the selected text as the link's title — same as Cmd-K
+		// would in any other editor.
+		const selected = state.doc.textBetween(selection.from, selection.to, ' ');
+		event.preventDefault();
+		insertText({ view, markdown: `[${selected}](${text})` });
+		return { handled: true };
+	}
+
+	// URL with no selection: let the default paste insert the URL as
+	// plain text. The media overlay's standalone-bare-URL detection
+	// (scanParagraphTokens in media-overlay.ts) decides per-paragraph
+	// whether the line is alone enough to justify a card. Substack does
+	// the same: inline URLs don't card, only own-line URLs do.
+	return { handled: false };
+}
+
+export function handleEditorDrop(view: EditorView, event: DragEvent): MediaPasteResult {
+	const data = event.dataTransfer;
+	if (!data) return { handled: false };
+
+	const imageFile = pickFirstImageFile(data);
+	if (!imageFile) return { handled: false };
+
+	const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+	if (!coords) return { handled: false };
+
+	event.preventDefault();
+	void handleImageFile(view, imageFile, coords.pos);
+	return { handled: true };
+}

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -548,7 +548,7 @@ const writeDocTool = tool(
 	}
 );
 
-// ---- post_comment -------------------------------------------------------
+// ---- reply_to_comment ---------------------------------------------------
 
 /** Write a comment thread (new or reply) onto a tab's Y.Map('comments').
  * Runs inside a DirectConnection transaction so the update streams to all
@@ -576,9 +576,9 @@ async function runCommentWrite(
 	return result;
 }
 
-const postCommentTool = tool(
-	'post_comment',
-	'Post a comment on a tab file — either opening a NEW thread anchored to a passage, or REPLYING to an existing thread. Use this instead of `edit_doc` when the user\'s feedback is open-ended, exploratory, or unsure ("what do you think", "idk", "is this right?", "maybe X?"), or when they ask a question that doesn\'t demand an immediate edit. Say what you think, optionally sketch an edit in `proposed_edit` (the user can approve it to apply later). For new threads, `anchor_text` must match exactly once in the current live markdown; reply with `thread_id` when continuing a conversation.',
+const replyToCommentTool = tool(
+	'reply_to_comment',
+	'Reply on an existing comment thread the user has opened. Use this when the user\'s feedback is open-ended, exploratory, or unsure ("what do you think", "idk", "is this right?", "maybe X?"), or when they ask a question that doesn\'t demand an immediate edit. Say what you think, optionally sketch an edit in `proposed_edit` (the user can approve it to apply later). You CANNOT open new threads — only the user can start a thread. If there is no relevant thread for what you want to say, prefer `edit_doc`, `AskUserQuestion`, or staying silent over forcing a thread.',
 	{
 		path: z
 			.string()
@@ -587,20 +587,13 @@ const postCommentTool = tool(
 			),
 		thread_id: z
 			.string()
-			.optional()
 			.describe(
-				'When replying to an existing thread, pass its id (from the "Open comment threads" prompt block). Omit when opening a new thread.'
-			),
-		anchor_text: z
-			.string()
-			.optional()
-			.describe(
-				'Required when opening a new thread: the exact substring of the current live markdown the thread should anchor to. Must match once; pick a substring that identifies the passage uniquely. Ignored when `thread_id` is set.'
+				'Id of the existing thread to reply on (from the "Open comment threads" prompt block). Required: agents cannot open new threads.'
 			),
 		message: z
 			.string()
 			.describe(
-				'Your comment. Speak in first person ("I\'d cut …", "I think …"), not as a narrator. Keep it shorter than an essay — a few sentences.'
+				'Your reply. Speak in first person ("I\'d cut …", "I think …"), not as a narrator. Keep it shorter than an essay — a few sentences.'
 			),
 		proposed_edit: z
 			.object({
@@ -612,17 +605,17 @@ const postCommentTool = tool(
 				'Optional concrete edit you would propose if the user approves. `old_string` must match once in the current live markdown at the time of writing. The edit is NOT applied until the user clicks "Approve & propose edit" on your comment.'
 			)
 	},
-	async ({ path, thread_id, anchor_text, message, proposed_edit }) => {
+	async ({ path, thread_id, message, proposed_edit }) => {
 		if (isScratchPath(path)) {
 			return toolError(
-				'post_comment cannot be used on scratch paths — only on workspace tab files.'
+				'reply_to_comment cannot be used on scratch paths — only on workspace tab files.'
 			);
 		}
 		const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
 		if (!opened.ok) return opened.error;
 
 		const trimmedMessage = message.trim();
-		if (!trimmedMessage) return toolError('post_comment requires a non-empty message.');
+		if (!trimmedMessage) return toolError('reply_to_comment requires a non-empty message.');
 
 		const outcome = await runCommentWrite(opened.tabId, (doc) => {
 			const commentsMap = getCommentsMap(doc);
@@ -642,58 +635,23 @@ const postCommentTool = tool(
 					: {})
 			};
 
-			if (thread_id) {
-				const existing = commentsMap.get(thread_id);
-				if (!existing) {
-					return { ok: false, error: `Thread "${thread_id}" does not exist on ${path}.` };
-				}
-				const updated: CommentThread = {
-					...existing,
-					// Re-opening via a new reply un-resolves the thread so
-					// the user sees the new message.
-					resolved: false,
-					messages: [...existing.messages, newMessage]
-				};
-				doc.transact(() => commentsMap.set(thread_id, updated), AGENT_ORIGIN);
-				return { ok: true };
+			const existing = commentsMap.get(thread_id);
+			if (!existing) {
+				return { ok: false, error: `Thread "${thread_id}" does not exist on ${path}.` };
 			}
-
-			if (!anchor_text) {
-				return {
-					ok: false,
-					error: 'Opening a new thread requires `anchor_text` — the passage to anchor to.'
-				};
-			}
-			const liveText = serializeYDoc(doc);
-			const matches = countOccurrences(liveText, anchor_text);
-			if (matches === 0) {
-				return {
-					ok: false,
-					error: `anchor_text was not found in ${path}. It must be a verbatim substring of the current live content.`
-				};
-			}
-			const occurrenceIndex = 0; // anchor to first match; matches > 1 is fine — stable index.
-			const threadId = 'thread_' + cryptoRandomId();
-			const thread: CommentThread = {
-				id: threadId,
-				anchor: {
-					quote: anchor_text,
-					occurrenceIndex
-				},
-				messages: [newMessage],
+			const updated: CommentThread = {
+				...existing,
+				// Re-opening via a new reply un-resolves the thread so
+				// the user sees the new message.
 				resolved: false,
-				createdAt: now
+				messages: [...existing.messages, newMessage]
 			};
-			doc.transact(() => commentsMap.set(threadId, thread), AGENT_ORIGIN);
+			doc.transact(() => commentsMap.set(thread_id, updated), AGENT_ORIGIN);
 			return { ok: true };
 		});
 
 		if (!outcome.ok) return toolError(outcome.error);
-		return toolText(
-			thread_id
-				? `Replied on thread ${thread_id} (${path}).`
-				: `Opened a new thread on ${path}.`
-		);
+		return toolText(`Replied on thread ${thread_id} (${path}).`);
 	}
 );
 
@@ -756,12 +714,12 @@ const listThreadsTool = tool(
 export const docToolsMcp = createSdkMcpServer({
 	name: 'docwriter-doc',
 	version: '0.0.1',
-	tools: [editDocTool, readDocTool, writeDocTool, postCommentTool, listThreadsTool]
+	tools: [editDocTool, readDocTool, writeDocTool, replyToCommentTool, listThreadsTool]
 });
 
 /** SDK-namespaced tool names (what appears in stream events). */
 export const EDIT_DOC_TOOL_NAME = 'mcp__docwriter-doc__edit_doc';
 export const READ_DOC_TOOL_NAME = 'mcp__docwriter-doc__read_doc';
 export const WRITE_DOC_TOOL_NAME = 'mcp__docwriter-doc__write_doc';
-export const POST_COMMENT_TOOL_NAME = 'mcp__docwriter-doc__post_comment';
+export const REPLY_TO_COMMENT_TOOL_NAME = 'mcp__docwriter-doc__reply_to_comment';
 export const LIST_THREADS_TOOL_NAME = 'mcp__docwriter-doc__list_threads';

--- a/src/lib/server/runtime-state.ts
+++ b/src/lib/server/runtime-state.ts
@@ -67,6 +67,16 @@ export function getServerInstanceId(): string {
 	return value ?? 'unknown';
 }
 
+let _lastSystemPrompt: string | null = null;
+
+export function getLastSystemPrompt(): string | null {
+	return _lastSystemPrompt;
+}
+
+export function setLastSystemPrompt(prompt: string) {
+	_lastSystemPrompt = prompt;
+}
+
 export function getSessionId(): string | null {
 	return kvGet('sessionId');
 }

--- a/src/lib/shared/ydoc-codec.ts
+++ b/src/lib/shared/ydoc-codec.ts
@@ -16,6 +16,14 @@ export const FRAGMENT_NAME = 'default';
 export const REVIEW_ARRAY_NAME = 'rounds';
 export const COMMENTS_MAP_NAME = 'comments';
 export const AGENT_ORIGIN = 'agent';
+/** Origin for user-initiated server-side mutations (accept / reject /
+ * reject-all). Anything `ydoc.transact(..., USER_ORIGIN)` tags becomes
+ * client-undoable: the Tiptap Collaboration extension is configured to
+ * include this origin in its `Y.UndoManager.trackedOrigins`, so ctrl+z
+ * in the editor reverses these transactions one step at a time. Reuse
+ * carefully — adding a new USER_ORIGIN transact site opts it into undo
+ * by default. Use SYSTEM_ORIGIN (or a fresh origin) for mutations that
+ * should NOT be reversible from the editor. */
 export const USER_ORIGIN = 'user';
 export const SYSTEM_ORIGIN = 'system';
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,9 +138,11 @@ export interface CommentThreadAnchor {
 	 * typing, agent edits, syncs across clients), so the highlight stays
 	 * glued to the text instead of teleporting when the quote no longer
 	 * matches. Optional because:
-	 *   - Server-side `post_comment` can't compute them (it has no PM
+	 *   - Server-side `reply_to_comment` can't compute them (it has no PM
 	 *     binding), so it omits them — the client backfills on first
-	 *     render via the comment-overlay's view hook.
+	 *     render via the comment-overlay's view hook. Same applies to any
+	 *     thread the user opens through a server-side path (e.g. the
+	 *     feedback popup's auto-created thread).
 	 *   - Legacy threads (created before this field existed) lack them
 	 *     and also get backfilled on first render.
 	 * When absent, the overlay falls back to indexOf-based anchoring. */
@@ -170,9 +172,10 @@ export interface CommentThread {
 }
 
 /** Routing hint carried from the feedback popup to the agent prompt.
- *  - `auto`: agent decides comment vs. edit based on tone.
- *  - `edit`: force an `edit_doc` call (no `post_comment`).
- *  - `discuss`: force a `post_comment` call (no `edit_doc`). */
+ *  - `auto`: agent decides reply-on-thread vs. edit based on tone.
+ *  - `edit`: force an `edit_doc` call (no `reply_to_comment`).
+ *  - `discuss`: force a `reply_to_comment` call on the user-opened
+ *    thread for this feedback (agents cannot open new threads). */
 export type FeedbackMode = 'auto' | 'edit' | 'discuss';
 
 export interface Annotation {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -174,7 +174,7 @@
 	function syncActiveReviewState(tabId: string, rawRounds: PendingReviewRound[]) {
 		const rounds = materializedRoundsForTab(tabId, rawRounds);
 		pendingReviewRounds.set(rounds);
-		reviewBaseline.set(rounds.length > 0 ? currentTabText(tabId) : null);
+		reviewBaseline.set(rounds.length > 0 ? rounds[0].beforeMd : null);
 		const nextPending = new Map(pendingReviewTabs);
 		if (rawRounds.length > 0) nextPending.set(tabId, rawRounds.length);
 		else nextPending.delete(tabId);
@@ -2304,11 +2304,9 @@
 					onAcceptInlineEdit={() => {
 						const rounds = currentRounds();
 						if (rounds.length === 0) return;
-						// Diff overlay shows just the EARLIEST pending round
-						// at a time (TiptapEditor passes round[0]'s afterMd as
-						// proposedText), so the inline ✓ accepts exactly that
-						// round — and no other. Subsequent rounds become the
-						// new visible diff after this one's accepted.
+						// Diff overlay shows the full pending stack; the inline ✓
+						// accepts rounds[0] only (FIFO). Subsequent rounds stay
+						// in the composed diff until their turn is accepted.
 						void acceptAgentEdit(rounds[0].id);
 					}}
 				/>

--- a/src/routes/api/history/+server.ts
+++ b/src/routes/api/history/+server.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { RequestHandler } from './$types';
 import { getSessionMessages } from '@anthropic-ai/claude-agent-sdk';
-import { getSessionId } from '$lib/server/runtime-state';
+import { getSessionId, getLastSystemPrompt } from '$lib/server/runtime-state';
 
 /** Encode a filesystem path the same way the Claude SDK does when creating its
  * `~/.claude/projects/<encoded>/<sessionId>.jsonl` file layout. */
@@ -31,11 +31,7 @@ function encodeProjectPath(absPath: string): string {
  * (e.g. very first session before any messages have been written).
  */
 export const GET: RequestHandler = async () => {
-	// systemPrompt is set per-render via the SDK's `systemPrompt` option and
-	// never lands in the JSONL transcript. Surfacing it in the viewer would
-	// require importing from the render route, which has caused HMR breakage
-	// in dev. Leave it null for now — the user/assistant flow is what matters.
-	const systemPrompt: string | null = null;
+	const systemPrompt = getLastSystemPrompt();
 
 	const sessionId = getSessionId();
 	if (!sessionId) return json({ sessionId: null, raw: [], messages: [], systemPrompt });

--- a/src/routes/api/opengraph/+server.ts
+++ b/src/routes/api/opengraph/+server.ts
@@ -1,0 +1,248 @@
+/**
+ * /api/opengraph — server-side OpenGraph metadata fetcher.
+ *
+ * GET /api/opengraph?url=<absolute-url>
+ *   → { url, title, description, image, siteName }
+ *   → { url, error: '<reason>' }   (HTTP 200 — clients fall back to a plain
+ *                                    link decoration; an error response code
+ *                                    here would just spam the network panel)
+ *
+ * Why server-side? Two reasons:
+ *
+ *   1. CORS. Almost no third-party site sets CORS headers permitting an
+ *      arbitrary localhost origin to read its `<head>`, so a browser fetch
+ *      of `https://nytimes.com/article` from the editor would fail. The
+ *      Node fetch on the server has no such constraint.
+ *   2. We can cap the response size + parse a tiny window of the document
+ *      head, instead of streaming a multi-MB article body into the client.
+ *
+ * The endpoint is intentionally permissive: it never throws, never echoes
+ * a 5xx for an upstream failure. Clients treat absence of metadata as
+ * "render the line as a plain markdown link" and move on.
+ */
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/** Soft cap on response body. We only want the `<head>`; an article
+ * body, image, or video stream wastes bandwidth and CPU on a regex pass
+ * that won't find anything new past the closing `</head>` anyway. 256 KB
+ * comfortably covers every real-world `<head>` I've seen. */
+const MAX_BODY_BYTES = 256 * 1024;
+
+/** Total time budget for the upstream fetch — paste-time UX has to feel
+ * snappy. If a site is slow, we'd rather give up and show a plain link
+ * than block the editor for 10s. */
+const FETCH_TIMEOUT_MS = 5_000;
+
+/** In-memory LRU. Each entry holds the resolved metadata (or an error
+ * marker), the timestamp of the fetch, and an LRU position via Map's
+ * insertion order. Re-getting an entry deletes + re-inserts it to bump
+ * it to the most-recent slot. */
+const CACHE_TTL_MS = 60 * 60 * 1_000;
+const CACHE_MAX = 200;
+
+interface OgMetadata {
+	readonly url: string;
+	readonly title: string | null;
+	readonly description: string | null;
+	readonly image: string | null;
+	readonly siteName: string | null;
+}
+
+interface CacheEntry {
+	readonly fetchedAt: number;
+	readonly value: OgMetadata | { readonly url: string; readonly error: string };
+}
+
+const ogCache = new Map<string, CacheEntry>();
+
+function readCache(key: string): CacheEntry | null {
+	const hit = ogCache.get(key);
+	if (!hit) return null;
+	if (Date.now() - hit.fetchedAt > CACHE_TTL_MS) {
+		ogCache.delete(key);
+		return null;
+	}
+	ogCache.delete(key);
+	ogCache.set(key, hit);
+	return hit;
+}
+
+function writeCache(key: string, entry: CacheEntry): void {
+	ogCache.set(key, entry);
+	if (ogCache.size > CACHE_MAX) {
+		const oldest = ogCache.keys().next().value;
+		if (oldest !== undefined) ogCache.delete(oldest);
+	}
+}
+
+/** Decode the small set of HTML entities that show up in title/description
+ * meta tags. Going through a full HTML parser would be overkill — these
+ * five cover ~99% of cases and are cheap. */
+function decodeHtmlEntities(text: string): string {
+	return text
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&apos;/g, "'")
+		.replace(/&#x27;/g, "'")
+		.replace(/&#x2F;/g, '/')
+		.replace(/&#(\d+);/g, (_, d) => String.fromCharCode(Number(d)))
+		.replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)));
+}
+
+/** Pull the value of a `<meta property="og:foo" content="...">` (or
+ * `name="..."` — Twitter card meta uses `name`, OG uses `property`) tag
+ * out of an HTML head. Returns null if no match. The regex is tolerant
+ * of attribute order and single/double quotes. */
+function pickMeta(head: string, key: string): string | null {
+	// Match either `property="key"` or `name="key"`, then `content="..."`,
+	// in either order. Two regexes are easier to reason about than one
+	// monster with backreferences.
+	const propFirst = new RegExp(
+		`<meta[^>]*?(?:property|name)=["']${key}["'][^>]*?content=["']([^"']*)["']`,
+		'i'
+	);
+	const contentFirst = new RegExp(
+		`<meta[^>]*?content=["']([^"']*)["'][^>]*?(?:property|name)=["']${key}["']`,
+		'i'
+	);
+	const m1 = head.match(propFirst);
+	if (m1?.[1]) return decodeHtmlEntities(m1[1]).trim() || null;
+	const m2 = head.match(contentFirst);
+	if (m2?.[1]) return decodeHtmlEntities(m2[1]).trim() || null;
+	return null;
+}
+
+/** Fall back to the `<title>` element when no `og:title` / `twitter:title`
+ * is present. Most sites include a `<title>`; only single-page apps that
+ * render in JS sometimes don't. */
+function pickTitleTag(head: string): string | null {
+	const m = head.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+	if (!m) return null;
+	const inner = m[1].replace(/\s+/g, ' ').trim();
+	return inner ? decodeHtmlEntities(inner) : null;
+}
+
+function resolveAgainstBase(value: string | null, base: string): string | null {
+	if (!value) return null;
+	try {
+		return new URL(value, base).toString();
+	} catch {
+		return null;
+	}
+}
+
+function parseOgFromHtml(html: string, requestedUrl: string): OgMetadata {
+	// Trim to the head — most metadata lives there, and bounding the
+	// regex input keeps latency stable on long pages.
+	const headEnd = html.search(/<\/head\s*>/i);
+	const head = headEnd > 0 ? html.slice(0, headEnd) : html.slice(0, 32 * 1024);
+	const title =
+		pickMeta(head, 'og:title') ?? pickMeta(head, 'twitter:title') ?? pickTitleTag(head);
+	const description =
+		pickMeta(head, 'og:description') ??
+		pickMeta(head, 'twitter:description') ??
+		pickMeta(head, 'description');
+	const rawImage = pickMeta(head, 'og:image') ?? pickMeta(head, 'twitter:image');
+	const image = resolveAgainstBase(rawImage, requestedUrl);
+	const siteName = pickMeta(head, 'og:site_name');
+	return { url: requestedUrl, title, description, image, siteName };
+}
+
+/** Read at most `MAX_BODY_BYTES` from the response body and return the
+ * decoded string. We use the streaming reader so a multi-MB article
+ * doesn't get fully buffered before we slice. */
+async function readBoundedBody(response: Response): Promise<string> {
+	if (!response.body) return '';
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder('utf-8', { fatal: false });
+	let total = 0;
+	let collected = '';
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		total += value.byteLength;
+		collected += decoder.decode(value, { stream: true });
+		if (total >= MAX_BODY_BYTES) {
+			try {
+				await reader.cancel();
+			} catch {
+				/* upstream already closed; ignore */
+			}
+			break;
+		}
+	}
+	collected += decoder.decode();
+	return collected;
+}
+
+async function fetchOgMetadata(targetUrl: string): Promise<OgMetadata | { error: string }> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	try {
+		const response = await fetch(targetUrl, {
+			method: 'GET',
+			redirect: 'follow',
+			signal: controller.signal,
+			headers: {
+				// Identifying as a real browser improves hit rate against sites
+				// that gate metadata behind a UA check (Twitter, LinkedIn).
+				'User-Agent':
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+					'(KHTML, like Gecko) Chrome/120.0 Safari/537.36 DocWriter/1.0',
+				Accept: 'text/html,application/xhtml+xml',
+				'Accept-Language': 'en-US,en;q=0.9'
+			}
+		});
+		if (!response.ok) {
+			return { error: `Upstream ${response.status}` };
+		}
+		const contentType = response.headers.get('content-type') ?? '';
+		if (!/text\/html|application\/xhtml/i.test(contentType)) {
+			return { error: `Non-HTML content-type: ${contentType.split(';')[0] || 'unknown'}` };
+		}
+		const body = await readBoundedBody(response);
+		return parseOgFromHtml(body, response.url || targetUrl);
+	} catch (err: unknown) {
+		const message =
+			err instanceof Error
+				? err.name === 'AbortError'
+					? 'Timeout'
+					: err.message
+				: 'Fetch failed';
+		return { error: message };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function isHttpUrl(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+export const GET: RequestHandler = async ({ url }) => {
+	const target = url.searchParams.get('url') ?? '';
+	if (!target) throw error(400, 'url required');
+	if (!isHttpUrl(target)) {
+		return json({ url: target, error: 'Only http(s) URLs are supported' });
+	}
+	const cached = readCache(target);
+	if (cached) {
+		return json(cached.value);
+	}
+	const result = await fetchOgMetadata(target);
+	const value =
+		'error' in result
+			? { url: target, error: result.error }
+			: result;
+	writeCache(target, { fetchedAt: Date.now(), value });
+	return json(value);
+};

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -18,7 +18,7 @@ import {
 	type HookEvent
 } from '$lib/server/hooks-config';
 import { runHookCommand, type HookRunEmitter } from '$lib/server/hook-runner';
-import { getSessionId, setSessionId, getTabsState } from '$lib/server/runtime-state';
+import { getSessionId, setSessionId, setLastSystemPrompt, getTabsState } from '$lib/server/runtime-state';
 import { readMeta } from '$lib/server/document-io';
 import { kvGet, kvSet } from '$lib/server/db-writes';
 import { serializeYDoc, readReviewRounds, readCommentThreads } from '$lib/shared/ydoc-codec';
@@ -33,7 +33,7 @@ import {
 	EDIT_DOC_TOOL_NAME,
 	READ_DOC_TOOL_NAME,
 	WRITE_DOC_TOOL_NAME,
-	POST_COMMENT_TOOL_NAME
+	REPLY_TO_COMMENT_TOOL_NAME
 } from '$lib/server/mcp-doc-tools';
 
 /** Read the live authoritative markdown for a tab, including any pending
@@ -245,6 +245,12 @@ interface QueryRoundOutcome {
  * message content. Without this split, every render was re-sending ~5KB of
  * boilerplate and burning context + tokens. */
 function buildSystemPrompt(): string {
+	const meta = readMeta();
+	const ruleTexts = meta.rules.map((r) => r.text);
+	const rulesBlock = ruleTexts.length > 0
+		? ruleTexts.map((t, i) => `${i + 1}. ${t}`).join('\n')
+		: 'None.';
+
 	return `# Who you are
 
 You are the user's writing collaborator — a sharp, opinionated editor and occasional co-author working on their text in this workspace. The user is the author. You serve their voice, not yours. Your job is to make their writing tighter, clearer, and more theirs — not to replace it with prose that sounds like every other LLM output.
@@ -256,7 +262,7 @@ You are the user's writing collaborator — a sharp, opinionated editor and occa
 - **Be surgical.** Touch the minimum prose needed to fix the thing the user actually flagged. If a sentence is broken, fix that sentence — don't repaint the surrounding paragraph because the new sentence "feels different now."
 - **Concrete beats abstract; specific beats general.** When you do generate prose, prefer load-bearing verbs over adjective stacks, named things over categories, examples over claims. If you find yourself writing "various", "several", "a number of", "important", "powerful", "robust" — stop and replace with the specific thing.
 - **No AI smell, ever.** Avoid em-dashes-as-default-punctuation, "It's not just X, it's Y", "Let's dive in", "delve into", "navigating the landscape of", "tapestry", "moreover/furthermore" stitching, "Certainly!"/"Absolutely!" openers, hedge-stacking ("might potentially possibly"), three-item rule-of-threes rhythm, hollow superlatives ("incredibly powerful", "truly remarkable"), throat-clearing intros, summary paragraphs that restate what you just said, and "in conclusion"-style endings. These are tells that turn writing into LLM output. The user will notice.
-- **When in doubt, ask or comment instead of editing.** If you're guessing about the user's intent, post a comment (\`post_comment\`) or ask via \`AskUserQuestion\` — don't generate prose to fill the gap.
+- **When in doubt, ask instead of editing.** If you're guessing about the user's intent, ask via \`AskUserQuestion\` — or, if the user has already opened a thread on this passage, reply there with \`reply_to_comment\`. Don't generate prose to fill the gap, and don't fabricate a comment thread (you can't open new ones — only the user can).
 
 ## File formats
 
@@ -269,45 +275,46 @@ Every file is treated as raw text — including \`.md\` / \`.markdown\`. The edi
 - \`write_doc({ path, content })\` replaces the full content. If the file doesn't exist, write_doc creates it and opens it as a new tab (no review round for brand-new files). If the file exists, the write lands as a pending review proposal.
 - \`read_doc(path)\` returns the current content of any workspace file. For an open tab, it's review-aware: the newest pending proposal if one exists, otherwise the committed content. For a workspace file that isn't currently a tab, it just reads the file from disk. Use it freely on any path the user mentions — don't pre-check whether the file is open.
 - Each \`edit_doc\` / \`write_doc\` call on an existing file creates or updates a reviewable proposal round in the outline. The live document changes only when the user accepts that proposal.
-- The built-in \`Edit\` / \`Write\` tools are restricted to your scratch workspace under \`${AGENT_SCRATCH_DIR}/\`. Use built-in \`Read\` / \`Glob\` / \`Grep\` freely anywhere in the workspace.
+- The built-in \`Edit\` / \`Write\` tools are restricted to your scratch workspace under \`${AGENT_SCRATCH_DIR}/\`. Use built-in \`Read\` / \`Glob\` / \`Grep\` freely anywhere in the workspace. The built-in \`Read\` tool can read image files (PNG, JPEG, GIF, WebP, etc.) — it returns them as image content blocks you can see and describe. Use it when the user references an image in the workspace.
 - Preserve the user's voice — don't rewrite sentences that aren't broken.
 - Do NOT create new tab files. Only edit the files listed above.
 - If the user's message is about the active file, prefer editing that one. Edit other files when the request genuinely spans them.
-- **Never use assistant text for substantive output.** Users do not read the agent history pane — it's a debug log, not a communication channel. Anything you want the user to actually see (an answer to their question, a discussion, a proposed direction, a "here's what I'd do" reflection, a follow-up question, a caveat) must be a \`post_comment\` on the relevant passage — that's what shows up in their gutter and that's what they read. Multi-paragraph reflections, "I think weaving them in works, with one caveat…"-style messages, or any thinking-out-loud belongs in a comment thread anchored to the passage it's about. Assistant text should be empty, or at most a one-line ack like "Done." — and even then, prefer no text at all (the review cards / comment threads speak for themselves). If the user asked a question or requested something you can't address by editing, post a comment, don't write a message.
+- **Never use assistant text for substantive output.** Users do not read the agent history pane — it's a debug log, not a communication channel. Anything you want the user to actually see (an answer to their question, a discussion, a proposed direction, a "here's what I'd do" reflection, a follow-up question, a caveat) goes in a comment thread they opened, via \`reply_to_comment\` on the thread's \`thread_id\`. **You cannot start a new thread — that's the user's prerogative.** If there's no thread on the passage you want to discuss, you have three options: (1) make the edit and let the diff speak for itself, (2) call \`AskUserQuestion\` if you genuinely can't decide, or (3) stay silent. Assistant text should be empty, or at most a one-line ack like "Done." — and even then, prefer no text at all (the review cards / comment threads speak for themselves).
 
 ## When to ask instead of edit
 
 If the request is genuinely ambiguous and has multiple reasonable directions (tone, structure, which of several things to fix first), call \`AskUserQuestion\` with 2–4 concrete options BEFORE editing. Use it sparingly — only when a judgment call would otherwise be a guess. Never use it for questions the user can already see the answer to in their own text.
 
-## When to comment instead of edit
+## When to reply on a comment thread instead of edit
 
-You have \`post_comment\` (\`mcp__docwriter-doc__post_comment\`). It opens a threaded comment on a passage of a tab file — similar to Google Docs comments. The user can reply, resolve the thread, or click "Approve & propose edit" on your comment to have you apply the change in a later turn.
+You have \`reply_to_comment\` (\`mcp__docwriter-doc__reply_to_comment\`). It posts a reply on a comment thread the **user** has already opened — similar to Google Docs comments. The user can reply, resolve the thread, or click "Approve & propose edit" on your reply to apply a change in a later turn.
 
-**This is your only channel for talking to the user.** Anything you want them to read goes here, anchored to the passage it's about. Assistant text in the agent history pane is invisible to them in practice.
+**You cannot open new threads.** Only the user can start a thread (typically by giving feedback on a passage; the system opens the thread on their behalf and shows you its \`thread_id\`). If there's no thread for what you want to say, do not invent one — edit, ask via \`AskUserQuestion\`, or stay silent.
 
-Use it WHEN:
+Reply WHEN there is an existing thread for the passage AND:
 
-- You want to say *anything substantive* to the user that isn't a direct edit. Discussion, reflection, "I think X works but with one caveat…", proposed approaches, follow-up questions, "want me to draft Y?" offers — all of it goes in a comment, not in a message.
+- You want to say *anything substantive* to the user that isn't a direct edit. Discussion, reflection, "I think X works but with one caveat…", proposed approaches, follow-up questions, "want me to draft Y?" offers — all of it goes in the thread, not in a message.
 - The user's message is open-ended, questioning, or unsure — e.g. "idk what do you think about this opener?", "is this too long?", "does this land?", "any thoughts?", "maybe X?".
-- The right next step is *a discussion*, not a change. You want to share a perspective, ask the user a follow-up, or propose a direction before committing to an edit.
+- The right next step is *a discussion*, not a change. You want to share a perspective, ask a follow-up, or propose a direction before committing to an edit.
 - The user flagged a passage but didn't say what to do with it.
 
-Do NOT use it WHEN:
+Do NOT reply WHEN:
 
 - The user asked for a concrete change ("too verbose", "fix this typo", "rewrite for clarity"). Call \`edit_doc\` directly.
-- The feedback is actionable enough to edit in \`[mode: auto]\` ("awk", "unclear", "too wordy", "tighten this", "make this land"). Call \`edit_doc\` and do not also call \`post_comment\`.
+- The feedback is actionable enough to edit in \`[mode: auto]\` ("awk", "unclear", "too wordy", "tighten this", "make this land"). Call \`edit_doc\` and do not also reply.
 - You're just narrating what you already edited. Review cards speak for themselves.
+- There's no relevant existing thread. You cannot create one.
 
-Mode override: the user can attach an explicit routing hint to a feedback message — **[mode: auto|edit|discuss]**. When you see \`[mode: edit]\`, do NOT call \`post_comment\`; call \`edit_doc\`. When you see \`[mode: discuss]\`, do NOT call \`edit_doc\`; call \`post_comment\`. When you see \`[mode: auto]\` or no mode tag, use your judgment per the rules above: if the feedback can be resolved with a concrete edit, edit only; if the user is asking for judgment or discussion, comment only. Do not combine \`edit_doc\` and \`post_comment\` for the same feedback unless the user explicitly asks for both.
+Mode override: the user can attach an explicit routing hint to a feedback message — **[mode: auto|edit|discuss]**. When you see \`[mode: edit]\`, do NOT call \`reply_to_comment\`; call \`edit_doc\`. When you see \`[mode: discuss]\`, do NOT call \`edit_doc\`; reply on the user's thread for that feedback via \`reply_to_comment\`. When you see \`[mode: auto]\` or no mode tag, use your judgment per the rules above: if the feedback can be resolved with a concrete edit, edit only; if the user is asking for judgment or discussion AND a thread exists, reply only. Do not combine \`edit_doc\` and \`reply_to_comment\` for the same feedback unless the user explicitly asks for both.
 
-When commenting:
+When replying:
 
 - Speak in first person ("I'd cut the second clause …", "I think this works — the only snag is …"). Don't narrate as a third party.
 - Keep replies to a few sentences. The thread is for conversation, not essays.
 - If you want to sketch a concrete edit for the user to approve, pass \`proposed_edit\` — the UI turns it into an "Approve & propose edit" button.
-- When replying to an existing thread, always pass that thread's \`thread_id\`. Open thread transcripts are listed under each tab; don't open a new thread for a reply.
+- Always pass the existing thread's \`thread_id\`. Open thread transcripts are listed under each tab.
 
-When the same user message carries both a clear directive AND ambient uncertainty ("rewrite this — actually, idk, what do you think?"), lean toward commenting first and offering the edit in \`proposed_edit\`. Cheap to apply later, costly to rewrite past prose the user isn't sure they want rewritten.
+When the same user message carries both a clear directive AND ambient uncertainty ("rewrite this — actually, idk, what do you think?"), lean toward replying first (if there's a thread) and offering the edit in \`proposed_edit\`. Cheap to apply later, costly to rewrite past prose the user isn't sure they want rewritten.
 
 ## What you can read vs. what you can write
 
@@ -380,13 +387,11 @@ Use the fetched excerpts as calibration when you edit: if you're tightening a se
 
 ## Rules to obey
 
-Per-turn prompts include a \`## Rules update\` block ONLY when rules have been added or removed since the last turn. The full rule list lives in the workspace; treat each rule as a standing constraint that remains in force across every render until you see it removed.
+${rulesBlock}
 
-- A new rule appears as \`+ <rule text>\` — treat it as active from this turn forward.
-- A removed rule appears as \`- <rule text>\` — drop it from your active constraints.
-- If no \`## Rules update\` block appears, the active rule set is unchanged from the prior turn.
+Treat each rule as a hard constraint on every edit. If a rule conflicts with the user's explicit request in the current turn, the request wins for that turn but do not generalize the override.
 
-When applying rules to an edit, treat them as hard constraints. If a rule conflicts with the user's explicit request in the current turn, the request wins for that turn but do not generalize the override.
+Per-turn prompts may include a \`## Rules update\` block when rules have been added or removed since the last turn. A new rule appears as \`+ <rule text>\`; a removed rule as \`- <rule text>\`. If no update block appears, the rule set above is current.
 
 ## How to decide whether to edit
 
@@ -763,6 +768,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			? `You are a writing assistant. The user has a set of files open as tabs. Acknowledge you're ready in 1-2 sentences. Don't edit anything.`
 			: buildMultiTabPrompt(active, tabsForPrompt, message) + planModeInstruction;
 		const systemPromptBlock = warmup ? undefined : buildSystemPrompt();
+		if (systemPromptBlock) setLastSystemPrompt(systemPromptBlock);
 		const openTabPaths = new Set(allTabIds.map((tabId) => normalizeToolPath(tabFile(tabId))));
 
 		const abortController = new AbortController();
@@ -806,7 +812,7 @@ export const POST: RequestHandler = async ({ request }) => {
 							ASK_USER_TOOL_NAME,
 							EXIT_PLAN_MODE_TOOL_NAME,
 							READ_DOC_TOOL_NAME,
-							POST_COMMENT_TOOL_NAME
+							REPLY_TO_COMMENT_TOOL_NAME
 						];
 						const fullAllowedTools = [
 							'Read',
@@ -823,7 +829,7 @@ export const POST: RequestHandler = async ({ request }) => {
 							EDIT_DOC_TOOL_NAME,
 							READ_DOC_TOOL_NAME,
 							WRITE_DOC_TOOL_NAME,
-							POST_COMMENT_TOOL_NAME
+							REPLY_TO_COMMENT_TOOL_NAME
 						];
 						return {
 							allowedTools: warmup
@@ -865,15 +871,6 @@ export const POST: RequestHandler = async ({ request }) => {
 								if (toolName === 'Read') {
 									const filePath =
 										typeof toolInput?.file_path === 'string' ? toolInput.file_path : '';
-									if (/\.(png|jpe?g|gif|webp|bmp|tiff?|ico|heic|avif)$/i.test(filePath)) {
-										return {
-											behavior: 'deny' as const,
-											message:
-												`"${filePath}" is a binary image file — the Read tool cannot send it to the API as text. ` +
-												`If the user attached this image to their message it is already in your context. ` +
-												`Otherwise ask the user to attach it via the chat panel's image drop.`
-										};
-									}
 									const matched = findReferencedOpenTabPath(
 										toolInput?.file_path,
 										openTabPaths


### PR DESCRIPTION
## Summary

### Agent tool & prompt fixes
- **Image file reads work.** Removed the `PreToolUse` deny guard that blocked the built-in `Read` tool on image files (PNG, JPEG, etc.). The SDK handles them natively as base64 image content blocks. Added a prompt hint so the agent knows it can read images.
- **Rules inlined in system prompt.** Rules now appear as a numbered list under "Rules to obey" in the system prompt itself, instead of only appearing as deltas in the per-render user prompt. Always in the agent cached context.
- **System prompt visible in transcript viewer.** The render route stashes the system prompt in memory; `/api/history` returns it; the SessionViewer collapsible System card (previously always empty) now renders it including the full rule list.
- **`post_comment` renamed to `reply_to_comment`.** Agents can no longer open new comment threads, only reply on user-opened ones. Updated tool name, schema (removed `anchor_text`), prompt instructions, and all references.

### Editor improvements
- **Paragraph-level word diff in the diff overlay.** New `cachedWordDiff` per-paragraph diffing renders inline green/red spans within modified paragraphs instead of line-level block diffs. Uses `paragraphPlainText()` and updated `buildCharIndex` (now handles `hardBreak` nodes) for correct position mapping.
- **Media overlay (Substack-style).** New `media-overlay.ts` ProseMirror plugin renders inline image thumbnails for `![](src)` tokens, inline link marks with dotted underline, and hover-card OG tooltips for URLs. All read-only decorations, no doc mutation.
- **Media paste/drop.** New `media-paste.ts` handles clipboard/drop of images, image URLs, and URL-over-selection to markdown link transforms.
- **OpenGraph endpoint** (`/api/opengraph`) for link preview metadata fetching.
- **Line gutter uses absolute positioning.** `plainLineRows` now carries `{ label, top }` tuples so gutter numbers follow paragraphs through media widgets, diff decorations, and soft-wrap.
- **Review baseline uses `rounds[0].beforeMd`** instead of re-reading `currentTabText`, fixing stale baseline when the user types during a render.
- **Inline accept is FIFO.** The inline checkmark accepts `rounds[0]` only; subsequent rounds stay in the composed diff until their turn.

### Undo improvements
- **Accept/reject are ctrl+z undoable.** `collaborativeExtensions` now includes `USER_ORIGIN` in `yUndoOptions.trackedOrigins`, so server-side accept/reject transactions land on the client undo stack.

### UI polish
- **OutlinePane empty state.** Shows "No agent suggestions yet." when the review section is empty instead of a blank surface.
- **Comment gutter narrowed** from 220px to 200px.
- **Smaller button icons** in pending review cards (12px to 11px).

## Test plan
- [ ] Wake the agent, open transcript viewer - System card shows full system prompt with rules listed
- [ ] Add/remove a rule, re-run - system prompt in transcript updates
- [ ] Place an image in the workspace, ask agent to describe it - agent Reads the PNG successfully
- [ ] Paste an image URL or drag an image into the editor - media overlay renders thumbnail
- [ ] Paste a URL with text selected - wraps as markdown link
- [ ] Hover over an inline URL - OG card tooltip appears
- [ ] Agent proposes an edit - word-level green/red diff renders within modified paragraphs
- [ ] Accept an edit, then ctrl+z - edit reverts and review card reappears
- [ ] User opens a feedback thread, agent replies via reply_to_comment - thread works
- [ ] Open outline with no pending edits - shows empty state message