### PR TITLE
Widen editor area and add full sidebar collapse

### DIFF
--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -615,10 +615,10 @@
 	.comment-gutter {
 		position: relative;
 		flex-shrink: 0;
-		/* Keep in sync with `--gutter-width` in +page.svelte. */
-		width: 240px;
-		min-width: 240px;
-		max-width: 240px;
+		/* Reads `--gutter-width` from +page.svelte. */
+		width: var(--gutter-width, 240px);
+		min-width: var(--gutter-width, 240px);
+		max-width: var(--gutter-width, 240px);
 		height: 100%;
 		/* Extra bottom room so the lowest card can sit clear of the fixed
 		 * agent dock (AgentDockShell publishes its height as the var). */

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -615,13 +615,10 @@
 	.comment-gutter {
 		position: relative;
 		flex-shrink: 0;
-		/* Keep in sync with `.plain-editor-shell.has-comment-gutter`'s
-		 * third grid column in TiptapEditor.svelte. Compromise between
-		 * the original 220px (felt too wide collapsed) and 180px (too
-		 * narrow for an expanded thread with code paths / long URLs). */
-		width: 280px;
-		min-width: 280px;
-		max-width: 280px;
+		/* Keep in sync with `--gutter-width` in +page.svelte. */
+		width: 240px;
+		min-width: 240px;
+		max-width: 240px;
 		height: 100%;
 		/* Extra bottom room so the lowest card can sit clear of the fixed
 		 * agent dock (AgentDockShell publishes its height as the var). */

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1482,7 +1482,7 @@
 	 * `.comment-gutter` in CommentGutter.svelte. */
 	.plain-editor-shell {
 		display: grid;
-		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 280px);
+		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
 		gap: 18px;
 		width: 100%;
 		justify-content: center;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -340,6 +340,17 @@ if (typeof window !== 'undefined') {
 	showFilesPane.subscribe((v) => window.localStorage.setItem(SHOW_FILES_PANE_KEY, String(v)));
 }
 
+const SHOW_SIDEBAR_KEY = 'docwriter.showSidebar';
+function readShowSidebar(): boolean {
+	if (typeof window === 'undefined') return true;
+	const raw = window.localStorage.getItem(SHOW_SIDEBAR_KEY);
+	return raw === null ? true : raw !== 'false';
+}
+export const showSidebar = writable<boolean>(readShowSidebar());
+if (typeof window !== 'undefined') {
+	showSidebar.subscribe((v) => window.localStorage.setItem(SHOW_SIDEBAR_KEY, String(v)));
+}
+
 /** Whether the floating agent dock is expanded into a panel (showing the
  * history log + dock controls) or collapsed to a pill in the bottom-right.
  * Persisted so it survives reloads. Default collapsed. */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1939,10 +1939,6 @@
 		fileTreeHeight = clampFileTreeHeight(fileTreeHeight - deltaY);
 	}
 
-	function toggleFilesPane() {
-		showFilesPane.set(!filesVisible);
-	}
-
 	function toggleSidebar() {
 		showSidebar.set(!sidebarVisible);
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -100,6 +100,7 @@
 		editorSoftWrap,
 		historyVerbosity,
 		showFilesPane,
+		showSidebar,
 		agentSettings,
 		expandedReviewRoundId,
 		tabs,
@@ -1790,6 +1791,9 @@
 	let filesVisible = $state(true);
 	showFilesPane.subscribe((v) => (filesVisible = v));
 
+	let sidebarVisible = $state(true);
+	showSidebar.subscribe((v) => (sidebarVisible = v));
+
 	// Mirror of agentSettings.muted for class binding on the right pane.
 	// When true, everything in the right sidebar except the agent dock
 	// gets a translucent veil so the user isn't distracted by inflight
@@ -1892,6 +1896,12 @@
 				},
 				{
 					kind: 'action',
+					label: 'Sidebar',
+					checked: sidebarVisible,
+					onClick: () => showSidebar.set(!sidebarVisible)
+				},
+				{
+					kind: 'action',
 					label: 'Files pane',
 					checked: filesVisible,
 					onClick: () => showFilesPane.set(!filesVisible)
@@ -1902,7 +1912,7 @@
 	]);
 
 	// Pane widths (resizable)
