### PR TITLE
[codex] Fix review undo and model selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@anthropic-ai/claude-agent-sdk": "^0.2.92",
+				"@anthropic-ai/sdk": "^0.81.0",
 				"@hocuspocus/provider": "^3.4.4",
 				"@hocuspocus/server": "^3.4.4",
 				"@tiptap/core": "^3.22.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.92",
+		"@anthropic-ai/sdk": "^0.81.0",
 		"@hocuspocus/provider": "^3.4.4",
 		"@hocuspocus/server": "^3.4.4",
 		"@tiptap/core": "^3.22.3",

--- a/src/lib/components/HistoryPane.svelte
+++ b/src/lib/components/HistoryPane.svelte
@@ -118,12 +118,9 @@
 	let verbosity = $state<HistoryVerbosity>('verbose');
 	historyVerbosity.subscribe((v) => (verbosity = v));
 
-	/** Minimal-mode filter: keep only user actions WITH an explicit trigger,
-	 * actual file mutations (Edit/Write tool calls), hook runs, and
-	 * render_end markers. Hide the intermediate noise (Read/Glob/Grep/Bash/
-	 * Skill exploration, assistant prose, render_start) AND the implicit
-	 * "Review document and improve" user_action that fires on bare Wake Up
-	 * (it adds no information — the edit itself tells the story). */
+	/** Minimal-mode filter: keep user-facing conversation, actual file
+	 * mutations (Edit/Write tool calls), hook runs, and important status.
+	 * Hide intermediate tool noise and housekeeping actions. */
 	function keepInMinimal(e: HistoryEntry): boolean {
 		if (e.type === 'user_action') {
 			// Drop the default / housekeeping descriptions that are just
@@ -131,15 +128,17 @@
 			const d = e.description;
 			if (
 				d === 'Review documents & see if there’s anything to do' ||
+				d === 'Agent ran and made no edits' ||
 				d === 'Accepted agent\'s edit' ||
 				d === 'Rejected agent\'s edit' ||
-				/^Accepted \d+ agent edit/.test(d) ||
-				/^Rejected \d+ agent edit/.test(d)
+				/^Accepted (?:all )?\d+ agent edit/.test(d) ||
+				/^Rejected (?:all )?\d+ agent edit/.test(d)
 			) {
 				return false;
 			}
 			return true;
 		}
+		if (e.type === 'assistant_text') return e.text.trim() !== '';
 		if (e.type === 'hook_run') return true;
 		if (e.type === 'tool_call') {
 			return /^(Edit|Write)$/.test(e.tool_name);
@@ -156,7 +155,7 @@
 		if (e.type === 'notification') {
 			return e.priority === 'high' || e.priority === 'immediate';
 		}
-		// Skip render_end / render_start / assistant_text in minimal.
+		// Skip render_end / render_start / assistant_thinking in minimal.
 		return false;
 	}
 

--- a/src/lib/editor-extensions.ts
+++ b/src/lib/editor-extensions.ts
@@ -4,9 +4,10 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import HardBreak from '@tiptap/extension-hard-break';
 import Collaboration from '@tiptap/extension-collaboration';
+import { ySyncPluginKey } from '@tiptap/y-tiptap';
 import type { Extensions } from '@tiptap/core';
-import type * as Y from 'yjs';
-import { USER_ORIGIN } from '$lib/shared/ydoc-codec';
+import * as Y from 'yjs';
+import { FRAGMENT_NAME, REVIEW_ARRAY_NAME, USER_ORIGIN } from '$lib/shared/ydoc-codec';
 
 /** Plain-text extension set: minimal schema (doc, paragraph, text, hard-break).
  * Every file — including `.md` / `.markdown` / `.mdx` — is rendered as source
@@ -29,24 +30,26 @@ export function plainBaseExtensions(options?: { placeholder?: string }): Extensi
  * and binds them to the supplied Y.Doc's `default` XmlFragment. Always plain
  * text — see `plainBaseExtensions` for why.
  *
- * `yUndoOptions.trackedOrigins` is additive: y-prosemirror's yUndoPlugin
- * always tracks `ySyncPluginKey` (so local typing stays undoable) and
- * concatenates whatever we pass here. Including `USER_ORIGIN` makes the
- * server-side accept / reject / reject-all transactions undoable from
- * the client — ctrl+z after an Accept reverts the text edit AND
- * resurrects the just-deleted pending review card in one step (they're
- * applied in a single `ydoc.transact(..., USER_ORIGIN)`, so the
- * UndoManager treats them as one stack entry). */
+ * The custom UndoManager scopes both the text fragment and the pending
+ * review array. That keeps ordinary local typing undoable (`ySyncPluginKey`)
+ * while letting Accept/Reject apply as undoable user actions (`USER_ORIGIN`):
+ * ctrl+z after Accept reverts the text and resurrects the just-deleted
+ * pending review card; ctrl+z after Reject resurrects the diff card. */
 export function collaborativeExtensions(
 	ydoc: Y.Doc,
 	options?: { placeholder?: string }
 ): Extensions {
+	const fragment = ydoc.getXmlFragment(FRAGMENT_NAME);
+	const reviewArray = ydoc.getArray(REVIEW_ARRAY_NAME);
+	const undoManager = new Y.UndoManager([fragment, reviewArray], {
+		trackedOrigins: new Set([ySyncPluginKey, USER_ORIGIN])
+	});
 	return [
 		...plainBaseExtensions(options),
 		Collaboration.configure({
 			document: ydoc,
-			field: 'default',
-			yUndoOptions: { trackedOrigins: [USER_ORIGIN] }
+			field: FRAGMENT_NAME,
+			yUndoOptions: { undoManager }
 		})
 	];
 }

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -990,6 +990,10 @@
 		return wrapperEl?.scrollTop ?? 0;
 	}
 
