### PR TITLE
Fix accept diff always accepting first round instead of selected

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2305,10 +2305,16 @@
 					onAcceptInlineEdit={() => {
 						const rounds = currentRounds();
 						if (rounds.length === 0) return;
-						// Diff overlay shows the full pending stack; the inline ✓
-						// accepts rounds[0] only (FIFO). Subsequent rounds stay
-						// in the composed diff until their turn is accepted.
-						void acceptAgentEdit(rounds[0].id);
+						// In muted mode, the user clicks a card to peek a specific
+						// round — accept that one. Otherwise (non-muted or no peek
+						// selected) accept rounds[0] (FIFO).
+						let targetId: string | null = null;
+						expandedReviewRoundId.subscribe((v) => (targetId = v))();
+						const target = targetId
+							? rounds.find((r) => r.id === targetId)
+							: rounds[0];
+						if (!target) return;
+						void acceptAgentEdit(target.id);
 					}}
 				/>
 				{/key}


### PR DESCRIPTION
When using muted mode and peeking a specific round, clicking "Accept diff" would always accept rounds[0] instead of the expanded round. Now checks expandedReviewRoundId store to accept the round the user is actually viewing.

https://claude.ai/code/session_01Pcu1QiYURRdt6SiTqfuA7J