### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,23 @@ Node version (important gotcha):
 AI agent (for end-to-end testing of the headline feature):
 
 - The editor loads and edits without any key, but the agent loop
-  (Send → propose edit → review card) needs a provider credential.
-- `OPENAI_API_KEY` is available; select **Settings → Provider → OpenAI**.
+  (Send → propose edit → review card) needs a provider credential. Prompt
+  the agent via the **Send** button (top-right of the center pane); proposed
+  edits appear as tracked changes plus an **Accept/Reject/Retry** review card
+  in the right pane. Accept writes through to `document.md`.
+- **Claude** (default provider) needs `ANTHROPIC_API_KEY` (a secret). Two
+  non-obvious gotchas when present:
+  - The `@anthropic-ai/claude-agent-sdk` ships both a glibc and a musl native
+    binary and its resolver prefers the **musl** one, which cannot run on this
+    glibc VM (`ReferenceError: Claude Code native binary not found … -musl/claude`).
+    The update script deletes
+    `node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl` after install so
+    the glibc binary is selected; if you reinstall deps by hand, remove it again.
+  - **Claude Opus 4.8** currently errors with `thinking.type.enabled is not
+    supported for this model` against the bundled SDK version. Use
+    **Settings → Model → Claude Sonnet 4.6** (or Haiku 4.5) for agent runs.
+- **OpenAI**: `OPENAI_API_KEY` works via **Settings → Provider → OpenAI**.
   NON-OBVIOUS: the OpenAI provider defaults to the **Codex Mini**
   (`codex-mini`) model, which is unavailable and errors with
   `Error 400 The requested model 'codex-mini' does not exist`. Switch to
   **Settings → Model → GPT-5.5** (or another listed GPT-5.x) before sending.
-- The default provider is Claude, which needs `ANTHROPIC_API_KEY` or a
-  `claude login` session (neither is present by default here).
-- Prompt the agent via the **Send** button (top-right of the center pane);
-  proposed edits appear as tracked changes plus an **Accept/Reject/Retry**
-  review card in the right pane. Accept writes through to `document.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+DocWriter is an AI-assisted markdown writing editor (SvelteKit + Svelte 5 +
+Tiptap, server-owned Yjs CRDT, embedded SQLite). See `README.md` for the
+standard dev commands and `CLAUDE.md` / `ARCHITECTURE.md` for the system design.
+
+## Cursor Cloud specific instructions
+
+Services & ports (single Node process):
+
+- `npm run dev` starts Vite on **:5173** and auto-boots the Hocuspocus Y.Doc
+  WebSocket sync server on **:3001** in-process (from `src/hooks.server.ts`).
+  The browser only paints after the WS `synced` event, so a blank editor that
+  never fills in usually means the :3001 WS server didn't start.
+- `npm run dev` runs against the current working directory as the workspace
+  root, so the file tree shows the whole repo. To run against a clean target
+  folder instead, use `npm run dev:workspace -- [--no-open] [--host 0.0.0.0] /path/to/folder`.
+- No test framework is configured; `npm run check` (svelte-check) is the
+  validation command. `npm run build` is the production build.
+
+Node version (important gotcha):
+
+- `.npmrc` sets `engine-strict=true` and a dependency requires Node
+  **>=22.19.0**; the repo pins **22.22.2** via `.nvmrc`. The system
+  `/exec-daemon/node` is older (22.14.0) and sits ahead of nvm on `PATH`, so a
+  raw `node`/`npm install` can fail with `EBADENGINE`. The update script and a
+  one-time `~/.bashrc` pin already force nvm's 22.22.2 for new shells; if a
+  shell still shows `node v22.14.0`, run `nvm use` (reads `.nvmrc`) first.
+
+AI agent (for end-to-end testing of the headline feature):
+
+- The editor loads and edits without any key, but the agent loop
+  (Send → propose edit → review card) needs a provider credential.
+- `OPENAI_API_KEY` is available; select **Settings → Provider → OpenAI**.
+  NON-OBVIOUS: the OpenAI provider defaults to the **Codex Mini**
+  (`codex-mini`) model, which is unavailable and errors with
+  `Error 400 The requested model 'codex-mini' does not exist`. Switch to
+  **Settings → Model → GPT-5.5** (or another listed GPT-5.x) before sending.
+- The default provider is Claude, which needs `ANTHROPIC_API_KEY` or a
+  `claude login` session (neither is present by default here).
+- Prompt the agent via the **Send** button (top-right of the center pane);
+  proposed edits appear as tracked changes plus an **Accept/Reject/Retry**
+  review card in the right pane. Accept writes through to `document.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the DocWriter development environment for Cursor Cloud agents and verifies it end-to-end with both AI providers. Adds `AGENTS.md` with durable, non-obvious startup/run caveats and registers a minimal dependency-refresh update script.

No application code was modified.

## What was set up

- **Node**: repo enforces `engine-strict=true` and needs Node ≥22.19.0 (pinned `22.22.2` via `.nvmrc`). The system `/exec-daemon/node` (22.14.0) shadows nvm, so a one-time `~/.bashrc` pin + the update script force nvm's 22.22.2.
- **Dependencies**: `npm install` (575 packages).
- **Claude SDK binary fix**: `@anthropic-ai/claude-agent-sdk` resolves its bundled **musl** native binary first, which can't run on this glibc VM. The update script removes `node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl` after install so the working glibc binary is selected.
- **Run**: single Node process — Vite UI on `:5173` + in-process Hocuspocus Y.Doc WebSocket sync on `:3001`.

## Verification

| Step | Command | Result |
|------|---------|--------|
| Type-check | `npm run check` | 0 errors, 2 warnings |
| Build | `npm run build` | success |
| Dev server | `npm run dev:workspace -- /tmp/docwriter-demo` | HTTP 200 on :5173, WS on :3001 |
| Hello-world (OpenAI) | agent (GPT-5.5) proposes + accepts an edit | written to `document.md` |
| Hello-world (Claude) | agent (Sonnet 4.6) proposes + accepts an edit | written to `document.md` |

The hello-world exercised the headline feature: typed a request in the agent Send box → agent called `read_doc`/`edit_doc` → proposed a tracked-change edit → Accept persisted it to `document.md`.

### Claude provider (Anthropic key now added)
[docwriter_claude_provider_edit_accepted.mp4](https://cursor.com/agents/bc-9a770200-8305-4c85-bcf5-bb9952f6283e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocwriter_claude_provider_edit_accepted.mp4)

[Claude agent proposed edit as tracked changes](https://cursor.com/agents/bc-9a770200-8305-4c85-bcf5-bb9952f6283e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaude_proposed_edit.webp)
[Claude edit accepted and merged into the document](https://cursor.com/agents/bc-9a770200-8305-4c85-bcf5-bb9952f6283e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaude_edit_accepted_final.webp)

### OpenAI provider
[docwriter_agent_edit_accepted_demo.mp4](https://cursor.com/agents/bc-9a770200-8305-4c85-bcf5-bb9952f6283e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocwriter_agent_edit_accepted_demo.mp4)

## Update script

```
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
nvm install
npm install
rm -rf node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a770200-8305-4c85-bcf5-bb9952f6283e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a770200-8305-4c85-bcf5-bb9952f6283e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

