### PR TITLE
Fix URL hover tooltip during pending diffs

### DIFF
--- a/src/lib/editor/diff-overlay.ts
+++ b/src/lib/editor/diff-overlay.ts
@@ -8,6 +8,7 @@ import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
 import { wordDiff, type DiffPart as WordDiffPart } from '$lib/diff';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import { buildCharIndex, paragraphPlainText } from './char-index';
+import { applyProposedLinkAttrs } from './media-overlay';
 
 /** Memoize diffWords / diffLines by their string inputs. The diff inputs
  * (baseline + proposedText) only change when the review state changes,
@@ -671,6 +672,7 @@ export const DiffOverlay = Extension.create({
 															span.className = addedClass;
 															span.textContent = value;
 															span.setAttribute('contenteditable', 'false');
+															applyProposedLinkAttrs(span, value);
 															return span;
 														},
 														{ side: -1, key: `add:${editorPos}:${value}` }
@@ -966,6 +968,7 @@ function renderModifiedParagraph(
 						span.className = addedClass;
 						span.textContent = afterText;
 						span.setAttribute('contenteditable', 'false');
+						applyProposedLinkAttrs(span, afterText);
 						return span;
 					},
 					{ side: -1, ignoreSelection: true, key: `modadd-block:${para.pos}` }
@@ -1015,6 +1018,7 @@ function renderModifiedParagraph(
 						span.className = addedClass;
 						span.textContent = value;
 						span.setAttribute('contenteditable', 'false');
+						applyProposedLinkAttrs(span, value);
 						return span;
 					},
 					{
@@ -1040,6 +1044,7 @@ function createAddedLineWidget(
 	const block = document.createElement('div');
 	block.className = className;
 	block.textContent = line || ' ';
+	applyProposedLinkAttrs(block, line);
 	// `contenteditable=false` keeps PM from treating the widget DOM as
 	// document content. Click handling lives in the plugin's
 	// `handleDOMEvents.mousedown` so we don't need a per-widget listener

--- a/src/lib/editor/media-overlay.ts
+++ b/src/lib/editor/media-overlay.ts
@@ -200,6 +200,27 @@ const INLINE_URL_RE = /https?:\/\/[^\s<>"'()]+/g;
  * URL only, not the period. */
 const URL_TRAILING_TRIM_RE = /[.,;:!?)\]}]+$/;
 
+/** First absolute http(s) URL in `text`, or null. Shared with the diff
+ * overlay so proposed (green ghost) URL tokens get the same hover-card
+ * affordance as live doc links. */
+export function extractUrlFromText(text: string): string | null {
+	INLINE_URL_RE.lastIndex = 0;
+	const match = INLINE_URL_RE.exec(text);
+	if (!match) return null;
+	const trimmed = match[0].replace(URL_TRAILING_TRIM_RE, '');
+	return trimmed || null;
+}
+
+/** When proposed diff text contains a URL, mark the element so the
+ * media-overlay hover handler shows og metadata for the NEW url rather
+ * than the live-doc inline mark (which still points at the old one). */
+export function applyProposedLinkAttrs(el: HTMLElement, text: string): void {
+	const url = extractUrlFromText(text);
+	if (!url) return;
+	el.classList.add('media-link-inline');
+	el.dataset.url = url;
+}
+
 function scanInlineLinks(doc: PMNode): InlineLink[] {
 	const out: InlineLink[] = [];
 	doc.descendants((node, pos) => {


### PR DESCRIPTION
## Summary
- During a pending review, proposed URL text in green diff ghost widgets now gets `media-link-inline` and `data-url` from the **new** URL.
- Adds shared helpers in `media-overlay.ts` (`extractUrlFromText`, `applyProposedLinkAttrs`) and applies them from all proposed-text paths in `diff-overlay.ts`.
- Fixes the bug where hovering a changed URL in a diff still showed og-card metadata for the old live-doc link.

Closes #14.

## Test plan
- [ ] Open a doc with a bare URL (e.g. `https://example.com/old`).
- [ ] Trigger an agent edit that changes the URL (or use dev `fakeAgentReplace`).
- [ ] Expand the diff and hover the green proposed URL — tooltip should show metadata for the **new** URL.
- [ ] Hover the struck-through old URL — tooltip should still show the old URL.
- [ ] `npm run check` passes.


Made with [Cursor](https://cursor.com)