### PR TITLE
Add rules pill bar and agent dock nudge animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ vite.config.ts.timestamp-*
 # bug-hunting scratch scripts
 scratch-*.ts
 scratch-*.mjs
+dw-*.mjs

--- a/src/lib/components/AgentDockShell.svelte
+++ b/src/lib/components/AgentDockShell.svelte
@@ -20,7 +20,23 @@
 	dockExpanded.subscribe((v) => (expanded = v));
 
 	let rendering = $state(false);
-	isRendering.subscribe((v) => (rendering = v));
+	let nudge = $state(false);
+	let lastIdleAt = Date.now();
+	const NUDGE_COOLDOWN_MS = 60_000;
+
+	isRendering.subscribe((v) => {
+		const wasIdle = !rendering;
+		rendering = v;
+		if (v && wasIdle && !expanded) {
+			const idleFor = Date.now() - lastIdleAt;
+			if (idleFor >= NUDGE_COOLDOWN_MS) {
+				nudge = true;
+				setTimeout(() => (nudge = false), 1200);
+			}
+		}
+		if (!v) lastIdleAt = Date.now();
+	});
+
 	let countdown = $state(0);
 	submitCountdown.subscribe((v) => (countdown = v));
 	// Badge = messages the user has queued while a render is in flight, NOT
@@ -87,6 +103,7 @@
 				<button
 					class="dock-agent-btn"
 					class:awake={rendering}
+					class:nudge
 					onclick={() => dockExpanded.set(true)}
 					use:tooltip={'Open the agent dock'}
 				>
@@ -156,13 +173,30 @@
 		cursor: pointer;
 		white-space: nowrap;
 		position: relative;