+	export function focusEditor(): void {
+		editor?.commands.focus();
+	}
+
 	// Flash a sage-green halo on the freshly-accepted text range. Called
 	// by the parent right after a successful Accept; locates the new
 	// text in the live PM doc and dispatches the celebration decoration

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -298,23 +298,28 @@ export async function acceptTabRounds(
 export async function rejectTabRounds(
 	tabId: string,
 	roundId?: string
-): Promise<{ rejectedCount: number; rounds: PendingReviewRound[] }> {
+): Promise<{ rejectedCount: number; rounds: PendingReviewRound[]; yjsUpdate: string | null }> {
 	return withLiveDoc(tabId, (ydoc) => {
 		const reviewArr = getReviewArray(ydoc);
 		const current = reviewArr.toArray();
-		if (current.length === 0) return { rejectedCount: 0, rounds: [] };
+		if (current.length === 0) return { rejectedCount: 0, rounds: [], yjsUpdate: null };
 		// No roundId = reject everything. With a roundId, drop only that
 		// round; later rounds stay and will surface stale if they no longer
 		// apply (the materializer marks them).
+		const beforeStateVector = Y.encodeStateVector(ydoc);
 		if (!roundId) {
 			ydoc.transact(() => reviewArr.delete(0, current.length), USER_ORIGIN);
-			return { rejectedCount: current.length, rounds: [] };
+			const deltaBytes = Y.encodeStateAsUpdate(ydoc, beforeStateVector);
+			const yjsUpdate = Buffer.from(deltaBytes).toString('base64');
+			return { rejectedCount: current.length, rounds: [], yjsUpdate };
 		}
 		const idx = current.findIndex((r) => r.id === roundId);
-		if (idx < 0) return { rejectedCount: 0, rounds: current };
+		if (idx < 0) return { rejectedCount: 0, rounds: current, yjsUpdate: null };
 		ydoc.transact(() => reviewArr.delete(idx, 1), USER_ORIGIN);
 		const remaining = current.slice(0, idx).concat(current.slice(idx + 1));
-		return { rejectedCount: 1, rounds: remaining };
+		const deltaBytes = Y.encodeStateAsUpdate(ydoc, beforeStateVector);
+		const yjsUpdate = Buffer.from(deltaBytes).toString('base64');
+		return { rejectedCount: 1, rounds: remaining, yjsUpdate };
 	});
 }
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -262,7 +262,58 @@ export const activeTab = writable<string | null>(null);
 
 // ── Preferences ───────────────────────────────────────────────────────
 
-export const selectedModel = writable<string>('opus');
+/** One selectable model in the Settings → Model menu. `id` is the full Claude
+ * API model ID sent to the agent; `label` is the human-readable name. */
+export type ModelOption = { id: string; label: string };
+
+/** Newest-first static list, shown immediately on load and used as the
+ * fallback whenever the live Models API can't be reached. Mirrors the server
+ * fallback in `/api/models`. */
+export const FALLBACK_MODELS: ModelOption[] = [
+	{ id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+	{ id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+	{ id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+	{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+	{ id: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
+	{ id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+	{ id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' }
+];
+
+/** Live model catalog populated by `loadAvailableModels()`. Starts on the
+ * static fallback so the menu is never empty. */
+export const availableModels = writable<ModelOption[]>(FALLBACK_MODELS);
+
+// `selectedModel` persists only on an EXPLICIT user pick (via
+// `setSelectedModel`). The bare initial default ('opus') is NOT written, so we
+// can tell "user hasn't chosen" apart from "user picked Opus" and keep
+// defaulting to the latest Opus as new models ship.
+const SELECTED_MODEL_KEY = 'docwriter.selectedModel';
+const storedModel = typeof window === 'undefined' ? null : window.localStorage.getItem(SELECTED_MODEL_KEY);
+export const selectedModel = writable<string>(storedModel ?? 'opus');
+
+/** Set the model in response to an explicit user choice and persist it. */
+export function setSelectedModel(id: string) {
+	selectedModel.set(id);
+	if (typeof window !== 'undefined') window.localStorage.setItem(SELECTED_MODEL_KEY, id);
+}
+
+/** Fetch the live model list from `/api/models`. If the user hasn't explicitly
+ * pinned a model yet, adopt the server's default (latest Opus). Silently keeps
+ * the fallback list on any error. */
+export async function loadAvailableModels() {
+	if (typeof window === 'undefined') return;
+	try {
+		const res = await fetch('/api/models');
+		if (!res.ok) return;
+		const data = (await res.json()) as { models?: ModelOption[]; defaultModel?: string };
+		if (data.models?.length) availableModels.set(data.models);
+		// Only auto-adopt the default when the user has made no explicit pick.
+		if (!storedModel && data.defaultModel) selectedModel.set(data.defaultModel);
+	} catch {
+		// Keep the fallback list / current selection.
+	}
+}
+
 export const selectedTheme = writable<string>('light');
 
 /** History pane verbosity. `verbose` = every tool call, assistant monologue,

--- a/src/lib/yjs-doc.ts
+++ b/src/lib/yjs-doc.ts
@@ -1,6 +1,6 @@
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
-import { COMMENTS_MAP_NAME, FRAGMENT_NAME, REVIEW_ARRAY_NAME } from '$lib/shared/ydoc-codec';
+import { COMMENTS_MAP_NAME, FRAGMENT_NAME, REVIEW_ARRAY_NAME, USER_ORIGIN } from '$lib/shared/ydoc-codec';
 import type { CommentThread, PendingReviewRound } from './types';
 
 /**
@@ -152,6 +152,23 @@ export function waitForTabSync(tabId: string, timeoutMs = 2_000): Promise<boolea
 	return waitForProviderIdle(doc.wsProvider, timeoutMs);
 }
 
+/** Temporarily stop receiving WebSocket updates for a tab. Accept/Reject use
+ * this to prevent the server's broadcast from winning the race against the
+ * HTTP response: the returned update must be applied locally with USER_ORIGIN
+ * so the editor creates a real undo stack item. */
+export function pauseTabSync(tabId: string): () => void {
+	const doc = registry.get(tabId);
+	const provider = doc?.wsProvider;
+	if (!provider) return () => {};
+	provider.disconnect();
+	let resumed = false;
+	return () => {
+		if (resumed) return;
+		resumed = true;
+		void provider.connect();
+	};
+}
+
 export function isYDocEmptyForTab(tabId: string): boolean {
 	return getXmlFragmentForTab(tabId).length === 0;
 }
@@ -187,16 +204,15 @@ export async function renameTab(oldId: string, newId: string): Promise<void> {
 	registry.set(newId, { ydoc: newYdoc, wsProvider, readyPromise });
 }
 
-/** Apply a base64-encoded Yjs update directly to a tab's local Y.Doc,
- * using the tab's own WebSocket provider as the Yjs origin. This prevents
- * the HocuspocusProvider from echoing the update back to the server (the
- * provider skips forwarding updates whose origin equals itself). When the
- * server later delivers the same update via WebSocket it will be a no-op. */
+/** Apply a base64-encoded Yjs update directly to a tab's local Y.Doc.
+ * Use USER_ORIGIN so the editor's UndoManager records accept/reject
+ * transactions as user actions; the later WebSocket broadcast of the same
+ * server update is a CRDT no-op. */
 export function applyUpdateToTab(tabId: string, updateBase64: string): void {
 	const doc = registry.get(tabId);
 	if (!doc) return;
 	const bytes = Uint8Array.from(atob(updateBase64), (c) => c.charCodeAt(0));
-	Y.applyUpdate(doc.ydoc, bytes, doc.wsProvider ?? 'server-accept');
+	Y.applyUpdate(doc.ydoc, bytes, USER_ORIGIN);
 }
 
 export async function resetAllYDocs(): Promise<void> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -71,7 +71,8 @@
 		destroyTab,
 		renameTab,
 		reconcileServerInstance,
-		applyUpdateToTab
+		applyUpdateToTab,
+		pauseTabSync
 	} from '$lib/yjs-doc';
 	import type { Editor } from '@tiptap/core';
 	import {
@@ -89,6 +90,10 @@
 		pushHistory,
 		nextHistoryKey,
 		selectedModel,
+		setSelectedModel,
+		availableModels,
+		loadAvailableModels,
+		type ModelOption,
 		selectedTheme,
 		submitCountdown,
 		editorFontScale,
@@ -118,6 +123,7 @@
 		flushAutosave: () => Promise<boolean>;
 		cancelIdleTimer: () => void;
 		getScrollTop: () => number;
+		focusEditor: () => void;
 		flashAcceptedRange: (text: string) => void;
 	};
 
@@ -1206,6 +1212,52 @@
 		].join('\n');
 	}
 
+	type ReviewAction = 'accept_rounds' | 'reject_rounds';
+	type ReviewActionResponse = {
+		ok?: boolean;
+		rounds?: PendingReviewRound[];
+		yjsUpdate?: string | null;
+		acceptedCount?: number;
+		rejectedCount?: number;
+		error?: string;
+		stale?: boolean;
+		staleRoundId?: string | null;
+		staleRoundKind?: string | null;
+	};
+
+	/** Shared accept/reject transport. The ordering here is the undo contract:
+	 * pause WebSocket sync, let the server mutate, apply the returned delta
+	 * locally with USER_ORIGIN, then reconnect. That guarantees the browser's
+	 * UndoManager sees Accept/Reject as a local user action instead of a
+	 * provider-origin remote update. */
+	async function postReviewAction(
+		tabId: string,
+		action: ReviewAction,
+		roundId?: string
+	): Promise<{ res: Response; data: ReviewActionResponse }> {
+		const synced = await editorRef?.flushAutosave();
+		if (synced === false) {
+			throw new Error('Latest local edits are still syncing to the server. Try again in a moment.');
+		}
+
+		const resumeTabSync = pauseTabSync(tabId);
+		try {
+			const res = await fetch(`/api/document?tab=${encodeURIComponent(tabId)}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action, roundId })
+			});
+			const data = (await res.json().catch(() => ({}))) as ReviewActionResponse;
+			if (res.ok && data?.ok && Array.isArray(data.rounds) && typeof data.yjsUpdate === 'string') {
+				applyUpdateToTab(tabId, data.yjsUpdate);
+				editorRef?.focusEditor();
+			}
+			return { res, data };
+		} finally {
+			resumeTabSync();
+		}
+	}
+
 	/** Accept a single pending round by id (or all rounds if no id is
 	 * given — used by the "Accept all" path). Rounds are independent: the
 	 * server applies just this round's edit op against the current live
@@ -1230,16 +1282,7 @@
 		clearPeekIfMatches(roundId);
 		editorRef?.cancelIdleTimer();
 		try {
-			const synced = await editorRef?.flushAutosave();
-			if (synced === false) {
-				throw new Error('Latest local edits are still syncing to the server. Try again in a moment.');
-			}
-			const res = await fetch(`/api/document?tab=${encodeURIComponent(tabId)}`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ action: 'accept_rounds', roundId })
-			});
-			const data = await res.json().catch(() => ({}));
+			const { res, data } = await postReviewAction(tabId, 'accept_rounds', roundId);
 			if (res.status === 409 && data?.stale) {
 				const staleRoundId: string | null = data.staleRoundId ?? roundId ?? null;
 				const reason: string = typeof data.error === 'string' && data.error
@@ -1265,16 +1308,6 @@
 			if (!res.ok || !data?.ok || !Array.isArray(data.rounds)) {
 				throw new Error(data?.error || `HTTP ${res.status}`);
 			}
-			// Apply the server's Yjs delta directly to the local Y.Doc.
-			// This updates the editor in-place without any disconnect/remount:
-			// the same update Hocuspocus broadcasts over WebSocket, but
-			// delivered via the HTTP response so it arrives synchronously.
-			// Using the tab's own provider as origin prevents the provider
-			// from echoing it back; when the WebSocket broadcast arrives
-			// shortly after it will be a CRDT no-op.
-			if (typeof data.yjsUpdate === 'string') {
-				applyUpdateToTab(tabId, data.yjsUpdate);
-			}
 			const acceptedCount =
 				typeof data.acceptedCount === 'number'
 					? data.acceptedCount
@@ -1291,17 +1324,17 @@
 				if (!op.newString) continue;
 				editorRef?.flashAcceptedRange(op.newString);
 			}
-		clearFeedbackAnnotationsForTab(tabId);
-		const acceptedMsg =
-			acceptedCount === rounds.length
-				? `Accepted all ${rounds.length} agent edit${rounds.length === 1 ? '' : 's'}`
-				: `Accepted ${acceptedCount} agent edit${acceptedCount === 1 ? '' : 's'}`;
-		pushHistory({
-			type: 'user_action',
-			timestamp: Date.now(),
-			description: acceptedMsg
-		});
-		void submit(acceptedMsg);
+			clearFeedbackAnnotationsForTab(tabId);
+			const acceptedMsg =
+				acceptedCount === rounds.length
+					? `Accepted all ${rounds.length} agent edit${rounds.length === 1 ? '' : 's'}`
+					: `Accepted ${acceptedCount} agent edit${acceptedCount === 1 ? '' : 's'}`;
+			pushHistory({
+				type: 'user_action',
+				timestamp: Date.now(),
+				description: acceptedMsg
+			});
+			void submit(acceptedMsg);
 		} catch (e) {
 			console.error('Failed to accept agent edit:', e);
 			pushHistory({
@@ -1366,22 +1399,7 @@
 		clearPeekIfMatches(roundId);
 		editorRef?.cancelIdleTimer();
 		try {
-			const synced = await editorRef?.flushAutosave();
-			if (synced === false) {
-				throw new Error('Latest local edits are still syncing to the server. Try again in a moment.');
-			}
-			// No more disconnect/remount: reject only deletes from the review
-			// Y.Array on the server, never touches the doc fragment. The Yjs
-			// sync delivers the array-mutation update to the editor, the
-			// review observer fires, and the pending-edits panel updates in
-			// place. The teardown was a leftover from the wholesale-replace
-			// accept path; it never had a reason to apply to reject.
-			const res = await fetch(`/api/document?tab=${encodeURIComponent(tabId)}`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ action: 'reject_rounds', roundId })
-			});
-			const data = await res.json().catch(() => ({}));
+			const { res, data } = await postReviewAction(tabId, 'reject_rounds', roundId);
 			if (!res.ok || !data?.ok || !Array.isArray(data.rounds)) {
 				throw new Error(data?.error || `HTTP ${res.status}`);
 			}
@@ -1671,6 +1689,9 @@
 	let model = $state('opus');
 	selectedModel.subscribe((v) => (model = v));
 
+	let modelOptions = $state<ModelOption[]>([]);
+	availableModels.subscribe((v) => (modelOptions = v));
+
 	let themeName = $state('light');
 	selectedTheme.subscribe((v) => (themeName = v));
 
@@ -1724,11 +1745,12 @@
 				{
 					kind: 'submenu',
 					label: 'Model',
-					items: [
-						{ kind: 'action', label: 'Opus', checked: model === 'opus', onClick: () => selectedModel.set('opus') },
-						{ kind: 'action', label: 'Sonnet', checked: model === 'sonnet', onClick: () => selectedModel.set('sonnet') },
-						{ kind: 'action', label: 'Haiku', checked: model === 'haiku', onClick: () => selectedModel.set('haiku') }
-					]
+					items: modelOptions.map((m) => ({
+						kind: 'action' as const,
+						label: m.label,
+						checked: model === m.id,
+						onClick: () => setSelectedModel(m.id)
+					}))
 				},
 				{ kind: 'panel', label: 'Agent behavior', panelKey: 'agentSettings' },
 				{
@@ -1981,6 +2003,10 @@
 		// writes every session to disk keyed by sessionId; we just read it
 		// back and convert to our HistoryEntry format.
 		void restoreAgentHistory();
+
+		// Pull the live model catalog for the Settings → Model menu and adopt
+		// the latest-Opus default if the user hasn't pinned a model.
+		void loadAvailableModels();
 
 		// Now that stores are populated, attach persist-on-change subscribers.
 		// The debounced write coalesces bursts of clicks into one PUT.

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -1,0 +1,63 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import Anthropic from '@anthropic-ai/sdk';
+
+/** One selectable model in the Settings → Model menu. `id` is the full Claude
+ * API model ID (e.g. `claude-opus-4-8`) sent straight to `query()`. */
+export type ModelOption = { id: string; label: string };
+
+/** Used when the Models API can't be reached (no `ANTHROPIC_API_KEY`, offline,
+ * Claude-subscription OAuth without a key, etc.). Kept newest-first; bump this
+ * when a new family member ships and the live list is unavailable. */
+const FALLBACK_MODELS: ModelOption[] = [
+	{ id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+	{ id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+	{ id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+	{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+	{ id: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
+	{ id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+	{ id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' }
+];
+
+/** Pick the default: the newest Opus in the (newest-first) list, falling back
+ * to the first entry, then to the bare `opus` alias. */
+function defaultModelFor(models: ModelOption[]): string {
+	return models.find((m) => m.id.includes('opus'))?.id ?? models[0]?.id ?? 'opus';
+}
+
+// Module-scope cache: the model catalog changes rarely, so we fetch it once per
+// server process and reuse it across requests.
+let cache: { models: ModelOption[]; defaultModel: string } | null = null;
+
+export const GET: RequestHandler = async () => {
+	if (cache) return json(cache);
+
+	try {
+		// `new Anthropic()` throws synchronously if no API key is configured, and
+		// `models.list()` rejects on auth/network failure — both land in catch.
+		const client = new Anthropic();
+		const collected: Array<{ id: string; label: string; created: number }> = [];
+		for await (const m of client.models.list({ limit: 1000 })) {
+			if (!m.id.startsWith('claude-')) continue;
+			collected.push({
+				id: m.id,
+				label: m.display_name || m.id,
+				created: Date.parse(m.created_at) || 0
+			});
+		}
+		if (collected.length === 0) throw new Error('no models returned');
+
+		// Newest-first. The API already returns this order, but sort defensively.
+		collected.sort((a, b) => b.created - a.created);
+		const models = collected.map(({ id, label }) => ({ id, label }));
+		cache = { models, defaultModel: defaultModelFor(models) };
+		return json(cache);
+	} catch {
+		// Don't cache the fallback — a later request may succeed once auth/network
+		// recovers.
+		return json({
+			models: FALLBACK_MODELS,
+			defaultModel: defaultModelFor(FALLBACK_MODELS)
+		});
+	}
+};


### PR DESCRIPTION
## Summary

- Makes Accept and Reject review actions undoable by pausing tab sync, applying returned Yjs deltas locally with `USER_ORIGIN`, and scoping the editor UndoManager to both document text and pending review rounds.
- Keeps Claude assistant messages visible in the history pane minimal view while hiding accept/reject/no-edit housekeeping rows.
- Adds live Claude model discovery for the Settings -> Model menu with a fallback catalog and explicit `@anthropic-ai/sdk` dependency.

## Root Cause

Yjs transaction origins are local-only. Server-side Accept/Reject transactions arrived in the browser over WebSocket as provider-origin updates, so the client UndoManager did not track them. If the WebSocket update won the race before the HTTP response, the later local apply was a duplicate no-op and Ctrl/Cmd+Z had nothing to undo.

## Validation

- `npm run check` passes with 0 errors.
- Existing warnings remain in `OutlinePane.svelte` (`line-clamp`) and `TabBar.svelte` (`tablist` tabindex).
- Focused Yjs repros confirmed old WebSocket-first Accept/Reject produced undo stack 0, while the paused-sync path produced stack 1 and restored the accepted/rejected review state.

Fixes #15.
