### PR TITLE
fix: ensure strikeout decorations clear after accepting edits

### DIFF
--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -832,17 +832,14 @@
 		queueMicrotask(() => {
 			diffUpdateQueued = false;
 			if (!editor) return;
-			// Defensive consistency check: if no rounds, ensure baseline is null
-			// and vice versa. This guards against timing issues where one store
-			// updates before the other (e.g. fragment observer sets baseline to
-			// null before the array observer clears rounds, or vice versa).
+			// Guard against timing issues where one store updates before the
+			// other (e.g. fragment observer clears rounds before array observer
+			// sets baseline to null). Use hasRounds as source of truth.
 			const hasRounds = currentRoundsList.length > 0;
-			const effectiveBaseline = hasRounds ? currentBaseline : null;
-			const effectiveProposal = hasRounds ? currentProposalText : null;
 			// Muted mode: hide the overlay entirely until the user clicks a
 			// pending card, then show only that round's decorations.
-			let baselineForOverlay = effectiveBaseline;
-			let proposalForOverlay = effectiveProposal;
+			let baselineForOverlay = hasRounds ? currentBaseline : null;
+			let proposalForOverlay = hasRounds ? currentProposalText : null;
 			let pendingRoundsForOverlay: MaterializedPendingReviewRound[] = [];
 			if (isMuted && hasRounds) {
 				const expanded = expandedRoundId

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -832,12 +832,19 @@
 		queueMicrotask(() => {
 			diffUpdateQueued = false;
 			if (!editor) return;
+			// Defensive consistency check: if no rounds, ensure baseline is null
+			// and vice versa. This guards against timing issues where one store
+			// updates before the other (e.g. fragment observer sets baseline to
+			// null before the array observer clears rounds, or vice versa).
+			const hasRounds = currentRoundsList.length > 0;
+			const effectiveBaseline = hasRounds ? currentBaseline : null;
+			const effectiveProposal = hasRounds ? currentProposalText : null;
 			// Muted mode: hide the overlay entirely until the user clicks a
 			// pending card, then show only that round's decorations.
-			let baselineForOverlay = currentBaseline;
-			let proposalForOverlay = currentProposalText;
+			let baselineForOverlay = effectiveBaseline;
+			let proposalForOverlay = effectiveProposal;
 			let pendingRoundsForOverlay: MaterializedPendingReviewRound[] = [];
-			if (isMuted && currentRoundsList.length > 0) {
+			if (isMuted && hasRounds) {
 				const expanded = expandedRoundId
 					? currentRoundsList.find((r) => r.id === expandedRoundId)
 					: null;
@@ -849,7 +856,7 @@
 					baselineForOverlay = null;
 					proposalForOverlay = null;
 				}
-			} else if (currentRoundsList.length > 0) {
+			} else if (hasRounds) {
 				pendingRoundsForOverlay = currentRoundsList;
 			}
 			setDiffState(editor, {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -462,14 +462,10 @@
 		const textHandler = () => {
 			if (tabId !== getCurrentActiveTab()) return;
 			const rounds = arr.toArray();
-			if (rounds.length === 0) {
-				// Clear both stores to ensure consistency. This guards against
-				// timing issues where the fragment observer fires but the array
-				// observer hasn't yet, leaving pendingReviewRounds stale.
-				pendingReviewRounds.set([]);
-				reviewBaseline.set(null);
-				return;
-			}
+			// Use syncActiveReviewState for both paths to ensure consistent
+			// store updates (including pendingReviewTabs). This guards against
+			// timing issues where the fragment observer fires but the array
+			// observer hasn't yet, leaving pendingReviewRounds stale.
 			syncActiveReviewState(tabId, rounds);
 		};
 		fragment.observe(textHandler);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -463,6 +463,10 @@
 			if (tabId !== getCurrentActiveTab()) return;
 			const rounds = arr.toArray();
 			if (rounds.length === 0) {
+				// Clear both stores to ensure consistency. This guards against
+				// timing issues where the fragment observer fires but the array
+				// observer hasn't yet, leaving pendingReviewRounds stale.
+				pendingReviewRounds.set([]);
 				reviewBaseline.set(null);
 				return;
 			}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where strikeout (diff-removed) decorations could persist after accepting agent edits, even though the text content was correct (PDF rendered normally).

## Problem

The issue was reported by Yiming: after accepting agent edits, the strikeout styling remained visible in the editor even though the underlying text was correct. The root cause was a potential timing issue between two Yjs observers:

1. **Fragment observer** - fires when document text changes
2. **Array observer** - fires when the review array changes

When accepting edits, both the fragment AND the review array are modified in one Yjs transaction. The fragment observer could see an empty rounds array before updating the stores, leading to a state desync.

## Solution

Two changes ensure consistency:

1. **Fragment observer uses `syncActiveReviewState` for all paths** - Instead of manually clearing stores in a special empty-rounds branch, always use the existing helper. This ensures consistent store updates including `pendingReviewTabs`.

2. **`updateDiff()` uses `hasRounds` as source of truth** - If no rounds exist, baseline and proposal are forced to `null` regardless of their current values.

## Changes

- `src/routes/+page.svelte`: Fragment observer now uses `syncActiveReviewState` for both empty and non-empty rounds
- `src/lib/editor/TiptapEditor.svelte`: `updateDiff()` guards baseline/proposal with `hasRounds` check

## Testing

- TypeScript check passes with 0 errors

## Skipped recommendations (out of scope)

Per code review, these are recommended but would require larger refactoring:
- Merging `reviewBaseline` + `pendingReviewRounds` into a single store/object to eliminate timing issues at the source
- Applying the same `hasRounds` guard to gutter props for full consistency
- Adding guards to avoid redundant store writes on every keystroke when no rounds exist
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-people-group.slack.com/archives/C0B3XN8TY90/p1781821369705869?thread_ts=1781821369.705869&cid=C0B3XN8TY90)

<div><a href="https://cursor.com/agents/bc-22df9946-f9b0-530a-bfe8-9bb42f6f4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22df9946-f9b0-530a-bfe8-9bb42f6f4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