-		transition: box-shadow 0.12s ease, border-color 0.12s ease;
+		transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease, background 0.3s ease;
 	}
 	.dock-agent-btn:hover {
 		box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
 	}
 	.dock-agent-btn.awake {
 		border-color: transparent;
+		background: var(--accent-bg);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14), 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+		animation: dock-glow 2s ease-in-out infinite;
+	}
+	.dock-agent-btn.nudge {
+		animation: dock-nudge 1s cubic-bezier(0.22, 1, 0.36, 1), dock-glow 2s ease-in-out 1s infinite;
+	}
+	@keyframes dock-nudge {
+		0% { transform: scale(1); }
+		15% { transform: scale(1.35); }
+		40% { transform: scale(1.1); }
+		60% { transform: scale(1.2); }
+		100% { transform: scale(1); }
+	}
+	@keyframes dock-glow {
+		0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14), 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent); }
+		50% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14), 0 0 0 6px color-mix(in srgb, var(--accent) 15%, transparent), 0 0 20px color-mix(in srgb, var(--accent) 20%, transparent); }
 	}
 	.dock-label {
 		font-size: 11px;
@@ -173,6 +207,9 @@
 	}
 	.dock-agent-btn:hover .dock-label {
 		color: var(--text);
+	}
+	.dock-agent-btn.awake .dock-label {
+		color: var(--accent);
 	}
 	.mascot-face {
 		display: inline-flex;

--- a/src/lib/components/RulesPillBar.svelte
+++ b/src/lib/components/RulesPillBar.svelte
@@ -1,0 +1,457 @@
+<script lang="ts">
+	import { X, Plus, Play, ChevronDown, BookOpen } from 'lucide-svelte';
+	import { rules, pushHistory } from '$lib/stores';
+	import type { Rule } from '$lib/types';
+
+	interface Props {
+		onSubmit?: (trigger: string) => void;
+	}
+	let { onSubmit }: Props = $props();
+
+	let rulesList: Rule[] = $state([]);
+	rules.subscribe((v) => (rulesList = v));
+
+	let popoverOpen = $state(false);
+	let newRule = $state('');
+	let inputEl: HTMLInputElement | undefined = $state();
+	let anchorEl: HTMLDivElement | undefined = $state();
+
+	const MAX_VISIBLE_PILLS = 3;
+	let visibleRules = $derived(rulesList.slice(0, MAX_VISIBLE_PILLS));
+	let overflowCount = $derived(Math.max(0, rulesList.length - MAX_VISIBLE_PILLS));
+
+	async function saveRules(nextRules: Rule[]) {
+		rules.set(nextRules);
+		await fetch('/api/document', {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ meta: { rules: nextRules } })
+		});
+	}
+
+	function addRule() {
+		if (!newRule.trim()) return;
+		const text = newRule.trim();
+		const next = [...rulesList, { id: 'r' + Date.now(), text }];
+		void saveRules(next);
+		pushHistory({ type: 'user_action', timestamp: Date.now(), description: `Added rule: "${text}"` });
+		newRule = '';
+		requestAnimationFrame(() => inputEl?.focus());
+		onSubmit?.(`The user added a new writing rule: "${text}". Revise the open files to comply.`);
+	}
+
+	function removeRule(id: string) {
+		const rule = rulesList.find((r) => r.id === id);
+		const next = rulesList.filter((x) => x.id !== id);
+		void saveRules(next);
+		if (rule) {
+			pushHistory({ type: 'user_action', timestamp: Date.now(), description: `Removed rule: "${rule.text}"` });
+		}
+	}
+
+	function togglePopover() {
+		popoverOpen = !popoverOpen;
+		if (popoverOpen) {
+			requestAnimationFrame(() => inputEl?.focus());
+		} else {
+			newRule = '';
+		}
+	}
+
+	function handleInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') addRule();
+		if (e.key === 'Escape') { popoverOpen = false; newRule = ''; }
+	}
+
+	function handlePopoverPointerdown(e: PointerEvent) {
+		e.stopPropagation();
+	}
+
+	function handleBackdropClick() {
+		popoverOpen = false;
+		newRule = '';
+	}
+
+	function applyRules() {
+		if (rulesList.length === 0) return;
+		const ruleList = rulesList.map((r) => `- ${r.text}`).join('\n');
+		onSubmit?.(
+			`Review files against the following rules and fix violations:\n${ruleList}\n\n` +
+				`Scope: I clicked "Apply rules" without specifying which tabs. ` +
+				`If more than one tab is open, call AskUserQuestion FIRST to confirm scope ` +
+				`(e.g. "Just the active tab", "All open tabs", or let me pick a subset) ` +
+				`before making any edits. If only one tab is open, skip the question and proceed.`
+		);
+		pushHistory({ type: 'user_action', timestamp: Date.now(), description: `Applying ${rulesList.length} rule${rulesList.length === 1 ? '' : 's'}` });
+	}
+</script>
+
+<div class="rules-pill-bar" bind:this={anchorEl}>
+	<!-- Inline pills for the first few rules -->
+	{#each visibleRules as rule (rule.id)}
+		<span class="rule-pill">
+			<span class="pill-text">{rule.text}</span>
+			<button
+				class="pill-remove"
+				onclick={() => removeRule(rule.id)}
+				title="Remove rule"
+				aria-label="Remove rule: {rule.text}"
+			>
+				<X size={9} strokeWidth={2.5} />
+			</button>
+		</span>
+	{/each}
+
+	<!-- Overflow badge -->
+	{#if overflowCount > 0}
+		<button class="overflow-badge" onclick={togglePopover} title="Show all rules">
+			+{overflowCount} more
+		</button>
+	{/if}
+
+	<!-- Add / manage button -->
+	<button
+		class="add-rule-btn"
+		class:active={popoverOpen}
+		onclick={togglePopover}
+		title={rulesList.length > 0 ? 'Manage rules' : 'Add a writing rule'}
+	>
+		<Plus size={11} strokeWidth={2} />
+		{#if rulesList.length === 0}
+			<span>Add rule</span>
+		{/if}
+	</button>
+
+	<!-- Apply button -->
+	{#if rulesList.length > 0}
+		<button class="apply-btn" onclick={applyRules} title="Apply rules to document">
+			<Play size={9} strokeWidth={2.5} />
+		</button>
+	{/if}
+</div>
+
+<!-- Popover (portal-style, outside the flex row) -->
+{#if popoverOpen}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div class="popover-backdrop" onclick={handleBackdropClick}>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="rules-popover" onpointerdown={handlePopoverPointerdown} onclick={(e) => e.stopPropagation()}>
+			<div class="popover-header">
+				<BookOpen size={13} strokeWidth={1.8} />
+				<span>Writing rules</span>
+			</div>
+
+			{#if rulesList.length > 0}
+				<div class="popover-rules-list">
+					{#each rulesList as rule (rule.id)}
+						<div class="popover-rule-row">
+							<span class="popover-rule-text">{rule.text}</span>
+							<button
+								class="popover-rule-remove"
+								onclick={() => removeRule(rule.id)}
+								title="Remove"
+							>
+								<X size={11} strokeWidth={2} />
+							</button>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<div class="popover-empty">No rules yet. Rules tell the AI what constraints to follow.</div>
+			{/if}
+
+			<div class="popover-input-row">
+				<input
+					bind:this={inputEl}
+					class="popover-input"
+					bind:value={newRule}
+					onkeydown={handleInputKeydown}
+					placeholder="Add a rule, e.g. 'No passive voice'"
+				/>
+				<button
+					class="popover-add-btn"
+					onclick={addRule}
+					disabled={!newRule.trim()}
+				>Add</button>
+			</div>
+
+			{#if rulesList.length > 0}
+				<button class="popover-apply-btn" onclick={applyRules}>
+					<Play size={11} strokeWidth={2} />
+					Apply rules to document
+				</button>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.rules-pill-bar {
+		display: flex;
+		flex-wrap: nowrap;
+		align-items: center;
+		gap: 5px;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* ── Inline pills ── */
+	.rule-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 6px 2px 8px;
+		border-radius: 4px;
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
+		font-size: 11.5px;
+		color: var(--text-secondary);
+		line-height: 1.2;
+		max-width: 200px;
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition: background 0.1s, border-color 0.1s;
+	}
+	.rule-pill:hover {
+		background: color-mix(in srgb, var(--accent) 14%, transparent);
+		border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+	}
+	.pill-text {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.pill-remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 13px;
+		height: 13px;
+		padding: 0;
+		border: none;
+		border-radius: 50%;
+		background: transparent;
+		color: var(--text-faint);
+		cursor: pointer;
+		flex-shrink: 0;
+		opacity: 0;
+		transition: opacity 0.1s, color 0.1s, background 0.1s;
+	}
+	.rule-pill:hover .pill-remove { opacity: 1; }
+	.pill-remove:hover {
+		color: white;
+		background: color-mix(in srgb, var(--diff-removed-color, #ef4444) 80%, transparent);
+	}
+
+	/* ── Overflow badge ── */
+	.overflow-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 7px;
+		border-radius: 4px;
+		border: none;
+		background: color-mix(in srgb, var(--text-faint) 12%, transparent);
+		color: var(--text-faint);
+		font: inherit;
+		font-size: 11px;
+		cursor: pointer;
+		flex-shrink: 0;
+		transition: background 0.1s, color 0.1s;
+	}
+	.overflow-badge:hover {
+		background: color-mix(in srgb, var(--text-faint) 20%, transparent);
+		color: var(--text-secondary);
+	}
+
+	/* ── Add button ── */
+	.add-rule-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		padding: 2px 5px;
+		border-radius: 4px;
+		border: 1px dashed color-mix(in srgb, var(--text-faint) 35%, transparent);
+		background: transparent;
+		color: var(--text-faint);
+		font: inherit;
+		font-size: 11.5px;
+		cursor: pointer;
+		transition: all 0.12s;
+		line-height: 1.2;
+		flex-shrink: 0;
+	}
+	.add-rule-btn:hover, .add-rule-btn.active {
+		color: var(--accent);
+		border-color: var(--accent);
+		border-style: solid;
+		background: color-mix(in srgb, var(--accent) 6%, transparent);
+	}
+
+	/* ── Apply button (inline) ── */
+	.apply-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		padding: 0;
+		border-radius: 4px;
+		border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+		background: transparent;
+		color: var(--text-faint);
+		cursor: pointer;
+		flex-shrink: 0;
+		transition: all 0.12s;
+	}
+	.apply-btn:hover {
+		color: var(--accent);
+		border-color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 6%, transparent);
+	}
+
+	/* ── Popover ── */
+	.popover-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 200;
+	}
+	.rules-popover {
+		position: fixed;
+		top: 80px;
+		left: 16px;
+		width: 340px;
+		max-height: 400px;
+		display: flex;
+		flex-direction: column;
+		padding: 12px;
+		background: var(--bg-elevated, var(--bg));
+		border: 1px solid var(--border-light);
+		border-radius: 10px;
+		box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+		z-index: 201;
+		font-family: 'Inter', -apple-system, sans-serif;
+	}
+	.popover-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-bottom: 10px;
+		font-size: 11.5px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.popover-empty {
+		font-size: 12px;
+		color: var(--text-faint);
+		padding: 6px 0 10px;
+		line-height: 1.4;
+	}
+	.popover-rules-list {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		margin-bottom: 10px;
+		max-height: 220px;
+		overflow-y: auto;
+		scrollbar-width: thin;
+	}
+	.popover-rule-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 5px 8px;
+		border-radius: 5px;
+		background: var(--bg-surface);
+	}
+	.popover-rule-row:hover {
+		background: var(--bg-hover);
+	}
+	.popover-rule-text {
+		flex: 1;
+		font-size: 12.5px;
+		color: var(--text-secondary);
+		line-height: 1.4;
+		min-width: 0;
+		overflow-wrap: break-word;
+	}
+	.popover-rule-remove {
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		cursor: pointer;
+		padding: 2px;
+		border-radius: 3px;
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		opacity: 0;
+		transition: opacity 0.1s;
+	}
+	.popover-rule-row:hover .popover-rule-remove { opacity: 1; }
+	.popover-rule-remove:hover {
+		color: var(--diff-removed-color, #ef4444);
+		background: var(--bg-hover);
+	}
+	.popover-input-row {
+		display: flex;
+		gap: 6px;
+	}
+	.popover-input {
+		flex: 1;
+		min-width: 0;
+		font: inherit;
+		font-size: 12.5px;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		padding: 6px 10px;
+		outline: none;
+		color: var(--text);
+		background: var(--bg);
+		transition: border-color 0.15s, box-shadow 0.15s;
+	}
+	.popover-input:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 2px var(--accent-bg);
+	}
+	.popover-input::placeholder { color: var(--text-faint); }
+	.popover-add-btn {
+		padding: 6px 14px;
+		border: none;
+		border-radius: 6px;
+		background: var(--accent);
+		color: white;
+		font: inherit;
+		font-size: 12.5px;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: opacity 0.1s;
+	}
+	.popover-add-btn:disabled { opacity: 0.35; cursor: default; }
+	.popover-add-btn:hover:not(:disabled) { opacity: 0.85; }
+	.popover-apply-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		width: 100%;
+		margin-top: 8px;
+		padding: 7px 12px;
+		border: 1px solid var(--accent-light);
+		border-radius: 6px;
+		background: var(--accent-bg);
+		color: var(--accent);
+		font-size: 12px;
+		font-weight: 500;
+		cursor: pointer;
+		font-family: inherit;
+		transition: all 0.15s;
+	}
+	.popover-apply-btn:hover {
+		background: var(--accent);
+		color: white;
+		border-color: var(--accent);
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import ToastStack from '$lib/components/ToastStack.svelte';
 	import { pushToast, dismissToast, toastQueue, type ToastSpec } from '$lib/toasts';
 	import RulesPanel from '$lib/components/RulesPanel.svelte';
+	import RulesPillBar from '$lib/components/RulesPillBar.svelte';
 	import ReferencesPanel from '$lib/components/ReferencesPanel.svelte';
 	import PanelResizer from '$lib/components/PanelResizer.svelte';
 	import HorizontalPanelResizer from '$lib/components/HorizontalPanelResizer.svelte';
@@ -1938,7 +1939,6 @@
 					onClick: () => editorSoftWrap.update((v) => !v)
 				},
 				{ kind: 'panel', label: 'Writing references', panelKey: 'references' },
-				{ kind: 'panel', label: 'Writing rules', panelKey: 'rules' },
 				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' },
 				{ kind: 'divider' },
 				{
@@ -2430,6 +2430,10 @@
 		<ApiKeysPanel />
 	{/snippet}
 
+	<div class="toolbar">
+		<RulesPillBar onSubmit={(trigger) => void submit(trigger)} />
+	</div>
+
 	<div class="body">
 		{#if sidebarVisible}
 		<aside class="left-pane" style:width="{leftWidth}px">
@@ -2621,6 +2625,14 @@
 	/* Submit button, mascot, and settings popover styles moved to
 	 * src/lib/components/AgentDock.svelte. */
 
+	.toolbar {
+		display: flex;
+		align-items: center;
+		padding: 4px 16px;
+		border-bottom: 1px solid var(--border-light);
+		background: var(--header-bg);
+		flex-shrink: 0;
+	}
 	.body {
 		display: flex;
 		flex: 1;


### PR DESCRIPTION
## Summary
- Moves writing rules out of the toolbar menu into an inline pill bar above the editor, with a popover for managing rules and an "Apply rules" button that triggers the agent.
- Adds a nudge animation (scale bounce with 60s cooldown) to the collapsed agent dock button when a render starts, plus a continuous glow while the agent is awake.
- Fixes stale indentation in the toolbar menu items.

## Test plan
- [ ] Open the app, verify the rules pill bar appears above the editor
- [ ] Add a rule via the "+" button, confirm it persists and shows as a pill
- [ ] Add 4+ rules, confirm overflow badge appears
- [ ] Click "Apply rules" and verify the agent triggers
- [ ] While the dock is collapsed, trigger a render and confirm the button nudges
- [ ] Confirm the nudge doesn't repeat within 60s
- [ ] Verify the glow animation plays while the agent is awake