-	let leftWidth = $state(260);
+	let leftWidth = $state(240);
 	const MIN_PANE_WIDTH = 180;
 	const MAX_PANE_WIDTH = 560;
 	function resizeLeft(delta: number) {
@@ -1931,6 +1941,10 @@
 
 	function toggleFilesPane() {
 		showFilesPane.set(!filesVisible);
+	}
+
+	function toggleSidebar() {
+		showSidebar.set(!sidebarVisible);
 	}
 
 	let docLoaded = $state(false);
@@ -2317,16 +2331,16 @@
 			<button
 				class="header-toggle"
 				type="button"
-				onclick={toggleFilesPane}
-				aria-pressed={filesVisible}
-				title={filesVisible ? 'Hide files pane' : 'Show files pane'}
+				onclick={toggleSidebar}
+				aria-pressed={sidebarVisible}
+				title={sidebarVisible ? 'Hide sidebar' : 'Show sidebar'}
 			>
-				{#if filesVisible}
+				{#if sidebarVisible}
 					<PanelLeftClose size={15} />
 				{:else}
 					<PanelLeftOpen size={15} />
 				{/if}
-				<span>Files</span>
+				<span>Sidebar</span>
 			</button>
 		</div>
 	</header>
@@ -2351,6 +2365,7 @@
 	{/snippet}
 
 	<div class="body">
+		{#if sidebarVisible}
 		<aside class="left-pane" style:width="{leftWidth}px">
 			<div class="left-pane-inner" bind:this={leftPaneInnerEl}>
 				<div class="outline-wrap">
@@ -2374,6 +2389,7 @@
 			</div>
 		</aside>
 		<PanelResizer onResize={resizeLeft} />
+		{/if}
 		<main class="center-pane">
 			<!-- Align the tab strip over the page column (same geometry as
 			     `.plain-editor-shell`) so the active tab sits on the page. -->
@@ -2471,8 +2487,8 @@
 		--canvas: var(--canvas-bg, color-mix(in srgb, var(--text) 6%, var(--bg)));
 		/* Page + comment-gutter widths — single source of truth; the editor
 		 * grid and the tab-align grid both read these. */
-		--paper-width: 860px;
-		--gutter-width: 280px;
+		--paper-width: 900px;
+		--gutter-width: 240px;
 		background: var(--canvas);
 		color: var(--text);
 		font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -2588,7 +2604,7 @@
 	 * so the tab strip lands directly over the page column below it. */
 	.tab-align {
 		display: grid;
-		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 280px);
+		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
 		gap: 18px;
 		justify-content: center;
 		padding: 10px 32px 0;


### PR DESCRIPTION
## Summary

- **Full sidebar collapse**: The header toggle now hides the entire left pane (outline + file tree), not just the file tree. Reclaims ~240px for the editor when collapsed. State persists in localStorage.
- **Wider paper**: `--paper-width` increased from 860px → 900px.
- **Narrower comment gutter**: `--gutter-width` reduced from 280px → 240px. CommentGutter reads the CSS variable instead of hardcoding the value.
- **Narrower default sidebar**: Left pane default width reduced from 260px → 240px.
- A separate "Files pane" toggle remains in the Settings menu for hiding just the file tree within the sidebar.

## Test plan

- [ ] Open a document with the sidebar visible — verify the editor paper is wider than before
- [ ] Click the "Sidebar" button in the header — verify the entire left pane (outline + file tree + resizer) disappears
- [ ] Click "Sidebar" again — verify the left pane reappears with previous file-tree visibility preserved
- [ ] Reload the page — verify sidebar collapsed/expanded state persists
- [ ] Open Settings → toggle "Files pane" off while sidebar is open — verify only the file tree hides, outline stays
- [ ] Check comment gutter alignment with review cards — verify cards align within the narrower 240px gutter

Closes #32

https://claude.ai/code/session_018QcvneX2fiWF1MzRVpKaKj


---
_Generated by [Claude Code](https://claude.ai/code/session_018QcvneX2fiWF1MzRVpKaKj)_