### PR TITLE
Fix Ctrl+X (cut) not working in feedback popup

### DIFF
--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1204,6 +1204,12 @@
 						e.preventDefault();
 						e.clipboardData?.setData('text/plain', feedbackPopup.text);
 					}}
+					oncut={(e) => {
+						if (feedbackInput || !feedbackPopup) return;
+						e.preventDefault();
+						e.clipboardData?.setData('text/plain', feedbackPopup.text);
+						deleteSelectedTextFromEditor();
+					}}
 				></div>
 				<button class="feedback-submit" onclick={sendCustomFeedback}>Go</button>
 			</div>


### PR DESCRIPTION
## Problem

In the editor's feedback popup, **Ctrl+C (copy) works but Ctrl+X (cut) does nothing.**

## Root cause

The feedback popup's `contenteditable` input (`src/lib/editor/TiptapEditor.svelte`) had an `oncopy` handler that, when no feedback text has been typed, writes the selected passage text to the clipboard:

```svelte
oncopy={(e) => {
  if (feedbackInput || !feedbackPopup) return;
  e.preventDefault();
  e.clipboardData?.setData('text/plain', feedbackPopup.text);
}}
```

There was **no matching `oncut` handler**, so Ctrl+X fell through to default behavior on an empty contenteditable and effectively did nothing.

## Fix

Add an `oncut` handler that mirrors the copy logic (write the passage text to the clipboard) and then deletes the selected passage from the editor via the existing `deleteSelectedTextFromEditor()` helper — i.e. cut = copy + delete.

```svelte
oncut={(e) => {
  if (feedbackInput || !feedbackPopup) return;
  e.preventDefault();
  e.clipboardData?.setData('text/plain', feedbackPopup.text);
  deleteSelectedTextFromEditor();
}}
```

## Validation

`npm run check` passes with 0 errors (the 2 pre-existing a11y/CSS warnings are unrelated).

https://claude.ai/code/session_011mEQmbAXerQc72m4q2ni6x

---
_Generated by [Claude Code](https://claude.ai/code/session_011mEQmbAXerQc72m4q2ni6x)_