### PR TITLE
Render PDF tabs with inline PDF.js viewer

### DIFF
--- a/src/lib/components/PdfViewerPane.svelte
+++ b/src/lib/components/PdfViewerPane.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { themes, applyTheme } from '$lib/themes';
+	import { selectedTheme } from '$lib/stores';
+
+	interface Props {
+		path: string;
+	}
+	let { path }: Props = $props();
+
+	let iframeEl: HTMLIFrameElement | null = $state(null);
+	let cacheBuster = $state(Date.now());
+	let themeName = $state('light');
+
+	let sseSource: EventSource | null = null;
+	let saved: { scrollTop: number; scale: number; page: number } | null = null;
+	let broadcastChannel: BroadcastChannel | null = null;
+
+	function makePdfSrc(filePath: string, buster: number): string {
+		const fileUrl = `/api/preview?path=${encodeURIComponent(filePath)}&v=${buster}`;
+		return `/pdfjs/web/viewer.html?file=${encodeURIComponent(fileUrl)}`;
+	}
+
+	let src = $derived(makePdfSrc(path, cacheBuster));
+
+	function captureScroll() {
+		if (!iframeEl) return;
+		try {
+			const w = iframeEl.contentWindow as unknown as {
+				PDFViewerApplication?: {
+					page?: number;
+					pdfViewer?: {
+						currentScale?: number;
+						container?: HTMLElement;
+					};
+				};
+			};
+			const app = w?.PDFViewerApplication;
+			if (!app) return;
+			saved = {
+				page: app.page ?? 1,
+				scrollTop: app.pdfViewer?.container?.scrollTop ?? 0,
+				scale: app.pdfViewer?.currentScale ?? 1
+			};
+		} catch {
+			/* detached or not ready */
+		}
+	}
+
+	function restoreScroll() {
+		if (!iframeEl || !saved) return;
+		try {
+			const w = iframeEl.contentWindow as unknown as {
+				PDFViewerApplication?: {
+					page?: number;
+					pdfViewer?: {
+						currentScale?: number;
+						container?: HTMLElement;
+					};
+					eventBus?: { on: (e: string, cb: () => void) => void };
+				};
+			};
+			const data = saved;
+			const apply = () => {
+				const app = w?.PDFViewerApplication;
+				if (!app) return;
+				if (app.pdfViewer && typeof data.scale === 'number') {
+					app.pdfViewer.currentScale = data.scale;
+				}
+				if (typeof data.page === 'number') app.page = data.page;
+				setTimeout(() => {
+					if (app.pdfViewer?.container && typeof data.scrollTop === 'number') {
+						app.pdfViewer.container.scrollTop = data.scrollTop;
+					}
+				}, 50);
+			};
+			const start = Date.now();
+			const tick = () => {
+				if (w?.PDFViewerApplication?.eventBus) {
+					w.PDFViewerApplication.eventBus.on('pagesinit', apply);
+					return;
+				}
+				if (Date.now() - start < 3000) setTimeout(tick, 50);
+			};
+			tick();
+		} catch {
+			/* ignore */
+		}
+	}
+
+	function reload() {
+		captureScroll();
+		cacheBuster = Date.now();
+	}
+
+	function connectSse() {
+		if (sseSource) return;
+		try {
+			sseSource = new EventSource('/api/live');
+		} catch {
+			return;
+		}
+		sseSource.addEventListener('preview_ready', (ev) => {
+			try {
+				const data = JSON.parse((ev as MessageEvent).data);
+				if (typeof data?.path !== 'string') return;
+				if (data.path === path || data.path.endsWith('/' + path)) reload();
+			} catch {
+				/* ignore */
+			}
+		});
+		sseSource.onerror = () => {
+			sseSource?.close();
+			sseSource = null;
+			setTimeout(connectSse, 3000);
+		};
+	}
+
+	function applyDocwriterTheme(name: string) {
+		const theme = themes.find((t) => t.name === name) ?? themes[0];
+		if (!theme) return;
+		themeName = theme.name;
+		injectThemeIntoIframe();
+	}
+
+	function injectThemeIntoIframe() {
+		if (!iframeEl) return;
+		const doc = iframeEl.contentDocument;
+		if (!doc?.documentElement) return;
+		const theme = themes.find((t) => t.name === themeName) ?? themes[0];
+		if (!theme) return;
+		doc.documentElement.setAttribute('data-docwriter-theme', theme.name);
+		for (const [k, v] of Object.entries(theme.vars)) {
+			doc.documentElement.style.setProperty(k, v);
+		}
+	}
+
+	function relaySynctexJump(file: string, line: number) {
+		window.postMessage(
+			{ kind: 'docwriter-synctex-jump', file, line },
+			window.location.origin
+		);
+	}
+
+	function attachSynctexHandler() {
+		if (!iframeEl) return;
+		const doc = iframeEl.contentDocument;
+		if (!doc) return;
+		const w = iframeEl.contentWindow as unknown as {
+			PDFViewerApplication?: { pdfViewer?: { currentScale?: number } };
+		};
+		const handler = async (ev: MouseEvent) => {
+			const target = ev.target as HTMLElement | null;
+			const pageEl = target?.closest('.page[data-page-number]') as HTMLElement | null;
+			if (!pageEl) return;
+			const pageNum = parseInt(pageEl.dataset.pageNumber ?? '0', 10);
+			if (!pageNum) return;
+			const rect = pageEl.getBoundingClientRect();
+			const scale = w?.PDFViewerApplication?.pdfViewer?.currentScale ?? 1;
+			const cssPerPt = scale * (96 / 72);
+			const x = (ev.clientX - rect.left) / cssPerPt;
+			const y = (ev.clientY - rect.top) / cssPerPt;
+			try {
+				const res = await fetch('/api/synctex', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ pdf: path, page: pageNum, x, y })
+				});
+				const data = await res.json();
+				if (data?.ok && typeof data.file === 'string' && typeof data.line === 'number') {
+					relaySynctexJump(data.file, data.line);
+				}
+			} catch {
+				/* synctex unavailable */
+			}
+		};
+		const listener = handler as unknown as EventListener;
+		doc.removeEventListener('dblclick', listener, true);
+		doc.addEventListener('dblclick', listener, true);
+	}
+
+	function scrollPdfTo(page: number, x: number, y: number) {
+		if (!iframeEl) return;
+		const w = iframeEl.contentWindow as unknown as {
+			PDFViewerApplication?: {
+				pdfViewer?: {
+					scrollPageIntoView: (opts: {
+						pageNumber: number;
+						destArray?: unknown[];
+					}) => void;
+				};
+			};
+		};
+		const app = w?.PDFViewerApplication;
+		if (!app?.pdfViewer) return;
+		try {
+			app.pdfViewer.scrollPageIntoView({
+				pageNumber: page,
+				destArray: ['XYZ', x, y, null]
+			});
+		} catch {
+			/* PDF not ready */
+		}
+	}
+
+	function connectBroadcastChannel() {
+		if (broadcastChannel) return;
+		try {
+			broadcastChannel = new BroadcastChannel('docwriter-preview');
+		} catch {
+			return;
+		}
+		broadcastChannel.onmessage = (ev: MessageEvent) => {
+			const data = ev.data as
+				| { kind?: string; page?: number; x?: number; y?: number; v?: number }
+				| null;
+			if (!data || data.kind !== 'pdf-jump') return;
+			scrollPdfTo(data.page ?? 1, data.x ?? 0, data.v ?? data.y ?? 0);
+		};
+	}
+
+	function onIframeLoad() {
+		restoreScroll();
+		injectThemeIntoIframe();
+		attachSynctexHandler();
+	}
+
+	onMount(() => {
+		connectSse();
+		connectBroadcastChannel();
+	});
+
+	onDestroy(() => {
+		sseSource?.close();
+		sseSource = null;
+		broadcastChannel?.close();
+		broadcastChannel = null;
+	});
+
+	$effect(() => {
+		void path;
+		cacheBuster = Date.now();
+		saved = null;
+	});
+
+	$effect(() => {
+		const unsub = selectedTheme.subscribe((name) => applyDocwriterTheme(name));
+		return unsub;
+	});
+</script>
+
+<div class="pdf-viewer-pane">
+	<iframe bind:this={iframeEl} {src} title={path} onload={onIframeLoad}></iframe>
+</div>
+
+<style>
+	.pdf-viewer-pane {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		background: var(--bg-surface, #1a1a1a);
+	}
+	iframe {
+		flex: 1;
+		border: none;
+		background: var(--bg, #fff);
+	}
+</style>

--- a/src/lib/components/PreviewButton.svelte
+++ b/src/lib/components/PreviewButton.svelte
@@ -5,12 +5,11 @@
 
 	/**
 	 * Top-right floating preview button. On click, opens /preview in a
-	 * popup window pointed at whatever output file the matching hook
-	 * produces for the active tab.
+	 * popup window pointed at the companion PDF for a `.tex` tab (same stem,
+	 * e.g. `main.tex` → `main.pdf`) or at a hook's configured output.
 	 *
-	 * Resolves the output via /api/hooks/preview-match. If no hook with
-	 * an `output` template matches the active tab, the button is hidden
-	 * — no point showing an inert control.
+	 * Resolves the output via /api/hooks/preview-match. If no companion
+	 * PDF or hook output matches, the button is hidden.
 	 */
 	interface Props {
 		activeTabPath: string | null;

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -684,10 +684,9 @@
 	 * `$state` so the `.feedback-active` class on the wrapper reacts. */
 	let feedbackSelectionRange: { from: number; to: number } | null = $state(null);
 
-	// Cached preview-hook output path for the active tab. Used to gate
-	// the "Show in PDF" button in the feedback popover — only useful
-	// when there's a build hook producing a PDF (or other previewable
-	// file) for the current tab. Refreshed on every active-tab change.
+	// Cached preview output for the active tab: companion PDF for `.tex`
+	// (same stem) or a hook's configured output. Gates the "Locate in PDF"
+	// button in the feedback popover.
 	let previewOutputPath = $state<string | null>(null);
 	$effect(() => {
 		tabId;

--- a/src/lib/server/preview-match.ts
+++ b/src/lib/server/preview-match.ts
@@ -1,0 +1,32 @@
+import { existsSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import { readHooks, resolveCommand } from './hooks-config';
+import { WORKSPACE_ROOT } from './document-files';
+
+/** If `file` is a `.tex` tab and a same-stem `.pdf` exists beside it
+ * (e.g. `main.tex` → `main.pdf`), return the absolute PDF path. */
+export function findCompanionPdfForTex(file: string): string | null {
+	const dot = file.lastIndexOf('.');
+	const slash = Math.max(file.lastIndexOf('/'), file.lastIndexOf('\\'));
+	if (dot <= slash) return null;
+	const ext = file.slice(dot + 1).toLowerCase();
+	if (ext !== 'tex') return null;
+	const pdfRel = `${file.slice(0, dot)}.pdf`;
+	const abs = resolvePath(WORKSPACE_ROOT, pdfRel);
+	return existsSync(abs) ? abs : null;
+}
+
+/** Resolve the preview output for an active tab: companion PDF for `.tex`
+ * files first, then the first enabled hook with an `output` template. */
+export function resolvePreviewOutputPath(file: string): string | null {
+	const companionPdf = findCompanionPdfForTex(file);
+	if (companionPdf) return companionPdf;
+
+	const hooks = readHooks().hooks.filter((h) => h.enabled !== false && h.output);
+	for (const hook of hooks) {
+		const resolved = resolveCommand(hook.output ?? '', { file, tool: '' });
+		if (!resolved) continue;
+		return resolvePath(WORKSPACE_ROOT, resolved);
+	}
+	return null;
+}

--- a/src/lib/shared/file-kinds.ts
+++ b/src/lib/shared/file-kinds.ts
@@ -1,0 +1,12 @@
+/** Client-safe file-kind helpers. */
+
+export function extensionOf(path: string): string | null {
+	const base = path.split('/').pop() || '';
+	const idx = base.lastIndexOf('.');
+	if (idx <= 0) return null;
+	return base.slice(idx + 1).toLowerCase();
+}
+
+export function isPdfPath(path: string): boolean {
+	return extensionOf(path) === 'pdf';
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,8 @@
 	import FileTree from '$lib/components/FileTree.svelte';
 	import type { FileEntry } from '$lib/components/FileTree.svelte';
 	import TiptapEditor from '$lib/editor/TiptapEditor.svelte';
+	import PdfViewerPane from '$lib/components/PdfViewerPane.svelte';
+	import { isPdfPath } from '$lib/shared/file-kinds';
 	import AgentDockShell from '$lib/components/AgentDockShell.svelte';
 	import ToastStack from '$lib/components/ToastStack.svelte';
 	import { pushToast, dismissToast, toastQueue, type ToastSpec } from '$lib/toasts';
@@ -289,6 +291,7 @@
 	function refreshPendingReviewTabs(tabIds: string[]) {
 		const pending = new Map<string, number>();
 		for (const id of tabIds) {
+			if (isPdfPath(id)) continue;
 			const raw = getReviewArrayForTab(id).toArray();
 			if (raw.length === 0) continue;
 			// Count only actionable rounds. A stale round (its old_string no
@@ -314,12 +317,12 @@
 			let active: string | null = data.active ?? null;
 			tabs.set(tabIds);
 			activeTab.set(active);
-			if (active) getYDocForTab(active);
+			if (active && !isPdfPath(active)) getYDocForTab(active);
 			refreshPendingReviewTabs(tabIds);
 			// Attach background observers for every non-active tab so their
 			// round/comment changes keep the all-tab pane current.
 			for (const id of tabIds) {
-				if (id !== active) attachBgTabObserver(id);
+				if (id !== active && !isPdfPath(id)) attachBgTabObserver(id);
 			}
 			syncAllTabsState();
 			return active;
@@ -331,6 +334,12 @@
 
 	/** Load a single tab's meta and hydrate review state from its Y.Doc. */
 	async function loadTab(tabId: string) {
+		if (isPdfPath(tabId)) {
+			detachActiveReviewObservers(
+				activeReviewObserver?.tabId ?? activeReviewTextObserver?.tabId ?? tabId
+			);
+			return;
+		}
 		try {
 			getYDocForTab(tabId);
 			const res = await fetch(`/api/document?tab=${encodeURIComponent(tabId)}`);
@@ -381,6 +390,7 @@
 		const roundsAgg: Array<{ tabId: string; rounds: MaterializedPendingReviewRound[] }> = [];
 		const commentsAgg: Array<{ tabId: string; threads: CommentThread[] }> = [];
 		for (const id of tabIds) {
+			if (isPdfPath(id)) continue;
 			const rawRounds = getReviewArrayForTab(id).toArray();
 			if (rawRounds.length > 0) {
 				roundsAgg.push({ tabId: id, rounds: materializedRoundsForTab(id, rawRounds) });
@@ -506,7 +516,7 @@
 		expandedReviewRoundId.set(null);
 		// Move the old active tab to a bg observer and drop the bg observer
 		// for the new active tab (the active observer takes over after loadTab).
-		if (current) attachBgTabObserver(current);
+		if (current && !isPdfPath(current)) attachBgTabObserver(current);
 		detachBgTabObserver(tabId);
 		// New tab gets its own scroll position (top); don't carry the
 		// previous tab's pendingScrollRestore over.
@@ -664,8 +674,10 @@
 	/** Path of the currently active tab — same as its id. Used by the
 	 * FileTree to highlight the active file. */
 	let activeTabFilePath = $state<string | null>(null);
+	let activeTabIsPdf = $state(false);
 	$effect(() => {
 		activeTabFilePath = currentActiveTabId;
+		activeTabIsPdf = activeTabFilePath ? isPdfPath(activeTabFilePath) : false;
 	});
 
 	/** Open a file from the FileTree. Any text file becomes an agent-
@@ -2483,26 +2495,30 @@
 					onDismissPlan={(id) => dismissPlanProposal(id)}
 					onRejectPlan={(id, feedback) => rejectPlanProposal(id, feedback)}
 				/>
-				<TiptapEditor
-					tabId={activeTabFilePath}
-					bind:this={editorRef}
-					onSubmit={(trigger) => submit(trigger)}
-					initialScrollTop={pendingScrollRestore}
-					onAcceptInlineEdit={(roundId) => {
-						const rounds = currentRounds();
-						if (rounds.length === 0 || !roundId) return;
-						void acceptAgentEdit(roundId);
-					}}
-					onRejectInlineEdit={(roundId) => {
-						const rounds = currentRounds();
-						if (rounds.length === 0 || !roundId) return;
-						void rejectAgentEdit(roundId);
-					}}
-					onAcceptFeedbackEdits={(roundIds) => {
-						if (roundIds.length > 0) void acceptAgentEdit(roundIds);
-					}}
-					onResolveThread={(threadId, resolved) => void resolveThread(threadId, resolved)}
-				/>
+				{#if activeTabIsPdf}
+					<PdfViewerPane path={activeTabFilePath} />
+				{:else}
+					<TiptapEditor
+						tabId={activeTabFilePath}
+						bind:this={editorRef}
+						onSubmit={(trigger) => submit(trigger)}
+						initialScrollTop={pendingScrollRestore}
+						onAcceptInlineEdit={(roundId) => {
+							const rounds = currentRounds();
+							if (rounds.length === 0 || !roundId) return;
+							void acceptAgentEdit(roundId);
+						}}
+						onRejectInlineEdit={(roundId) => {
+							const rounds = currentRounds();
+							if (rounds.length === 0 || !roundId) return;
+							void rejectAgentEdit(roundId);
+						}}
+						onAcceptFeedbackEdits={(roundIds) => {
+							if (roundIds.length > 0) void acceptAgentEdit(roundIds);
+						}}
+						onResolveThread={(threadId, resolved) => void resolveThread(threadId, resolved)}
+					/>
+				{/if}
 				{/key}
 			{:else if docLoaded}
 				<div class="empty-editor-state">
@@ -2519,7 +2535,7 @@
 {#if docLoaded}
 	<AgentDockShell
 		onNewSession={newSession}
-		onWakeUp={docLoaded && activeTabFilePath ? () => submit() : undefined}
+		onWakeUp={docLoaded && activeTabFilePath && !activeTabIsPdf ? () => submit() : undefined}
 		onCancel={cancelRender}
 		onToggleMuted={toggleMuted}
 	>

--- a/src/routes/api/hooks/preview-match/+server.ts
+++ b/src/routes/api/hooks/preview-match/+server.ts
@@ -1,30 +1,19 @@
 /**
  * GET /api/hooks/preview-match?file=...
  *
- * Given an active tab path, return the output file path of the first
- * enabled hook whose `output` template (with `{{file}}` substituted)
- * resolves to a sensible path. Used by the editor's preview button to
- * decide what to show when the user clicks it.
+ * Given an active tab path, return the preview output to open:
+ *   1. A same-stem `.pdf` beside a `.tex` file (e.g. `main.tex` →
+ *      `main.pdf`) when that PDF exists on disk — no hook required.
+ *   2. Otherwise the first enabled hook whose `output` template resolves
+ *      (pandoc HTML, etc.).
  *
- * Returns `{ outputPath: string | null }`. Null means "no matching
- * preview hook configured" — the button stays disabled.
+ * Returns `{ outputPath: string | null }`. Null hides the Preview button.
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { resolve as resolvePath } from 'node:path';
-import { readHooks, resolveCommand } from '$lib/server/hooks-config';
-import { WORKSPACE_ROOT } from '$lib/server/document-files';
+import { resolvePreviewOutputPath } from '$lib/server/preview-match';
 
 export const GET: RequestHandler = async ({ url }) => {
 	const file = url.searchParams.get('file') ?? '';
-	const hooks = readHooks().hooks.filter((h) => h.enabled !== false && h.output);
-	for (const hook of hooks) {
-		// Substitute {{file}} into output; if the result is non-empty,
-		// resolve against the workspace root and return.
-		const resolved = resolveCommand(hook.output ?? '', { file, tool: '' });
-		if (!resolved) continue;
-		const abs = resolvePath(WORKSPACE_ROOT, resolved);
-		return json({ outputPath: abs });
-	}
-	return json({ outputPath: null });
+	return json({ outputPath: resolvePreviewOutputPath(file) });
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening a `.pdf` file from the file tree (e.g. `main.pdf` after a LaTeX build) now shows a rendered PDF in the editor tab instead of the raw `%PDF-1.5` binary as plain text.

The **Preview** button on a `.tex` tab now appears automatically when a same-stem `.pdf` exists on disk (e.g. `main.tex` + `main.pdf`) — no enabled build hook required. Clicking it still opens the PDF in a popup that auto-reloads on rebuild.

## Changes

- **`PdfViewerPane`** — new inline viewer component that loads PDFs through the existing `/api/preview` endpoint and bundled PDF.js viewer
- **Tab routing in `+page.svelte`** — PDF tabs render `PdfViewerPane`; text tabs continue to use `TiptapEditor`
- **Y.Doc bypass** — PDF tabs skip Yjs hydration and review observers (they are read-only viewer tabs)
- **Companion PDF detection** — `preview-match` resolves `foo.tex` → `foo.pdf` when the PDF file exists, without hook configuration
- **Existing integrations preserved:**
  - Auto-reload when a hook emits `preview_ready` (e.g. after `pdflatex`)
  - SyncTeX double-click in the PDF jumps to the source `.tex` tab
  - "Locate in PDF" from the editor uses the same `BroadcastChannel` as the popup preview

## How to verify

1. Open a LaTeX project with a built `main.pdf`
2. Click `main.pdf` in the file tree — confirm inline PDF rendering
3. Switch to `main.tex` — confirm **Preview** button appears (no hook needed)
4. Click Preview — popup opens and reloads after rebuild
5. Optional: double-click in the PDF to jump to source
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acbf567a-5936-4cad-a3da-720e3e20c187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acbf567a-5936-4cad-a3da-720e3e20c187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

