### PR TITLE
[codex] add writing UI controls and skills support

### DIFF
--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -23,6 +23,7 @@
 	import { cubicOut } from 'svelte/easing';
 	import type { CommentThread } from '$lib/types';
 	import { resolveThreadRange } from '$lib/editor/comment-overlay';
+	import { resolveRoundAnchorPos } from '$lib/editor/diff-overlay';
 	import { tooltip } from '$lib/actions/tooltip';
 	import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
 	import { summarizeRound } from '$lib/review-diff';
@@ -120,6 +121,14 @@
 		if (muted) return [];
 		return roundsByThread.get(threadId) ?? [];
 	}
+	function editCardId(roundId: string): string {
+		return `edit:${roundId}`;
+	}
+	let looseEditRounds = $derived(
+		muted
+			? []
+			: rounds.filter((r) => !r.feedbackThreadId || !openThreadIds.has(r.feedbackThreadId))
+	);
 	/** A thread the agent opened (first message is the agent's) — hidden in
 	 * mute mode. User-opened threads always show. */
 	function isAgentThread(thread: CommentThread): boolean {
@@ -282,19 +291,43 @@
 		for (const thread of threads) {
 			if (thread.resolved) continue;
 			if (muted && isAgentThread(thread)) continue;
-			const range = resolveThreadRange(editor, thread);
-			if (!range) continue;
+			const threadEdits = editsForThread(thread.id);
+			const editPos =
+				baseline && threadEdits.length > 0
+					? resolveRoundAnchorPos(editor, threadEdits[0], baseline)
+					: null;
+			const range = editPos == null ? resolveThreadRange(editor, thread) : null;
+			const anchorPos = editPos ?? range?.from ?? null;
+			if (anchorPos == null) continue;
 			try {
-				const coords = editor.view.coordsAtPos(range.from);
+				const coords = editor.view.coordsAtPos(anchorPos);
 				entries.push({
 					id: thread.id,
 					kind: 'comment',
 					top: coords.top - gutterRect.top,
 					expanded: thread.id === openThreadId,
-					editCount: editsForThread(thread.id).length
+					editCount: threadEdits.length
 				});
 			} catch {
 				// coordsAtPos throws if the view isn't mounted — skip.
+			}
+		}
+		if (!muted && baseline) {
+			for (const round of looseEditRounds) {
+				const pos = resolveRoundAnchorPos(editor, round, baseline);
+				if (pos == null) continue;
+				try {
+					const coords = editor.view.coordsAtPos(pos);
+					entries.push({
+						id: editCardId(round.id),
+						kind: 'edit',
+						top: coords.top - gutterRect.top,
+						expanded: false,
+						editCount: 0
+					});
+				} catch {
+					// View not mounted or anchor no longer addressable.
+				}
 			}
 		}
 		entries.sort((a, b) => a.top - b.top);
@@ -336,6 +369,7 @@
 		threads;
 		openThreadId;
 		rounds;
+		looseEditRounds;
 		baseline;
 		muted;
 		requestAnimationFrame(() => recomputePositions());
@@ -358,6 +392,15 @@
 			.sort(
 				(a, b) =>
 					(stackedPositions.get(a.id) ?? 0) - (stackedPositions.get(b.id) ?? 0)
+			)
+	);
+	let visibleLooseEditRounds = $derived(
+		looseEditRounds
+			.filter((r) => stackedPositions.has(editCardId(r.id)))
+			.sort(
+				(a, b) =>
+					(stackedPositions.get(editCardId(a.id)) ?? 0) -
+					(stackedPositions.get(editCardId(b.id)) ?? 0)
 			)
 	);
 
@@ -628,6 +671,41 @@
 					{/if}
 				</div>
 			{/if}
+		</div>
+	{/each}
+	{#each visibleLooseEditRounds as round (round.id)}
+		{@const top = stackedPositions.get(editCardId(round.id)) ?? 0}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="gutter-card loose-edit-card"
+			class:stale={round.stale}
+			data-card-id={editCardId(round.id)}
+			style:top="{top}px"
+			in:fly={cardIn()}
+			onmouseenter={() => onHoverEdit(round.id)}
+			onmouseleave={() => onHoverEdit(null)}
+		>
+			<div class="card-collapsed-row">
+				<span class="avatar avatar-agent">
+					<Sparkles size={12} strokeWidth={1.8} />
+				</span>
+				<div class="card-preview" title={summarizeRound(round)}>
+					{summarizeRound(round)}
+				</div>
+				<span class="edit-row-actions">
+					<button class="mini-btn reject" title="Reject this edit" onclick={() => onRejectRound(round.id)}>
+						<X size={12} />
+					</button>
+					<button
+						class="mini-btn accept"
+						title={round.stale ? 'Stale — can no longer apply' : 'Accept this edit'}
+						disabled={round.stale}
+						onclick={() => onAcceptRound(round.id)}
+					>
+						<Check size={12} />
+					</button>
+				</span>
+			</div>
 		</div>
 	{/each}
 </div>

--- a/src/lib/components/OutlinePane.svelte
+++ b/src/lib/components/OutlinePane.svelte
@@ -37,12 +37,13 @@
 		pendingReviewRounds,
 		allTabPendingRounds,
 		allTabCommentThreads,
+		openCommentThreadId,
 		seenCommentIds,
 		markCommentSeen,
 		agentSettings,
 		expandedReviewRoundId
 	} from '$lib/stores';
-	import { getYDocForTab } from '$lib/yjs-doc';
+	import { getCommentsMapForTab, getYDocForTab } from '$lib/yjs-doc';
 	import type { ProposedRule, ProposedHook, CommentThread } from '$lib/types';
 	import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
 	import {
@@ -226,10 +227,12 @@
 
 	async function handleCommentClick(tabId: string, thread: CommentThread) {
 		markCommentSeen(thread.id);
-		if (tabId !== activeTabId && onNavigateToComment) {
+		if (tabId !== activeTabId) {
+			if (!onNavigateToComment) return;
 			await onNavigateToComment(tabId, thread);
 			await tick();
 		}
+		openCommentThreadId.set(thread.id);
 	}
 
 	function diffPreview(round: MaterializedPendingReviewRound): ReviewPreviewLine[] {
@@ -267,6 +270,18 @@
 	function firstAgentMessage(thread: CommentThread): string {
 		return thread.messages.find((m) => m.author === 'agent')?.text ?? '';
 	}
+
+	function threadForRound(tabId: string, round: MaterializedPendingReviewRound): CommentThread | null {
+		const threadId = round.feedbackThreadId;
+		if (!threadId) return null;
+		return getCommentsMapForTab(tabId).get(threadId) ?? null;
+	}
+
+	async function openRoundThread(tabId: string, round: MaterializedPendingReviewRound) {
+		const thread = threadForRound(tabId, round);
+		if (!thread) return;
+		await handleCommentClick(tabId, thread);
+	}
 </script>
 
 <div class="outline-pane">
@@ -280,8 +295,12 @@
 					{#each toc as h}
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
-						<div class="toc-item" style:padding-left={`${(h.level - 1) * 12}px`} onclick={() => scrollToHeading(h.text)}>
-							<FileText size={11} />
+						<div
+							class="toc-item"
+							data-level={h.level}
+							style:padding-left={`${Math.max(0, h.level - 1) * 14}px`}
+							onclick={() => scrollToHeading(h.text)}
+						>
 							<span>{h.text}</span>
 						</div>
 					{/each}
@@ -359,6 +378,11 @@
 								<button class="btn-reject" onclick={() => onReject?.(round.id)}>
 									<X size={11} />Reject
 								</button>
+								{#if threadForRound(group.tabId, round)}
+									<button class="btn-secondary" onclick={() => void openRoundThread(group.tabId, round)}>
+										<MessageSquare size={11} />Thread
+									</button>
+								{/if}
 								<button class="btn-retry" onclick={() => openRetryFeedback(round.id)}>
 									<RotateCcw size={11} />Retry with feedback
 								</button>
@@ -502,17 +526,45 @@
 	}
 	.empty { color: var(--text-faint); font-size: 13px; padding: 4px 0; }
 	.toc-item {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		padding: 5px 8px;
-		border-radius: 4px;
+		position: relative;
+		display: block;
+		padding-top: 5px;
+		padding-right: 8px;
+		padding-bottom: 5px;
+		border-radius: 3px;
 		cursor: pointer;
 		color: var(--text-secondary);
 		font-size: 13px;
-		line-height: 1.4;
+		line-height: 1.35;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 	.toc-item:hover { background: var(--bg-hover); }
+	.toc-item:hover::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 7px;
+		bottom: 7px;
+		width: 2px;
+		border-radius: 2px;
+		background: var(--accent);
+	}
+	.toc-item[data-level='1'] {
+		font-weight: 500;
+		color: var(--text);
+	}
+	.toc-item[data-level='2'] {
+		font-weight: 450;
+		color: var(--text-secondary);
+	}
+	.toc-item[data-level='3'],
+	.toc-item[data-level='4'],
+	.toc-item[data-level='5'],
+	.toc-item[data-level='6'] {
+		font-size: 12.5px;
+		color: var(--text-muted);
+	}
 	.tab-group-label {
 		display: flex;
 		align-items: center;

--- a/src/lib/components/PanelResizer.svelte
+++ b/src/lib/components/PanelResizer.svelte
@@ -1,36 +1,93 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
+
 	let { onResize }: { onResize: (deltaX: number) => void } = $props();
 
 	let dragging = $state(false);
+	let resizerEl: HTMLDivElement | null = $state(null);
 	let startX = 0;
+	let activePointerId: number | null = null;
+	let previousBodyCursor = '';
+	let previousRootCursor = '';
+	let previousUserSelect = '';
 
-	function onMouseDown(e: MouseEvent) {
+	function onPointerMove(e: PointerEvent) {
+		if (!dragging) return;
+		e.preventDefault();
+		const delta = e.clientX - startX;
+		startX = e.clientX;
+		onResize(delta);
+	}
+
+	function finishDrag() {
+		if (!dragging) return;
+		dragging = false;
+		document.body.style.cursor = previousBodyCursor;
+		document.documentElement.style.cursor = previousRootCursor;
+		document.body.style.userSelect = previousUserSelect;
+
+		if (
+			activePointerId !== null &&
+			resizerEl?.hasPointerCapture?.(activePointerId)
+		) {
+			resizerEl.releasePointerCapture(activePointerId);
+		}
+		activePointerId = null;
+
+		window.removeEventListener('pointermove', onPointerMove);
+		window.removeEventListener('pointerup', finishDrag);
+		window.removeEventListener('pointercancel', finishDrag);
+		window.removeEventListener('blur', finishDrag);
+	}
+
+	function onPointerDown(e: PointerEvent) {
+		if (e.button !== 0) return;
+		e.preventDefault();
 		dragging = true;
 		startX = e.clientX;
+		activePointerId = e.pointerId;
+		previousBodyCursor = document.body.style.cursor;
+		previousRootCursor = document.documentElement.style.cursor;
+		previousUserSelect = document.body.style.userSelect;
 		document.body.style.cursor = 'col-resize';
+		document.documentElement.style.cursor = 'col-resize';
 		document.body.style.userSelect = 'none';
 
-		function onMouseMove(e: MouseEvent) {
-			const delta = e.clientX - startX;
-			startX = e.clientX;
-			onResize(delta);
+		try {
+			resizerEl?.setPointerCapture?.(e.pointerId);
+		} catch {
+			/* Pointer capture can fail for synthetic events; the drag shield still catches it. */
 		}
 
-		function onMouseUp() {
-			dragging = false;
-			document.body.style.cursor = '';
-			document.body.style.userSelect = '';
-			window.removeEventListener('mousemove', onMouseMove);
-			window.removeEventListener('mouseup', onMouseUp);
-		}
-
-		window.addEventListener('mousemove', onMouseMove);
-		window.addEventListener('mouseup', onMouseUp);
+		window.addEventListener('pointermove', onPointerMove, { passive: false });
+		window.addEventListener('pointerup', finishDrag);
+		window.addEventListener('pointercancel', finishDrag);
+		window.addEventListener('blur', finishDrag);
 	}
+
+	onDestroy(finishDrag);
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="resizer" class:active={dragging} onmousedown={onMouseDown}></div>
+<div
+	bind:this={resizerEl}
+	class="resizer"
+	class:active={dragging}
+	role="separator"
+	aria-orientation="vertical"
+	onpointerdown={onPointerDown}
+></div>
+{#if dragging}
+	<!-- Covers iframes during drag so pointerup cannot get swallowed by the embedded viewer. -->
+	<div
+		class="drag-shield"
+		role="presentation"
+		aria-hidden="true"
+		onpointermove={onPointerMove}
+		onpointerup={finishDrag}
+		onpointercancel={finishDrag}
+	></div>
+{/if}
 
 <style>
 	.resizer {
@@ -43,6 +100,8 @@
 		position: relative;
 		z-index: 10;
 		transition: background 0.15s;
+		touch-action: none;
+		user-select: none;
 	}
 	.resizer::after {
 		content: '';
@@ -57,5 +116,14 @@
 		background: var(--accent);
 		width: 3px;
 		left: 1px;
+	}
+	.drag-shield {
+		position: fixed;
+		inset: 0;
+		z-index: 2147483647;
+		cursor: col-resize;
+		background: transparent;
+		touch-action: none;
+		user-select: none;
 	}
 </style>

--- a/src/lib/components/PdfViewerPane.svelte
+++ b/src/lib/components/PdfViewerPane.svelte
@@ -1,256 +1,26 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
-	import { themes, applyTheme } from '$lib/themes';
+	import { onDestroy } from 'svelte';
 	import { selectedTheme } from '$lib/stores';
 
 	interface Props {
 		path: string;
+		closePdfSidebar?: boolean;
 	}
-	let { path }: Props = $props();
+	let { path, closePdfSidebar = true }: Props = $props();
 
-	let iframeEl: HTMLIFrameElement | null = $state(null);
-	let cacheBuster = $state(Date.now());
 	let themeName = $state('light');
-
-	let sseSource: EventSource | null = null;
-	let saved: { scrollTop: number; scale: number; page: number } | null = null;
-	let broadcastChannel: BroadcastChannel | null = null;
-
-	function makePdfSrc(filePath: string, buster: number): string {
-		const fileUrl = `/api/preview?path=${encodeURIComponent(filePath)}&v=${buster}`;
-		return `/pdfjs/web/viewer.html?file=${encodeURIComponent(fileUrl)}`;
-	}
-
-	let src = $derived(makePdfSrc(path, cacheBuster));
-
-	function captureScroll() {
-		if (!iframeEl) return;
-		try {
-			const w = iframeEl.contentWindow as unknown as {
-				PDFViewerApplication?: {
-					page?: number;
-					pdfViewer?: {
-						currentScale?: number;
-						container?: HTMLElement;
-					};
-				};
-			};
-			const app = w?.PDFViewerApplication;
-			if (!app) return;
-			saved = {
-				page: app.page ?? 1,
-				scrollTop: app.pdfViewer?.container?.scrollTop ?? 0,
-				scale: app.pdfViewer?.currentScale ?? 1
-			};
-		} catch {
-			/* detached or not ready */
-		}
-	}
-
-	function restoreScroll() {
-		if (!iframeEl || !saved) return;
-		try {
-			const w = iframeEl.contentWindow as unknown as {
-				PDFViewerApplication?: {
-					page?: number;
-					pdfViewer?: {
-						currentScale?: number;
-						container?: HTMLElement;
-					};
-					eventBus?: { on: (e: string, cb: () => void) => void };
-				};
-			};
-			const data = saved;
-			const apply = () => {
-				const app = w?.PDFViewerApplication;
-				if (!app) return;
-				if (app.pdfViewer && typeof data.scale === 'number') {
-					app.pdfViewer.currentScale = data.scale;
-				}
-				if (typeof data.page === 'number') app.page = data.page;
-				setTimeout(() => {
-					if (app.pdfViewer?.container && typeof data.scrollTop === 'number') {
-						app.pdfViewer.container.scrollTop = data.scrollTop;
-					}
-				}, 50);
-			};
-			const start = Date.now();
-			const tick = () => {
-				if (w?.PDFViewerApplication?.eventBus) {
-					w.PDFViewerApplication.eventBus.on('pagesinit', apply);
-					return;
-				}
-				if (Date.now() - start < 3000) setTimeout(tick, 50);
-			};
-			tick();
-		} catch {
-			/* ignore */
-		}
-	}
-
-	function reload() {
-		captureScroll();
-		cacheBuster = Date.now();
-	}
-
-	function connectSse() {
-		if (sseSource) return;
-		try {
-			sseSource = new EventSource('/api/live');
-		} catch {
-			return;
-		}
-		sseSource.addEventListener('preview_ready', (ev) => {
-			try {
-				const data = JSON.parse((ev as MessageEvent).data);
-				if (typeof data?.path !== 'string') return;
-				if (data.path === path || data.path.endsWith('/' + path)) reload();
-			} catch {
-				/* ignore */
-			}
-		});
-		sseSource.onerror = () => {
-			sseSource?.close();
-			sseSource = null;
-			setTimeout(connectSse, 3000);
-		};
-	}
-
-	function applyDocwriterTheme(name: string) {
-		const theme = themes.find((t) => t.name === name) ?? themes[0];
-		if (!theme) return;
-		themeName = theme.name;
-		injectThemeIntoIframe();
-	}
-
-	function injectThemeIntoIframe() {
-		if (!iframeEl) return;
-		const doc = iframeEl.contentDocument;
-		if (!doc?.documentElement) return;
-		const theme = themes.find((t) => t.name === themeName) ?? themes[0];
-		if (!theme) return;
-		doc.documentElement.setAttribute('data-docwriter-theme', theme.name);
-		for (const [k, v] of Object.entries(theme.vars)) {
-			doc.documentElement.style.setProperty(k, v);
-		}
-	}
-
-	function relaySynctexJump(file: string, line: number) {
-		window.postMessage(
-			{ kind: 'docwriter-synctex-jump', file, line },
-			window.location.origin
-		);
-	}
-
-	function attachSynctexHandler() {
-		if (!iframeEl) return;
-		const doc = iframeEl.contentDocument;
-		if (!doc) return;
-		const w = iframeEl.contentWindow as unknown as {
-			PDFViewerApplication?: { pdfViewer?: { currentScale?: number } };
-		};
-		const handler = async (ev: MouseEvent) => {
-			const target = ev.target as HTMLElement | null;
-			const pageEl = target?.closest('.page[data-page-number]') as HTMLElement | null;
-			if (!pageEl) return;
-			const pageNum = parseInt(pageEl.dataset.pageNumber ?? '0', 10);
-			if (!pageNum) return;
-			const rect = pageEl.getBoundingClientRect();
-			const scale = w?.PDFViewerApplication?.pdfViewer?.currentScale ?? 1;
-			const cssPerPt = scale * (96 / 72);
-			const x = (ev.clientX - rect.left) / cssPerPt;
-			const y = (ev.clientY - rect.top) / cssPerPt;
-			try {
-				const res = await fetch('/api/synctex', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ pdf: path, page: pageNum, x, y })
-				});
-				const data = await res.json();
-				if (data?.ok && typeof data.file === 'string' && typeof data.line === 'number') {
-					relaySynctexJump(data.file, data.line);
-				}
-			} catch {
-				/* synctex unavailable */
-			}
-		};
-		const listener = handler as unknown as EventListener;
-		doc.removeEventListener('dblclick', listener, true);
-		doc.addEventListener('dblclick', listener, true);
-	}
-
-	function scrollPdfTo(page: number, x: number, y: number) {
-		if (!iframeEl) return;
-		const w = iframeEl.contentWindow as unknown as {
-			PDFViewerApplication?: {
-				pdfViewer?: {
-					scrollPageIntoView: (opts: {
-						pageNumber: number;
-						destArray?: unknown[];
-					}) => void;
-				};
-			};
-		};
-		const app = w?.PDFViewerApplication;
-		if (!app?.pdfViewer) return;
-		try {
-			app.pdfViewer.scrollPageIntoView({
-				pageNumber: page,
-				destArray: ['XYZ', x, y, null]
-			});
-		} catch {
-			/* PDF not ready */
-		}
-	}
-
-	function connectBroadcastChannel() {
-		if (broadcastChannel) return;
-		try {
-			broadcastChannel = new BroadcastChannel('docwriter-preview');
-		} catch {
-			return;
-		}
-		broadcastChannel.onmessage = (ev: MessageEvent) => {
-			const data = ev.data as
-				| { kind?: string; page?: number; x?: number; y?: number; v?: number }
-				| null;
-			if (!data || data.kind !== 'pdf-jump') return;
-			scrollPdfTo(data.page ?? 1, data.x ?? 0, data.v ?? data.y ?? 0);
-		};
-	}
-
-	function onIframeLoad() {
-		restoreScroll();
-		injectThemeIntoIframe();
-		attachSynctexHandler();
-	}
-
-	onMount(() => {
-		connectSse();
-		connectBroadcastChannel();
+	const unsubscribeTheme = selectedTheme.subscribe((name) => {
+		themeName = name;
 	});
+	onDestroy(unsubscribeTheme);
 
-	onDestroy(() => {
-		sseSource?.close();
-		sseSource = null;
-		broadcastChannel?.close();
-		broadcastChannel = null;
-	});
-
-	$effect(() => {
-		void path;
-		cacheBuster = Date.now();
-		saved = null;
-	});
-
-	$effect(() => {
-		const unsub = selectedTheme.subscribe((name) => applyDocwriterTheme(name));
-		return unsub;
-	});
+	let src = $derived(
+		`/preview?path=${encodeURIComponent(path)}&theme=${encodeURIComponent(themeName)}&embedded=1${closePdfSidebar ? '&pdfSidebar=0' : ''}`
+	);
 </script>
 
 <div class="pdf-viewer-pane">
-	<iframe bind:this={iframeEl} {src} title={path} onload={onIframeLoad}></iframe>
+	<iframe {src} title={`Preview: ${path}`}></iframe>
 </div>
 
 <style>
@@ -258,7 +28,7 @@
 		flex: 1;
 		min-height: 0;
 		display: flex;
-		background: var(--bg-surface, #1a1a1a);
+		background: var(--bg, #fff);
 	}
 	iframe {
 		flex: 1;

--- a/src/lib/components/PreviewButton.svelte
+++ b/src/lib/components/PreviewButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Eye } from 'lucide-svelte';
+	import { Columns2, ExternalLink } from 'lucide-svelte';
 	import { selectedTheme } from '$lib/stores';
 
 	/**
@@ -13,8 +13,10 @@
 	 */
 	interface Props {
 		activeTabPath: string | null;
+		onOpenSplit?: (path: string) => void;
+		splitOpen?: boolean;
 	}
-	let { activeTabPath }: Props = $props();
+	let { activeTabPath, onOpenSplit, splitOpen = false }: Props = $props();
 
 	let outputPath = $state<string | null>(null);
 
@@ -38,7 +40,20 @@
 		}
 	}
 
-	onMount(refresh);
+	onMount(() => {
+		void refresh();
+		let es: EventSource | null = null;
+		try {
+			es = new EventSource('/api/live');
+			es.addEventListener('preview_ready', () => void refresh());
+			es.addEventListener('reload', () => void refresh());
+		} catch {
+			es = null;
+		}
+		return () => {
+			es?.close();
+		};
+	});
 
 	// Re-resolve whenever the active tab changes.
 	$effect(() => {
@@ -57,29 +72,51 @@
 </script>
 
 {#if outputPath}
-	<button class="preview-btn" onclick={openPreview} title={`Open preview: ${outputPath.split('/').pop()}`}>
-		<Eye size={12} />
-		<span>Preview</span>
-	</button>
+	<div class="preview-control" class:with-split={!!onOpenSplit}>
+		<button class="preview-btn" onclick={openPreview} title={`Open preview window: ${outputPath.split('/').pop()}`}>
+			<ExternalLink size={12} />
+			<span>Preview window</span>
+		</button>
+		{#if onOpenSplit}
+			<button
+				class="preview-btn icon-only"
+				class:active={splitOpen}
+				onclick={() => {
+					if (outputPath) onOpenSplit?.(outputPath);
+				}}
+				title={`Open side preview: ${outputPath.split('/').pop()}`}
+				aria-label="Open side preview"
+			>
+				<Columns2 size={13} />
+			</button>
+		{/if}
+	</div>
 {/if}
 
 <style>
 	/* Pinned top-right of the editor host, just to the left of where
 	 * the FindBar lives so they don't collide when find is open. The
 	 * FindBar wins the corner when both are visible. */
-	.preview-btn {
+	.preview-control {
 		position: absolute;
 		top: 12px;
 		right: 16px;
 		z-index: 11;
 		display: inline-flex;
 		align-items: center;
+		gap: 6px;
+	}
+	.preview-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 		gap: 5px;
 		height: 26px;
 		padding: 0 10px 0 8px;
 		font: inherit;
 		font-size: 12px;
 		font-weight: 500;
+		white-space: nowrap;
 		color: var(--text-faint);
 		background: var(--bg-elevated);
 		border: 1px solid var(--border-light);
@@ -92,5 +129,14 @@
 		color: var(--text);
 		background: var(--bg-hover);
 		border-color: var(--border);
+	}
+	.preview-btn.icon-only {
+		width: 28px;
+		padding: 0;
+	}
+	.preview-btn.active {
+		color: var(--accent);
+		background: var(--accent-bg);
+		border-color: var(--accent-light);
 	}
 </style>

--- a/src/lib/components/RulesPillBar.svelte
+++ b/src/lib/components/RulesPillBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { X, Plus, Play, ChevronDown, BookOpen } from 'lucide-svelte';
+	import { X, Plus, Play, BookOpen } from 'lucide-svelte';
 	import { rules, pushHistory } from '$lib/stores';
 	import type { Rule } from '$lib/types';
 
@@ -12,8 +12,12 @@
 	rules.subscribe((v) => (rulesList = v));
 
 	let popoverOpen = $state(false);
+	let popoverMode: 'manage' | 'edit' = $state('manage');
 	let newRule = $state('');
+	let editingRuleId: string | null = $state(null);
+	let draftRule = $state('');
 	let inputEl: HTMLInputElement | undefined = $state();
+	let editInputEl: HTMLTextAreaElement | undefined = $state();
 	let anchorEl: HTMLDivElement | undefined = $state();
 
 	const MAX_VISIBLE_PILLS = 3;
@@ -44,23 +48,76 @@
 		const rule = rulesList.find((r) => r.id === id);
 		const next = rulesList.filter((x) => x.id !== id);
 		void saveRules(next);
+		if (editingRuleId === id) closePopover();
 		if (rule) {
 			pushHistory({ type: 'user_action', timestamp: Date.now(), description: `Removed rule: "${rule.text}"` });
 		}
 	}
 
-	function togglePopover() {
-		popoverOpen = !popoverOpen;
-		if (popoverOpen) {
-			requestAnimationFrame(() => inputEl?.focus());
-		} else {
-			newRule = '';
+	function startEditingRule(id: string) {
+		const rule = rulesList.find((r) => r.id === id);
+		if (!rule) return;
+		popoverOpen = true;
+		popoverMode = 'edit';
+		editingRuleId = id;
+		draftRule = rule.text;
+		requestAnimationFrame(() => {
+			editInputEl?.focus();
+			editInputEl?.select();
+		});
+	}
+
+	function cancelEdit() {
+		editingRuleId = null;
+		draftRule = '';
+	}
+
+	function saveEditedRule(id: string) {
+		const text = draftRule.trim();
+		const rule = rulesList.find((r) => r.id === id);
+		if (!rule || !text) return;
+		if (text === rule.text) {
+			if (popoverMode === 'edit') closePopover();
+			else cancelEdit();
+			return;
 		}
+		const next = rulesList.map((r) => (r.id === id ? { ...r, text } : r));
+		void saveRules(next);
+		pushHistory({ type: 'user_action', timestamp: Date.now(), description: `Edited rule: "${rule.text}" to "${text}"` });
+		if (popoverMode === 'edit') closePopover();
+		else cancelEdit();
+	}
+
+	function openManagePopover() {
+		popoverOpen = true;
+		popoverMode = 'manage';
+		cancelEdit();
+		requestAnimationFrame(() => inputEl?.focus());
+	}
+
+	function toggleManagePopover() {
+		if (popoverOpen && popoverMode === 'manage') {
+			closePopover();
+			return;
+		}
+		openManagePopover();
 	}
 
 	function handleInputKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter') addRule();
-		if (e.key === 'Escape') { popoverOpen = false; newRule = ''; }
+		if (e.key === 'Escape') closePopover();
+	}
+
+	function handleEditKeydown(e: KeyboardEvent, id: string) {
+		if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			saveEditedRule(id);
+		}
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			if (popoverMode === 'edit') closePopover();
+			else cancelEdit();
+		}
 	}
 
 	function handlePopoverPointerdown(e: PointerEvent) {
@@ -68,8 +125,14 @@
 	}
 
 	function handleBackdropClick() {
+		closePopover();
+	}
+
+	function closePopover() {
 		popoverOpen = false;
+		popoverMode = 'manage';
 		newRule = '';
+		cancelEdit();
 	}
 
 	function applyRules() {
@@ -90,7 +153,15 @@
 	<!-- Inline pills for the first few rules -->
 	{#each visibleRules as rule (rule.id)}
 		<span class="rule-pill">
-			<span class="pill-text">{rule.text}</span>
+			<button
+				type="button"
+				class="pill-open"
+				onclick={() => startEditingRule(rule.id)}
+				title="Edit rule: {rule.text}"
+				aria-label="Edit rule: {rule.text}"
+			>
+				<span class="pill-text">{rule.text}</span>
+			</button>
 			<button
 				class="pill-remove"
 				onclick={() => removeRule(rule.id)}
@@ -104,7 +175,7 @@
 
 	<!-- Overflow badge -->
 	{#if overflowCount > 0}
-		<button class="overflow-badge" onclick={togglePopover} title="Show all rules">
+		<button class="overflow-badge" onclick={openManagePopover} title="Show all rules">
 			+{overflowCount} more
 		</button>
 	{/if}
@@ -112,8 +183,8 @@
 	<!-- Add / manage button -->
 	<button
 		class="add-rule-btn"
-		class:active={popoverOpen}
-		onclick={togglePopover}
+		class:active={popoverOpen && popoverMode === 'manage'}
+		onclick={toggleManagePopover}
 		title={rulesList.length > 0 ? 'Manage rules' : 'Add a writing rule'}
 	>
 		<Plus size={11} strokeWidth={2} />
@@ -139,14 +210,48 @@
 		<div class="rules-popover" onpointerdown={handlePopoverPointerdown} onclick={(e) => e.stopPropagation()}>
 			<div class="popover-header">
 				<BookOpen size={13} strokeWidth={1.8} />
-				<span>Writing rules</span>
+				<span>{popoverMode === 'edit' ? 'Edit rule' : 'Writing rules'}</span>
 			</div>
 
-			{#if rulesList.length > 0}
+			{#if popoverMode === 'edit'}
+				{@const editingRule = rulesList.find((rule) => rule.id === editingRuleId)}
+				{#if editingRule}
+					<div class="popover-rule-editor">
+						<textarea
+							bind:this={editInputEl}
+							class="popover-rule-edit-input"
+							bind:value={draftRule}
+							onkeydown={(e) => handleEditKeydown(e, editingRule.id)}
+							rows="4"
+							aria-label="Edit rule"
+						></textarea>
+						<div class="popover-rule-actions">
+							<button
+								type="button"
+								class="popover-rule-cancel"
+								onclick={closePopover}
+							>Cancel</button>
+							<button
+								type="button"
+								class="popover-rule-save"
+								onclick={() => saveEditedRule(editingRule.id)}
+								disabled={!draftRule.trim()}
+							>Save</button>
+						</div>
+					</div>
+				{/if}
+			{:else if rulesList.length > 0}
 				<div class="popover-rules-list">
 					{#each rulesList as rule (rule.id)}
 						<div class="popover-rule-row">
-							<span class="popover-rule-text">{rule.text}</span>
+							<button
+								type="button"
+								class="popover-rule-edit-body"
+								onclick={() => startEditingRule(rule.id)}
+								title="Edit rule"
+							>
+								<span class="popover-rule-text">{rule.text}</span>
+							</button>
 							<button
 								class="popover-rule-remove"
 								onclick={() => removeRule(rule.id)}
@@ -161,26 +266,28 @@
 				<div class="popover-empty">No rules yet. Rules tell the AI what constraints to follow.</div>
 			{/if}
 
-			<div class="popover-input-row">
-				<input
-					bind:this={inputEl}
-					class="popover-input"
-					bind:value={newRule}
-					onkeydown={handleInputKeydown}
-					placeholder="Add a rule, e.g. 'No passive voice'"
-				/>
-				<button
-					class="popover-add-btn"
-					onclick={addRule}
-					disabled={!newRule.trim()}
-				>Add</button>
-			</div>
+			{#if popoverMode === 'manage'}
+				<div class="popover-input-row">
+					<input
+						bind:this={inputEl}
+						class="popover-input"
+						bind:value={newRule}
+						onkeydown={handleInputKeydown}
+						placeholder="Add a rule, e.g. 'No passive voice'"
+					/>
+					<button
+						class="popover-add-btn"
+						onclick={addRule}
+						disabled={!newRule.trim()}
+					>Add</button>
+				</div>
 
-			{#if rulesList.length > 0}
-				<button class="popover-apply-btn" onclick={applyRules}>
-					<Play size={11} strokeWidth={2} />
-					Apply rules to document
-				</button>
+				{#if rulesList.length > 0}
+					<button class="popover-apply-btn" onclick={applyRules}>
+						<Play size={11} strokeWidth={2} />
+						Apply rules to document
+					</button>
+				{/if}
 			{/if}
 		</div>
 	</div>
@@ -201,7 +308,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
-		padding: 2px 6px 2px 8px;
+		padding: 0 4px 0 8px;
 		border-radius: 4px;
 		background: color-mix(in srgb, var(--accent) 8%, transparent);
 		border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
@@ -217,9 +324,22 @@
 		background: color-mix(in srgb, var(--accent) 14%, transparent);
 		border-color: color-mix(in srgb, var(--accent) 30%, transparent);
 	}
+	.pill-open {
+		display: inline-flex;
+		align-items: center;
+		min-width: 0;
+		padding: 2px 0;
+		border: none;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		line-height: inherit;
+		cursor: pointer;
+	}
 	.pill-text {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		min-width: 0;
 	}
 	.pill-remove {
 		display: inline-flex;
@@ -359,7 +479,7 @@
 	}
 	.popover-rule-row {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 8px;
 		padding: 5px 8px;
 		border-radius: 5px;
@@ -368,6 +488,16 @@
 	.popover-rule-row:hover {
 		background: var(--bg-hover);
 	}
+	.popover-rule-edit-body {
+		flex: 1;
+		min-width: 0;
+		padding: 0;
+		border: none;
+		background: transparent;
+		text-align: left;
+		font: inherit;
+		cursor: text;
+	}
 	.popover-rule-text {
 		flex: 1;
 		font-size: 12.5px;
@@ -375,6 +505,67 @@
 		line-height: 1.4;
 		min-width: 0;
 		overflow-wrap: break-word;
+	}
+	.popover-rule-editor {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+		width: 100%;
+		min-width: 0;
+	}
+	.popover-rule-edit-input {
+		width: 100%;
+		box-sizing: border-box;
+		resize: vertical;
+		min-height: 86px;
+		max-height: 180px;
+		font: inherit;
+		font-size: 12.5px;
+		line-height: 1.4;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		padding: 7px 9px;
+		outline: none;
+		color: var(--text);
+		background: var(--bg);
+	}
+	.popover-rule-edit-input:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 2px var(--accent-bg);
+	}
+	.popover-rule-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 6px;
+	}
+	.popover-rule-cancel,
+	.popover-rule-save {
+		padding: 5px 10px;
+		border-radius: 5px;
+		font: inherit;
+		font-size: 12px;
+		cursor: pointer;
+	}
+	.popover-rule-cancel {
+		border: 1px solid var(--border-light);
+		background: var(--bg);
+		color: var(--text-secondary);
+	}
+	.popover-rule-cancel:hover {
+		background: var(--bg-hover);
+	}
+	.popover-rule-save {
+		border: 1px solid var(--accent);
+		background: var(--accent);
+		color: white;
+		font-weight: 500;
+	}
+	.popover-rule-save:disabled {
+		opacity: 0.35;
+		cursor: default;
+	}
+	.popover-rule-save:hover:not(:disabled) {
+		opacity: 0.85;
 	}
 	.popover-rule-remove {
 		background: none;

--- a/src/lib/components/SessionViewer.svelte
+++ b/src/lib/components/SessionViewer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fade, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
-	import { X, Search, ChevronDown, ChevronRight, Activity } from 'lucide-svelte';
+	import { X, Search, ChevronDown, ChevronRight, Activity, Download } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { marked } from 'marked';
 
@@ -58,8 +58,34 @@
 		_resultError?: boolean;
 	}
 
+	type HistoryResponse = {
+		sessionId?: string | null;
+		raw?: unknown[];
+		messages?: unknown[];
+		systemPrompt?: string | null;
+		provider?: string | null;
+	};
+
+	type SaveFilePickerWindow = Window & {
+		showSaveFilePicker?: (options?: {
+			suggestedName?: string;
+			types?: Array<{
+				description: string;
+				accept: Record<string, string[]>;
+			}>;
+		}) => Promise<{
+			createWritable: () => Promise<{
+				write: (data: Blob) => Promise<void>;
+				close: () => Promise<void>;
+			}>;
+		}>;
+	};
+
 	let events = $state<SessionEvent[]>([]);
 	let sessionId = $state('');
+	let providerId = $state('claude');
+	let rawHistory = $state<unknown[]>([]);
+	let sdkMessages = $state<unknown[]>([]);
 	// Label for assistant rows / filter — reflects the provider that produced
 	// this session, not a hardcoded "Claude".
 	const PROVIDER_LABELS: Record<string, string> = {
@@ -74,6 +100,8 @@
 	let systemPromptOpen = $state(false);
 	let loading = $state(true);
 	let error = $state('');
+	let exportError = $state('');
+	let exporting = $state(false);
 	let searchQuery = $state('');
 	let filter = $state<'all' | 'user' | 'assistant' | 'tools' | 'thinking'>('all');
 	// Set of tool_use/thinking indices that are expanded
@@ -226,18 +254,125 @@
 		return `${(n / 1_000_000).toFixed(2)}M`;
 	}
 
+	function safeFilePart(value: string): string {
+		return (
+			value
+				.trim()
+				.replace(/[^a-zA-Z0-9._-]+/g, '-')
+				.replace(/^-+|-+$/g, '')
+				.slice(0, 80) || 'session'
+		);
+	}
+
+	function suggestedExportFilename(): string {
+		const stamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
+		const id = sessionId ? sessionId.slice(0, 12) : 'session';
+		return `docwriter-transcript-${safeFilePart(id)}-${stamp}.json`;
+	}
+
+	function buildExportPayload() {
+		const toolCallCount = toolCounts.reduce((a, [, v]) => a + v, 0);
+		return {
+			schema: 'docwriter.sessionTranscript.v1',
+			exportedAt: new Date().toISOString(),
+			session: {
+				id: sessionId || null,
+				provider: providerId,
+				assistantLabel
+			},
+			stats: {
+				turns: userTurns,
+				toolCalls: toolCallCount,
+				inputTokens: totalInTok,
+				outputTokens: totalOutTok,
+				context: {
+					percentFull: contextPctFull,
+					totalTokens: totalContextTokens,
+					budgetTokens: CONTEXT_BUDGET,
+					buckets: contextBuckets.map((bucket) => ({
+						id: bucket.id,
+						label: bucket.label,
+						tokens: bucket.tokens
+					}))
+				}
+			},
+			systemPrompt,
+			events: events.map((event) => ({ ...event })),
+			raw: {
+				entries: rawHistory,
+				messages: sdkMessages
+			}
+		};
+	}
+
+	function downloadJsonFallback(filename: string, jsonText: string) {
+		const blob = new Blob([jsonText], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = filename;
+		a.rel = 'noopener';
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		setTimeout(() => URL.revokeObjectURL(url), 1000);
+	}
+
+	async function saveJsonFile(filename: string, jsonText: string) {
+		const blob = new Blob([jsonText], { type: 'application/json' });
+		const picker = (window as SaveFilePickerWindow).showSaveFilePicker;
+		if (picker) {
+			try {
+				const handle = await picker({
+					suggestedName: filename,
+					types: [
+						{
+							description: 'JSON transcript',
+							accept: { 'application/json': ['.json'] }
+						}
+					]
+				});
+				const writable = await handle.createWritable();
+				await writable.write(blob);
+				await writable.close();
+				return;
+			} catch (e) {
+				if (e instanceof DOMException && e.name === 'AbortError') return;
+				console.warn('[SessionViewer] Save picker failed; falling back to download', e);
+			}
+		}
+		downloadJsonFallback(filename, jsonText);
+	}
+
+	async function exportTranscript() {
+		if (exporting || loading) return;
+		exporting = true;
+		exportError = '';
+		try {
+			const jsonText = JSON.stringify(buildExportPayload(), null, 2);
+			await saveJsonFile(suggestedExportFilename(), jsonText);
+		} catch (e) {
+			exportError = e instanceof Error ? e.message : String(e);
+		} finally {
+			exporting = false;
+		}
+	}
+
 	onMount(async () => {
 		void fetchRules();
 		try {
 			const res = await fetch('/api/history');
-			const data = await res.json();
+			const data = (await res.json()) as HistoryResponse;
 			sessionId = data.sessionId ?? '';
 			systemPrompt = typeof data.systemPrompt === 'string' ? data.systemPrompt : null;
 			// Prefer raw JSONL entries (direct file read, complete).
 			// Fall back to the SDK-wrapped `messages` array if raw is absent.
-			const raw: unknown[] = data.raw ?? [];
-			const messages: unknown[] = data.messages ?? [];
-			const provider = (data.provider ?? 'claude') as string;
+			rawHistory = Array.isArray(data.raw) ? data.raw : [];
+			sdkMessages = Array.isArray(data.messages) ? data.messages : [];
+			providerId = data.provider ?? 'claude';
+			const raw = rawHistory;
+			const messages = sdkMessages;
+			const provider = providerId;
 			assistantLabel = PROVIDER_LABELS[provider] ?? 'Assistant';
 			// Non-Claude providers persist DocWriter's own SSE event payloads
 			// (type: 'tool_call' | 'assistant_text' | …) rather than the Claude
@@ -600,6 +735,18 @@
 					<Activity size={11} />
 					<span>Context</span>
 					<span class="context-toggle-pct">{contextPctFull}%</span>
+				</button>
+				{#if exportError}
+					<span class="export-error" title={exportError}>Export failed</span>
+				{/if}
+				<button
+					class="export-btn"
+					onclick={exportTranscript}
+					disabled={loading || exporting}
+					aria-label="Export transcript JSON"
+					title="Export transcript as JSON"
+				>
+					<Download size={14} />
 				</button>
 				<button class="close-btn" onclick={onClose} aria-label="Close">
 					<X size={15} />
@@ -1175,8 +1322,9 @@
 		color: var(--text-faint);
 	}
 
-	/* ── Close button ────────────────────────────────────────────── */
-	.close-btn {
+	/* ── Top-right icon buttons ──────────────────────────────────── */
+	.close-btn,
+	.export-btn {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -1189,7 +1337,20 @@
 		cursor: pointer;
 		transition: all .1s;
 	}
-	.close-btn:hover { background: var(--bg-hover); color: var(--text); }
+	.close-btn:hover,
+	.export-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text);
+	}
+	.export-btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.export-error {
+		font-size: 11px;
+		color: #ef4444;
+		white-space: nowrap;
+	}
 
 	/* ── Body layout ─────────────────────────────────────────────── */
 	.body {

--- a/src/lib/components/SessionViewer.svelte
+++ b/src/lib/components/SessionViewer.svelte
@@ -64,6 +64,7 @@
 		messages?: unknown[];
 		systemPrompt?: string | null;
 		provider?: string | null;
+		model?: string | null;
 	};
 
 	type SaveFilePickerWindow = Window & {
@@ -84,6 +85,7 @@
 	let events = $state<SessionEvent[]>([]);
 	let sessionId = $state('');
 	let providerId = $state('claude');
+	let modelId = $state('');
 	let rawHistory = $state<unknown[]>([]);
 	let sdkMessages = $state<unknown[]>([]);
 	// Label for assistant rows / filter — reflects the provider that produced
@@ -175,6 +177,7 @@
 	let contextPctFull = $derived(
 		Math.min(100, Math.round((totalContextTokens / CONTEXT_BUDGET) * 100))
 	);
+	let modelDisplay = $derived(modelId || latestAssistant?.model || '');
 	type ContextBucket = { id: string; label: string; tokens: number; color: string };
 	let contextBuckets = $derived<ContextBucket[]>([
 		{ id: 'system', label: 'System prompt', tokens: systemPromptTokens, color: 'var(--ctx-color-system)' },
@@ -278,6 +281,7 @@
 			session: {
 				id: sessionId || null,
 				provider: providerId,
+				model: modelDisplay || null,
 				assistantLabel
 			},
 			stats: {
@@ -303,6 +307,14 @@
 				messages: sdkMessages
 			}
 		};
+	}
+
+	function modelFromEvents(parsedEvents: SessionEvent[]): string {
+		for (let i = parsedEvents.length - 1; i >= 0; i -= 1) {
+			const model = parsedEvents[i].model;
+			if (model) return model;
+		}
+		return '';
 	}
 
 	function downloadJsonFallback(filename: string, jsonText: string) {
@@ -370,6 +382,7 @@
 			rawHistory = Array.isArray(data.raw) ? data.raw : [];
 			sdkMessages = Array.isArray(data.messages) ? data.messages : [];
 			providerId = data.provider ?? 'claude';
+			modelId = typeof data.model === 'string' ? data.model : '';
 			const raw = rawHistory;
 			const messages = sdkMessages;
 			const provider = providerId;
@@ -383,7 +396,9 @@
 					: raw.length > 0
 						? parseRaw(raw)
 						: parseMessages(messages);
-			events = pairToolResults(parsed);
+			const paired = pairToolResults(parsed);
+			events = paired;
+			if (!modelId) modelId = modelFromEvents(paired);
 		} catch (e) {
 			error = String(e);
 		} finally {
@@ -411,11 +426,18 @@
 			if (t === 'assistant_text' || t === 'assistant_thinking') {
 				const kind: EventKind = t === 'assistant_thinking' ? 'thinking' : 'assistant_text';
 				const delta = typeof e.text === 'string' ? e.text : '';
+				const eventModel = typeof e.model === 'string' ? e.model : undefined;
 				if (acc && acc.kind === kind) {
 					acc.text = (acc.text ?? '') + delta;
+					if (!acc.model && eventModel) acc.model = eventModel;
 				} else {
 					flush();
-					acc = { kind, ts, text: delta };
+					acc = {
+						kind,
+						ts,
+						text: delta,
+						model: eventModel
+					};
 				}
 				continue;
 			}
@@ -721,6 +743,9 @@
 			</div>
 			<div class="topbar-right">
 				<div class="stats-pills">
+					{#if modelDisplay}
+						<span class="stat-pill model-pill" title={modelDisplay}>{modelDisplay}</span>
+					{/if}
 					<span class="stat-pill">{userTurns} turns</span>
 					<span class="stat-pill">{toolCounts.reduce((a,[,v])=>a+v,0)} calls</span>
 					<span class="stat-pill">{fmtTokens(totalInTok)} in</span>
@@ -902,6 +927,9 @@
 											<span class="msg-preview">{preview}</span>
 										{:else}
 											<span class="card-ts">{fmtTs(ev.ts)}</span>
+											{#if ev.model || modelDisplay}
+												<span class="model-info" title={ev.model || modelDisplay}>{ev.model || modelDisplay}</span>
+											{/if}
 											{#if ev.inputTokens || ev.outputTokens}
 												<span class="tok-info">
 													{fmtTokens((ev.inputTokens ?? 0) + (ev.cacheRead ?? 0))} in
@@ -1129,6 +1157,12 @@
 		padding: 2px 8px;
 		font-family: ui-monospace, monospace;
 		white-space: nowrap;
+	}
+	.model-pill {
+		max-width: 220px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		color: var(--text-secondary);
 	}
 
 	/* ── Context breakdown ───────────────────────────────────────── */
@@ -1489,6 +1523,15 @@
 		font-size: 11px;
 		color: var(--text-faint);
 		font-family: ui-monospace, monospace;
+	}
+	.model-info {
+		font-size: 11px;
+		color: var(--text-faint);
+		font-family: ui-monospace, monospace;
+		max-width: 240px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 	.tool-preview {
 		flex: 1;

--- a/src/lib/components/SkillsPanel.svelte
+++ b/src/lib/components/SkillsPanel.svelte
@@ -1,0 +1,489 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Play, Plus, RefreshCw, Trash2 } from 'lucide-svelte';
+
+	interface Props {
+		onSubmit?: (trigger: string) => void;
+	}
+
+	let { onSubmit }: Props = $props();
+
+	interface SkillSummary {
+		id: string;
+		name: string;
+		description: string;
+		enabled: boolean;
+		origin: 'bundled' | 'custom';
+		path: string;
+		source?: string;
+		missing?: boolean;
+	}
+
+	let skills = $state<SkillSummary[]>([]);
+	let nativeDirs = $state<string[]>([]);
+	let source = $state('');
+	let loading = $state(true);
+	let savingId = $state<string | null>(null);
+	let adding = $state(false);
+	let errorText = $state('');
+	let directSource = $derived(normalizeDirectSource(source));
+
+	async function load() {
+		loading = true;
+		errorText = '';
+		try {
+			const res = await fetch('/api/skills');
+			const data = await res.json();
+			if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+			skills = Array.isArray(data?.skills) ? data.skills : [];
+			nativeDirs = Array.isArray(data?.nativeDirs) ? data.nativeDirs : [];
+		} catch (e) {
+			errorText = (e as Error).message;
+		} finally {
+			loading = false;
+		}
+	}
+
+	function applyData(data: { skills?: SkillSummary[]; nativeDirs?: string[] }) {
+		if (Array.isArray(data.skills)) skills = data.skills;
+		if (Array.isArray(data.nativeDirs)) nativeDirs = data.nativeDirs;
+	}
+
+	async function toggle(skill: SkillSummary) {
+		savingId = skill.id;
+		errorText = '';
+		try {
+			const res = await fetch('/api/skills', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: skill.id, enabled: !skill.enabled })
+			});
+			const data = await res.json();
+			if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+			applyData(data);
+		} catch (e) {
+			errorText = (e as Error).message;
+		} finally {
+			savingId = null;
+		}
+	}
+
+	function normalizeDirectSource(raw: string): string | null {
+		const trimmed = raw.trim();
+		if (!trimmed) return null;
+		if (/^https:\/\/github\.com\/[^/\s]+\/[^/\s]+(?:\.git)?\/?$/.test(trimmed)) {
+			return trimmed;
+		}
+		if (/^github\.com\/[^/\s]+\/[^/\s]+(?:\.git)?\/?$/.test(trimmed)) {
+			return `https://${trimmed}`;
+		}
+		if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(trimmed)) {
+			return `https://github.com/${trimmed}`;
+		}
+		if (
+			trimmed.startsWith('/') ||
+			trimmed.startsWith('./') ||
+			trimmed.startsWith('../') ||
+			trimmed.startsWith('~/') ||
+			trimmed.includes('/') ||
+			/SKILL\.md$/i.test(trimmed)
+		) {
+			return trimmed;
+		}
+		return null;
+	}
+
+	function submitSkillRequest() {
+		const text = source.trim();
+		if (!text || !onSubmit) return;
+		onSubmit([
+			`The user typed this into the DocWriter Settings > Skills add box: "${text}".`,
+			'Treat it as a request to add or create an Agent Skill.',
+			'If it is a GitHub URL, GitHub owner/repo shorthand, local skill directory, or SKILL.md path, call `add_skill` with the resolved source.',
+			'If it is just a name or vague description, ask the user for the GitHub URL or local path, or identify a likely public skill source before calling `add_skill`.',
+			'Do not edit `.docwriter/skills.json`, `.claude/skills`, or `.agents/skills` directly.'
+		].join('\n'));
+		source = '';
+		errorText = '';
+	}
+
+	function runSkill(skill: SkillSummary) {
+		if (!onSubmit || !skill.enabled || skill.missing) return;
+		onSubmit(`/${skill.id}`);
+	}
+
+	async function addSkill() {
+		const trimmed = source.trim();
+		if (!trimmed || adding) return;
+		const resolved = normalizeDirectSource(trimmed);
+		if (!resolved) {
+			submitSkillRequest();
+			return;
+		}
+		adding = true;
+		errorText = '';
+		try {
+			const res = await fetch('/api/skills', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ source: resolved })
+			});
+			const data = await res.json();
+			if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+			source = '';
+			applyData(data);
+		} catch (e) {
+			errorText = (e as Error).message;
+		} finally {
+			adding = false;
+		}
+	}
+
+	async function removeSkill(skill: SkillSummary) {
+		if (skill.origin !== 'custom') return;
+		savingId = skill.id;
+		errorText = '';
+		try {
+			const res = await fetch(`/api/skills?id=${encodeURIComponent(skill.id)}`, {
+				method: 'DELETE'
+			});
+			const data = await res.json();
+			if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+			applyData(data);
+		} catch (e) {
+			errorText = (e as Error).message;
+		} finally {
+			savingId = null;
+		}
+	}
+
+	onMount(() => {
+		void load();
+	});
+</script>
+
+<div class="skills-panel" role="dialog">
+	<div class="panel-header">
+		<div>
+			<span class="panel-title">Skills</span>
+			<span class="panel-subtitle">reusable agent workflows</span>
+		</div>
+		<button class="icon-btn" type="button" onclick={() => void load()} title="Refresh skills">
+			<RefreshCw size={14} />
+		</button>
+	</div>
+
+	{#if errorText}
+		<div class="error">{errorText}</div>
+	{/if}
+
+	<div class="skill-list" class:loading>
+		{#if loading}
+			<div class="empty">Loading skills…</div>
+		{:else if skills.length === 0}
+			<div class="empty">No skills found.</div>
+		{:else}
+			{#each skills as skill (skill.id)}
+				<div class="skill-row" class:disabled={!skill.enabled || skill.missing}>
+					<div class="skill-main">
+						<div class="skill-topline">
+							<button
+								class="switch"
+								class:on={skill.enabled && !skill.missing}
+								type="button"
+								aria-pressed={skill.enabled && !skill.missing}
+								disabled={savingId === skill.id || skill.missing}
+								onclick={() => void toggle(skill)}
+								title={skill.enabled ? 'Disable skill' : 'Enable skill'}
+							>
+								<span></span>
+							</button>
+							<div class="skill-name">{skill.name}</div>
+							<span class="badge">{skill.origin === 'bundled' ? 'Preset' : 'Custom'}</span>
+						</div>
+						<div class="skill-description">{skill.description}</div>
+						<div class="skill-path">{skill.source || skill.path}</div>
+					</div>
+					<button
+						class="icon-btn run"
+						type="button"
+						disabled={!onSubmit || !skill.enabled || skill.missing}
+						onclick={() => runSkill(skill)}
+						title={skill.enabled && !skill.missing ? `Run /${skill.id}` : 'Enable skill before running'}
+						aria-label={`Run ${skill.name}`}
+					>
+						<Play size={13} />
+					</button>
+					{#if skill.origin === 'custom'}
+						<button
+							class="icon-btn danger"
+							type="button"
+							disabled={savingId === skill.id}
+							onclick={() => void removeSkill(skill)}
+							title="Remove skill"
+						>
+							<Trash2 size={14} />
+						</button>
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	</div>
+
+	<div class="add-section">
+		<div class="add-title">Add skill</div>
+		<div class="add-row">
+			<input
+				bind:value={source}
+				placeholder="GitHub URL or local path"
+				onkeydown={(e) => {
+					if (e.key === 'Enter') void addSkill();
+				}}
+			/>
+			<button
+				class="add-btn"
+				type="button"
+				disabled={!source.trim() || adding || (!directSource && !onSubmit)}
+				onclick={() => void addSkill()}
+				title={directSource ? 'Add skill' : 'Ask agent to add skill'}
+			>
+				<Plus size={14} />
+				<span>{adding ? 'Adding' : directSource ? 'Add' : 'Ask agent'}</span>
+			</button>
+		</div>
+	</div>
+
+	{#if nativeDirs.length > 0}
+		<div class="sync-note">
+			Synced to {nativeDirs.length} native folder{nativeDirs.length === 1 ? '' : 's'}.
+		</div>
+	{/if}
+</div>
+
+<style>
+	.skills-panel {
+		width: 390px;
+		max-width: calc(100vw - 32px);
+		box-sizing: border-box;
+		padding: 14px 16px 16px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 13px;
+		color: var(--text);
+	}
+	.panel-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 12px;
+		margin-bottom: 12px;
+	}
+	.panel-title {
+		display: block;
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+	.panel-subtitle {
+		display: block;
+		margin-top: 3px;
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+	.skill-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		max-height: min(54vh, 420px);
+		overflow: auto;
+		padding-right: 2px;
+	}
+	.skill-row {
+		display: flex;
+		gap: 8px;
+		align-items: flex-start;
+		border: 1px solid var(--border-light);
+		border-radius: 8px;
+		background: var(--bg-elevated);
+		padding: 10px;
+	}
+	.skill-row.disabled {
+		opacity: 0.62;
+	}
+	.skill-main {
+		min-width: 0;
+		flex: 1;
+	}
+	.skill-topline {
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		min-width: 0;
+	}
+	.skill-name {
+		font-size: 13px;
+		font-weight: 650;
+		color: var(--text);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.badge {
+		flex: 0 0 auto;
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--text-faint);
+		border: 1px solid var(--border-light);
+		border-radius: 999px;
+		padding: 1px 6px;
+	}
+	.skill-description {
+		margin-top: 6px;
+		font-size: 12px;
+		line-height: 1.45;
+		color: var(--text-muted);
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	.skill-path {
+		margin-top: 6px;
+		font-family: 'Geist Mono', ui-monospace, monospace;
+		font-size: 10.5px;
+		line-height: 1.35;
+		color: var(--text-faint);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.switch {
+		width: 30px;
+		height: 17px;
+		border: 1px solid var(--border-light);
+		border-radius: 999px;
+		background: var(--bg-surface);
+		padding: 2px;
+		cursor: pointer;
+		flex: 0 0 auto;
+		transition: background 120ms ease, border-color 120ms ease;
+	}
+	.switch span {
+		display: block;
+		width: 11px;
+		height: 11px;
+		border-radius: 999px;
+		background: var(--text-faint);
+		transition: transform 120ms ease, background 120ms ease;
+	}
+	.switch.on {
+		background: color-mix(in srgb, var(--accent) 18%, var(--bg-elevated));
+		border-color: color-mix(in srgb, var(--accent) 40%, var(--border-light));
+	}
+	.switch.on span {
+		transform: translateX(12px);
+		background: var(--accent);
+	}
+	.icon-btn {
+		width: 28px;
+		height: 28px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		background: var(--bg-elevated);
+		color: var(--text-muted);
+		cursor: pointer;
+		flex: 0 0 auto;
+	}
+	.icon-btn:hover:not(:disabled) {
+		color: var(--text);
+		border-color: var(--border);
+	}
+	.icon-btn.run {
+		color: var(--accent);
+	}
+	.icon-btn.run:hover:not(:disabled) {
+		border-color: color-mix(in srgb, var(--accent) 40%, var(--border-light));
+		background: color-mix(in srgb, var(--accent) 9%, var(--bg-elevated));
+	}
+	.icon-btn.danger:hover:not(:disabled) {
+		color: #dc2626;
+		border-color: color-mix(in srgb, #dc2626 40%, var(--border-light));
+	}
+	.icon-btn:disabled,
+	.add-btn:disabled,
+	.switch:disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+	.add-section {
+		margin-top: 14px;
+		padding-top: 12px;
+		border-top: 1px solid var(--border-light);
+	}
+	.add-title {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text);
+		margin-bottom: 7px;
+	}
+	.add-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 6px;
+	}
+	input {
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		background: var(--bg-elevated);
+		color: var(--text);
+		font: inherit;
+		font-size: 12px;
+		padding: 7px 8px;
+	}
+	input:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+	.add-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-light));
+		border-radius: 6px;
+		background: color-mix(in srgb, var(--accent) 12%, var(--bg-elevated));
+		color: var(--accent);
+		font: inherit;
+		font-size: 12px;
+		font-weight: 600;
+		padding: 0 10px;
+		cursor: pointer;
+	}
+	.error {
+		margin-bottom: 10px;
+		padding: 8px 10px;
+		border-radius: 6px;
+		background: color-mix(in srgb, #dc2626 9%, var(--bg-elevated));
+		color: #b91c1c;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+	.empty {
+		padding: 16px 10px;
+		text-align: center;
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+	.sync-note {
+		margin-top: 10px;
+		font-size: 11px;
+		color: var(--text-faint);
+	}
+</style>

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy, tick } from 'svelte';
 	import { Editor } from '@tiptap/core';
 	import { TextSelection, type Transaction } from '@tiptap/pm/state';
 	import { ySyncPluginKey } from 'y-prosemirror';
@@ -21,6 +21,11 @@
 	} from './find-overlay';
 	import { MediaOverlay } from './media-overlay';
 	import { D3Overlay } from './d3-overlay';
+	import { MarkdownRender } from './markdown-render';
+	import {
+		SourceCommentOverlay,
+		type SourceCommentStyle
+	} from './source-comment-overlay';
 	import { handleEditorPaste, handleEditorDrop } from './media-paste';
 	import FindBar from '$lib/components/FindBar.svelte';
 	import PreviewButton from '$lib/components/PreviewButton.svelte';
@@ -66,6 +71,9 @@
 		onAcceptFeedbackEdits?: (roundIds: string[]) => void;
 		/** Resolve / reopen a thread (undoable; also drops its pending edits). */
 		onResolveThread?: (threadId: string, resolved: boolean) => void;
+		/** Open the resolved preview output beside the source editor. */
+		onOpenSplitPreview?: (path: string) => void;
+		splitPreviewOpen?: boolean;
 	}
 	let {
 		tabId,
@@ -74,7 +82,9 @@
 		onAcceptInlineEdit,
 		onRejectInlineEdit,
 		onAcceptFeedbackEdits,
-		onResolveThread
+		onResolveThread,
+		onOpenSplitPreview,
+		splitPreviewOpen = false
 	}: Props = $props();
 
 	let element: HTMLDivElement;
@@ -178,6 +188,151 @@
 		return a?.from === b.from && a?.to === b.to;
 	}
 
+	function extensionForPath(path: string): string {
+		const clean = path.split(/[?#]/, 1)[0].toLowerCase();
+		const slash = Math.max(clean.lastIndexOf('/'), clean.lastIndexOf('\\'));
+		const dot = clean.lastIndexOf('.');
+		return dot > slash ? clean.slice(dot) : '';
+	}
+
+	function sourceCommentStyleForPath(path: string): SourceCommentStyle | null {
+		const ext = extensionForPath(path);
+		if (['.tex', '.ltx', '.sty', '.cls', '.bib'].includes(ext)) {
+			return { kind: 'line', marker: '%' };
+		}
+		if (['.py', '.r', '.rb', '.sh', '.bash', '.zsh', '.fish', '.yaml', '.yml', '.toml', '.ini', '.conf', '.env'].includes(ext)) {
+			return { kind: 'line', marker: '#' };
+		}
+		if (['.js', '.jsx', '.ts', '.tsx', '.svelte', '.java', '.c', '.cc', '.cpp', '.h', '.hpp', '.cs', '.go', '.rs', '.swift', '.kt', '.kts', '.php', '.scala'].includes(ext)) {
+			return { kind: 'line', marker: '//' };
+		}
+		if (['.sql', '.lua'].includes(ext)) {
+			return { kind: 'line', marker: '--' };
+		}
+		if (['.md', '.markdown', '.mdx', '.html', '.htm', '.xml', '.svg'].includes(ext)) {
+			return { kind: 'block', open: '<!-- ', close: ' -->' };
+		}
+		if (['.css', '.scss', '.less'].includes(ext)) {
+			return { kind: 'block', open: '/* ', close: ' */' };
+		}
+		return null;
+	}
+
+	function escapeRegExp(value: string): string {
+		return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	function selectedSourceLines(): Array<{ contentStart: number; text: string }> {
+		if (!editor || !(editor.state.selection instanceof TextSelection)) return [];
+		const { from, to, empty } = editor.state.selection;
+		const lines: Array<{ contentStart: number; text: string }> = [];
+		editor.state.doc.forEach((node, offset) => {
+			if (node.type.name !== 'paragraph') return;
+			const contentStart = offset + 1;
+			const contentEnd = contentStart + node.content.size;
+			const nodeEnd = offset + node.nodeSize;
+			const text = node.textBetween(0, node.content.size, '\n', '');
+			const include = empty
+				? from >= offset && from <= nodeEnd
+				: contentEnd > contentStart
+					? to > contentStart && from < contentEnd
+					: to >= contentStart && from <= contentStart;
+			if (include) lines.push({ contentStart, text });
+		});
+		return lines;
+	}
+
+	function selectedOrCurrentBlockRange(): { from: number; to: number } | null {
+		if (!editor || !(editor.state.selection instanceof TextSelection)) return null;
+		const { from, to, empty } = editor.state.selection;
+		if (!empty) return { from, to };
+		let range: { from: number; to: number } | null = null;
+		editor.state.doc.forEach((node, offset) => {
+			if (range || node.type.name !== 'paragraph') return;
+			const contentStart = offset + 1;
+			const contentEnd = contentStart + node.content.size;
+			if (from >= offset && from <= offset + node.nodeSize) {
+				range = { from: contentStart, to: contentEnd };
+			}
+		});
+		return range;
+	}
+
+	function toggleLineSourceComment(marker: string): boolean {
+		if (!editor) return false;
+		const lines = selectedSourceLines().filter((line) => line.text.trim().length > 0);
+		if (lines.length === 0) return false;
+		const markerRe = new RegExp(`^(\\s*)${escapeRegExp(marker)} ?`);
+		const shouldUncomment = lines.every((line) => markerRe.test(line.text));
+		let tr = editor.state.tr;
+		for (const line of [...lines].sort((a, b) => b.contentStart - a.contentStart)) {
+			if (shouldUncomment) {
+				const match = line.text.match(markerRe);
+				if (!match) continue;
+				const indentLen = match[1].length;
+				const removeFrom = line.contentStart + indentLen;
+				tr = tr.delete(removeFrom, removeFrom + match[0].length - indentLen);
+			} else {
+				const indentLen = line.text.match(/^\s*/)?.[0].length ?? 0;
+				tr = tr.insertText(`${marker} `, line.contentStart + indentLen);
+			}
+		}
+		if (!tr.docChanged) return false;
+		editor.view.dispatch(tr.scrollIntoView());
+		closeFeedbackPopup({ preserveSelection: true, refocusEditor: true });
+		return true;
+	}
+
+	function toggleBlockSourceComment(open: string, close: string): boolean {
+		if (!editor) return false;
+		const range = selectedOrCurrentBlockRange();
+		if (!range) return false;
+		const selected = editor.state.doc.textBetween(range.from, range.to, '\n', '\n');
+		let tr = editor.state.tr;
+		if (selected.startsWith(open) && selected.endsWith(close)) {
+			tr = tr.delete(range.to - close.length, range.to);
+			tr = tr.delete(range.from, range.from + open.length);
+		} else {
+			tr = tr.insertText(close, range.to);
+			tr = tr.insertText(open, range.from);
+		}
+		if (!tr.docChanged) return false;
+		editor.view.dispatch(tr.scrollIntoView());
+		closeFeedbackPopup({ preserveSelection: true, refocusEditor: true });
+		return true;
+	}
+
+	function toggleSourceComment(): boolean {
+		const style = sourceCommentStyleForPath(tabId);
+		if (!style) return false;
+		return style.kind === 'line'
+			? toggleLineSourceComment(style.marker)
+			: toggleBlockSourceComment(style.open, style.close);
+	}
+
+	function isSourceCommentShortcut(event: KeyboardEvent): boolean {
+		return (
+			(event.metaKey || event.ctrlKey) &&
+			!event.altKey &&
+			(event.key === '/' || event.key === '?' || event.code === 'Slash')
+		);
+	}
+
+	function handleSourceCommentShortcut(event: KeyboardEvent): boolean {
+		if (!isSourceCommentShortcut(event)) return false;
+		const target = event.target as HTMLElement | null;
+		const inThisEditor =
+			!!feedbackPopup ||
+			!!editor?.isFocused ||
+			!!(target && wrapperEl?.contains(target)) ||
+			!!(target && feedbackPopupEl?.contains(target));
+		if (!inThisEditor) return false;
+		if (!toggleSourceComment()) return false;
+		event.preventDefault();
+		event.stopPropagation();
+		return true;
+	}
+
 	function updateFeedbackPopup(autoFocus = false) {
 		if (!editor || !editor.isFocused) return;
 		const selection = editor.state.selection;
@@ -195,7 +350,7 @@
 			updateDiff();
 			return;
 		}
-		const selectedText = editor.state.doc.textBetween(from, to, ' ');
+		const selectedText = editor.state.doc.textBetween(from, to, '\n', '\n');
 		if (!selectedText.trim()) {
 			dismissedFeedbackSelectionRange = null;
 			feedbackPopup = null;
@@ -337,6 +492,7 @@
 	}
 
 	function handleFeedbackWindowKeydown(e: KeyboardEvent) {
+		if (handleSourceCommentShortcut(e)) return;
 		if (!feedbackPopup || e.key !== 'Escape') return;
 		e.preventDefault();
 		e.stopPropagation();
@@ -449,7 +605,10 @@
 		// it to `auto`, but we want to honor what the user picked.
 		feedbackMode = modeSnapshot;
 		const threadId = await maybeOpenThreadForFeedback(action.label, text, relSnapshot);
-		if (threadId) newAwaitingThreadId = threadId;
+		if (threadId) {
+			newAwaitingThreadId = threadId;
+			tick().then(() => { newAwaitingThreadId = null; });
+		}
 		const trigger = buildFeedbackTrigger(action.label, text, false, threadId);
 		feedbackMode = 'edit';
 		if (onSubmit) onSubmit(trigger);
@@ -476,7 +635,10 @@
 		closeFeedbackPopup();
 		feedbackMode = modeSnapshot;
 		const threadId = await maybeOpenThreadForFeedback(fb, text, relSnapshot);
-		if (threadId) newAwaitingThreadId = threadId;
+		if (threadId) {
+			newAwaitingThreadId = threadId;
+			tick().then(() => { newAwaitingThreadId = null; });
+		}
 		const trigger = buildFeedbackTrigger(fb, text, true, threadId);
 		feedbackMode = 'edit';
 		if (onSubmit) onSubmit(trigger);
@@ -496,7 +658,11 @@
 		) as HTMLElement[];
 		const visibleParagraphs = paragraphs
 			.map((paragraph, index) => ({ paragraph, index }))
-			.filter(({ paragraph }) => !paragraph.classList.contains('d3-code-line-hidden'));
+			.filter(({ paragraph }) =>
+				!paragraph.classList.contains('d3-code-line-hidden') &&
+				!paragraph.classList.contains('svg-source-line-hidden') &&
+				!paragraph.classList.contains('md-table-source-line-hidden')
+			);
 		const contentRect = contentEl.getBoundingClientRect();
 		if (paragraphs.length === 0) {
 			plainLineRows = [{ label: '1', top: 0 }];
@@ -729,6 +895,21 @@
 	}
 
 	let pdfJumpChannel: BroadcastChannel | null = null;
+	type PdfJumpMessage = {
+		kind: 'pdf-jump';
+		page: number;
+		x: number;
+		y: number;
+		h?: number;
+		v?: number;
+		w?: number;
+		height?: number;
+	};
+	type PdfSearchMessage = {
+		kind: 'pdf-search';
+		queries: string[];
+	};
+	type PdfPreviewMessage = PdfJumpMessage | PdfSearchMessage;
 	function getPdfJumpChannel(): BroadcastChannel | null {
 		if (typeof window === 'undefined') return null;
 		if (pdfJumpChannel) return pdfJumpChannel;
@@ -739,11 +920,69 @@
 		}
 		return pdfJumpChannel;
 	}
+	function postPdfPreviewMessage(message: PdfPreviewMessage) {
+		const ch = getPdfJumpChannel();
+		if (!ch) return;
+		ch.postMessage(message);
+	}
+	function postPdfPreviewMessageWithOpenRetry(message: PdfPreviewMessage, shouldOpenSidePreview: boolean) {
+		if (shouldOpenSidePreview) {
+			for (const delay of [250, 800, 1500, 2500]) {
+				setTimeout(() => postPdfPreviewMessage(message), delay);
+			}
+		} else {
+			postPdfPreviewMessage(message);
+		}
+	}
+	function stripLatexForPdfSearch(text: string): string {
+		let out = text
+			.replace(/~/g, ' ')
+			.replace(/``|''/g, '"')
+			.replace(/\\(?:cite|citep|citet|autocite|parencite|textcite)(?:\[[^\]]*\])*\{[^}]*\}/g, ' ')
+			.replace(/\\(?:ref|eqref|label|url|href)(?:\[[^\]]*\])*\{[^}]*\}/g, ' ');
+		for (let i = 0; i < 5; i += 1) {
+			out = out.replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?\{([^{}]*)\}/g, '$1');
+		}
+		return out
+			.replace(/\\([#$%&_{}])/g, '$1')
+			.replace(/[{}$]/g, ' ')
+			.replace(/\\[a-zA-Z]+\*?/g, ' ')
+			.replace(/[^\S\r\n]+/g, ' ')
+			.replace(/\s+/g, ' ')
+			.trim();
+	}
+	function pdfSearchQueries(text: string): string[] {
+		const cleaned = stripLatexForPdfSearch(text);
+		const words = cleaned.split(/\s+/).filter(Boolean);
+		const seen = new Set<string>();
+		const queries: string[] = [];
+		const add = (query: string) => {
+			const q = query.replace(/\s+/g, ' ').trim();
+			if (q.length < 18 || seen.has(q.toLowerCase())) return;
+			seen.add(q.toLowerCase());
+			queries.push(q);
+		};
+		add(words.slice(0, 16).join(' '));
+		for (const size of [12, 9, 6]) {
+			for (let start = 0; start <= Math.max(0, words.length - size); start += Math.max(1, Math.floor(size / 2))) {
+				add(words.slice(start, start + size).join(' '));
+				if (queries.length >= 12) return queries;
+			}
+		}
+		return queries;
+	}
 
 	async function showInPdf() {
 		if (!previewOutputPath) return;
 		const line = selectionLineNumber();
 		if (line == null) return;
+		const shouldOpenSidePreview = !splitPreviewOpen && !!onOpenSplitPreview;
+		if (shouldOpenSidePreview) onOpenSplitPreview?.(previewOutputPath);
+		const fallbackSearch = () => {
+			const queries = pdfSearchQueries(feedbackPopup?.text ?? '');
+			if (queries.length === 0) return;
+			postPdfPreviewMessageWithOpenRetry({ kind: 'pdf-search', queries }, shouldOpenSidePreview);
+		};
 		try {
 			const res = await fetch('/api/synctex', {
 				method: 'POST',
@@ -757,10 +996,11 @@
 				})
 			});
 			const data = await res.json();
-			if (!data?.ok) return;
-			const ch = getPdfJumpChannel();
-			if (!ch) return;
-			ch.postMessage({
+			if (!data?.ok) {
+				fallbackSearch();
+				return;
+			}
+			const jump: PdfJumpMessage = {
 				kind: 'pdf-jump',
 				page: data.page,
 				x: data.x,
@@ -769,9 +1009,10 @@
 				v: data.v,
 				w: data.w,
 				height: data.height
-			});
+			};
+			postPdfPreviewMessageWithOpenRetry(jump, shouldOpenSidePreview);
 		} catch {
-			/* synctex CLI missing or build not yet produced .synctex.gz — silent */
+			fallbackSearch();
 		}
 	}
 
@@ -856,6 +1097,14 @@
 			} else if (hasRounds) {
 				pendingRoundsForOverlay = currentRoundsList;
 			}
+			const validThreadIds = new Set(
+				threadsForTab.filter((t) => !t.resolved).map((t) => t.id)
+			);
+			const overlayRounds = pendingRoundsForOverlay.map((round) =>
+				round.feedbackThreadId && !validThreadIds.has(round.feedbackThreadId)
+					? { ...round, feedbackThreadId: undefined }
+					: round
+			);
 			setDiffState(editor, {
 				baseline: baselineForOverlay,
 				proposedText: proposalForOverlay,
@@ -875,7 +1124,7 @@
 				roundNumbers: openThreadRoundNumbers(),
 				// Pulse the hovered edit's diff so the user can locate it fast.
 				flashRoundId,
-				pendingRounds: pendingRoundsForOverlay
+				pendingRounds: overlayRounds
 			});
 		});
 	}
@@ -962,7 +1211,11 @@
 				CelebrationOverlay,
 				FindOverlay,
 				MediaOverlay,
-				D3Overlay
+				D3Overlay,
+				MarkdownRender,
+				SourceCommentOverlay.configure({
+					style: sourceCommentStyleForPath(tabId)
+				})
 			],
 			// Collaboration provides initial content from the Y.Doc; do NOT
 			// pass a string `content` here (doing so would wipe the Y.Doc).
@@ -988,6 +1241,7 @@
 						if (editor) openFind(editor);
 						return true;
 					}
+					if (handleSourceCommentShortcut(event)) return true;
 					// Cmd/Ctrl+Enter wakes the agent immediately, skipping the
 					// idle countdown. Plain Enter still inserts a new line.
 					if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
@@ -1024,8 +1278,10 @@
 
 		const editorRoot = editor.view.dom;
 
-		const handleD3CodeVisibilityChanged = () => schedulePlainLineSync();
-		editorRoot.addEventListener('d3-code-visibility-changed', handleD3CodeVisibilityChanged);
+		const handlePreviewLayoutChanged = () => schedulePlainLineSync();
+		editorRoot.addEventListener('d3-code-visibility-changed', handlePreviewLayoutChanged);
+		editorRoot.addEventListener('docwriter:media-layout-changed', handlePreviewLayoutChanged);
+		editorRoot.addEventListener('docwriter:markdown-layout-changed', handlePreviewLayoutChanged);
 
 		const handlePointerDown = () => {
 			pointerSelecting = true;
@@ -1082,7 +1338,9 @@
 
 		const detachOpenThread = () => {
 			editorRoot.removeEventListener('docwriter:open-thread', handleOpenThread as EventListener);
-			editorRoot.removeEventListener('d3-code-visibility-changed', handleD3CodeVisibilityChanged);
+			editorRoot.removeEventListener('d3-code-visibility-changed', handlePreviewLayoutChanged);
+			editorRoot.removeEventListener('docwriter:media-layout-changed', handlePreviewLayoutChanged);
+			editorRoot.removeEventListener('docwriter:markdown-layout-changed', handlePreviewLayoutChanged);
 			window.removeEventListener('mousedown', handleOutsideMousedown);
 			window.removeEventListener('mousedown', handleFeedbackOutsideMousedown);
 		};
@@ -1187,7 +1445,11 @@
 	     outside the scroll container so they pin regardless of scroll.
 	     When find is open, the preview button shifts down so the two
 	     don't overlap (FindBar wins the corner). -->
-	<PreviewButton activeTabPath={tabId} />
+	<PreviewButton
+		activeTabPath={tabId}
+		onOpenSplit={onOpenSplitPreview}
+		splitOpen={splitPreviewOpen}
+	/>
 	{#if findState.open}
 		<FindBar
 			findState={findState}
@@ -1319,7 +1581,7 @@
 					class="feedback-show-in-pdf"
 					type="button"
 					onclick={showInPdf}
-					title="Locate this passage in the preview window (forward SyncTeX). Preview window must be open."
+					title="Locate this passage in the PDF preview"
 				>
 					<Crosshair size={11} />
 					<span>Locate in PDF</span>
@@ -1437,7 +1699,7 @@
 	}
 	/* When the FindBar is open, drop the PreviewButton below it so the
 	 * two don't collide in the corner. */
-	.tiptap-host.find-open :global(.preview-btn) {
+	.tiptap-host.find-open :global(.preview-control) {
 		top: 50px;
 	}
 	.tiptap-wrapper {
@@ -1489,8 +1751,8 @@
 	 * `.comment-gutter` in CommentGutter.svelte. */
 	.plain-editor-shell {
 		display: grid;
-		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
-		gap: 18px;
+		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
+		gap: var(--editor-grid-gap, 18px);
 		width: 100%;
 		justify-content: center;
 		align-items: start;
@@ -1524,8 +1786,8 @@
 		 * so the digit stops well before the column rule. Fixed width +
 		 * `text-align: right` keeps single- and multi-digit numbers
 		 * right-aligned consistently. */
-		width: 40px;
-		padding-right: 12px;
+		width: var(--line-number-width, 40px);
+		padding-right: var(--line-number-pad-right, 12px);
 		box-sizing: border-box;
 		height: 1.45em;
 		text-align: right;
@@ -1577,6 +1839,11 @@
 		min-height: 1.45em;
 	}
 	.tiptap-editor :global(.tiptap-content:not(.tiptap-plain) p) { margin: 0 0 10px; }
+
+	.tiptap-editor :global(.source-comment) {
+		color: var(--text-muted);
+		opacity: 0.58;
+	}
 
 	/* `<mark>` from the Highlight extension: theme-aware flat tint (no
 	 * rough-notation for persistent marks since they can be many). */
@@ -1699,6 +1966,13 @@
 		user-select: none;
 		transform-origin: top;
 		animation: diffSlideIn 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+	}
+	.tiptap-editor :global(.diff-added[data-thread-id]),
+	.tiptap-editor :global(.diff-added-line[data-thread-id]),
+	.tiptap-editor :global(.diff-removed[data-thread-id]),
+	.tiptap-editor :global(.diff-removed-line[data-thread-id]),
+	.tiptap-editor :global(.diff-insert-caret[data-thread-id]) {
+		cursor: pointer;
 	}
 	/* Insertion caret: a small pulsing green bar marking where a collapsed,
 	 * purely-additive agent edit will add text — so an edit with nothing
@@ -1940,6 +2214,34 @@
 		font-weight: 700;
 		line-height: 1;
 		user-select: none;
+	}
+	.tiptap-editor :global(.diff-thread-btn) {
+		position: absolute;
+		left: calc(-3.45em - var(--thread-i, 0) * 1.55em);
+		top: 0.08em;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.55em;
+		height: 1.55em;
+		padding: 0;
+		border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border-light));
+		border-radius: 50%;
+		background: var(--bg-elevated);
+		color: var(--accent);
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+		cursor: pointer;
+		user-select: none;
+		z-index: 6;
+	}
+	.tiptap-editor :global(.diff-thread-btn:hover) {
+		background: var(--accent-bg);
+		border-color: var(--accent);
+	}
+	.tiptap-editor :global(.diff-thread-btn svg) {
+		display: block;
+		width: 0.85em;
+		height: 0.85em;
 	}
 	/* Hover-flash: pulse a changed paragraph when its row is hovered in the
 	 * thread card, so the user can locate it instantly. */
@@ -2302,6 +2604,23 @@
 		display: block;
 		max-width: 100%;
 	}
+	:global(.media-svg-widget) {
+		display: block;
+		max-width: 720px;
+		padding: 10px;
+		border: 1px solid var(--border-light);
+		border-radius: 8px;
+		background: var(--bg-elevated);
+	}
+	:global(.media-svg-label) {
+		margin-bottom: 8px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 10.5px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
 	:global(.media-thumb) {
 		display: block;
 		max-width: 100%;
@@ -2312,6 +2631,11 @@
 		object-fit: contain;
 		object-position: left center;
 		animation: media-fade-in 240ms ease-out both;
+	}
+	:global(.media-svg-thumb) {
+		width: 100%;
+		max-height: 420px;
+		background: white;
 	}
 	:global(.media-thumb-error) {
 		padding: 10px 12px;
@@ -2469,11 +2793,25 @@
 	.tiptap-editor :global(.tiptap-plain p.d3-code-line-expanded) {
 		animation: d3-source-reveal 90ms ease-out both;
 	}
+	.tiptap-editor :global(.tiptap-plain p.svg-source-line-hidden) {
+		display: none;
+	}
+	.tiptap-editor :global(.tiptap-plain p.svg-source-line-expanded) {
+		animation: d3-source-reveal 90ms ease-out both;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-table-source-line-hidden) {
+		display: none;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-table-source-line-expanded) {
+		animation: d3-source-reveal 90ms ease-out both;
+	}
 	@keyframes d3-source-reveal {
 		from { opacity: 0; transform: translateY(-1px); }
 		to { opacity: 1; transform: translateY(0); }
 	}
-	:global(.d3-code-toggle) {
+	:global(.d3-code-toggle),
+	:global(.svg-source-toggle),
+	:global(.md-table-source-toggle) {
 		display: inline-flex;
 		align-items: center;
 		margin: 1px 0 2px;
@@ -2482,7 +2820,9 @@
 		line-height: 1.45;
 		user-select: none;
 	}
-	:global(.d3-code-toggle-btn) {
+	:global(.d3-code-toggle-btn),
+	:global(.svg-source-toggle-btn),
+	:global(.md-table-source-toggle-btn) {
 		padding: 0;
 		border: 0;
 		background: transparent;
@@ -2494,9 +2834,67 @@
 		text-underline-offset: 3px;
 		transition: color 120ms ease, text-decoration-color 120ms ease;
 	}
-	:global(.d3-code-toggle-btn:hover) {
+	:global(.d3-code-toggle-btn:hover),
+	:global(.svg-source-toggle-btn:hover),
+	:global(.md-table-source-toggle-btn:hover) {
 		color: var(--text-muted);
 		text-decoration-color: color-mix(in srgb, var(--text-muted) 45%, transparent);
+	}
+	:global(.md-table-widget) {
+		display: block;
+		max-width: min(100%, 980px);
+		margin: 6px 0 14px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		animation: media-fade-in 180ms ease-out both;
+	}
+	:global(.md-table-label) {
+		margin-bottom: 5px;
+		font-size: 10.5px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	:global(.md-table-scroll) {
+		max-width: 100%;
+		overflow-x: auto;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		background: var(--bg-elevated);
+	}
+	:global(.md-table-preview) {
+		width: 100%;
+		min-width: 520px;
+		border-collapse: collapse;
+		font-size: calc(13px * var(--font-scale, 1));
+		line-height: 1.45;
+		color: var(--text);
+	}
+	:global(.md-table-preview th),
+	:global(.md-table-preview td) {
+		padding: 8px 10px;
+		border-bottom: 1px solid var(--border-light);
+		border-right: 1px solid var(--border-light);
+		vertical-align: top;
+	}
+	:global(.md-table-preview th:last-child),
+	:global(.md-table-preview td:last-child) {
+		border-right: 0;
+	}
+	:global(.md-table-preview tbody tr:last-child td) {
+		border-bottom: 0;
+	}
+	:global(.md-table-preview th) {
+		background: var(--bg-surface);
+		font-weight: 650;
+		color: var(--text-secondary);
+	}
+	:global(.md-table-preview code) {
+		font-family: 'Geist Mono', ui-monospace, monospace;
+		font-size: 0.92em;
+		background: var(--bg-surface);
+		border-radius: 3px;
+		padding: 1px 4px;
 	}
 	:global(.d3-widget) {
 		display: block;
@@ -2587,5 +2985,100 @@
 	@keyframes media-tooltip-in {
 		from { opacity: 0; transform: translateY(-3px); }
 		to { opacity: 1; transform: translateY(0); }
+	}
+
+	/* ── Markdown visual rendering (decoration-only) ── */
+	.tiptap-editor :global(.tiptap-plain p.md-heading) {
+		font-family: 'Lora', 'Georgia', serif;
+		color: var(--text);
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-h1) {
+		font-size: calc(26px * var(--font-scale, 1));
+		font-weight: 700;
+		line-height: 1.3;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-h2) {
+		font-size: calc(22px * var(--font-scale, 1));
+		font-weight: 600;
+		line-height: 1.35;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-h3) {
+		font-size: calc(19px * var(--font-scale, 1));
+		font-weight: 600;
+		line-height: 1.4;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-h4) {
+		font-size: calc(17px * var(--font-scale, 1));
+		font-weight: 600;
+		line-height: 1.4;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-h5),
+	.tiptap-editor :global(.tiptap-plain p.md-h6) {
+		font-size: calc(15px * var(--font-scale, 1));
+		font-weight: 600;
+		line-height: 1.45;
+	}
+	.tiptap-editor :global(.md-syntax) {
+		opacity: 0.3;
+	}
+	.tiptap-editor :global(.md-bold) {
+		font-weight: 700;
+	}
+	.tiptap-editor :global(.md-italic) {
+		font-style: italic;
+	}
+	.tiptap-editor :global(.md-code) {
+		font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-size: 0.9em;
+		background: var(--bg-surface);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	.tiptap-editor :global(.md-strikethrough) {
+		text-decoration: line-through;
+		opacity: 0.6;
+	}
+	.tiptap-editor :global(.md-link-text) {
+		color: var(--accent);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+	.tiptap-editor :global(.md-link-url) {
+		opacity: 0.3;
+		font-size: 0.9em;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-blockquote) {
+		border-left: 3px solid var(--border-light);
+		padding-left: 12px;
+		color: var(--text-muted);
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-list-item) {
+		--md-list-offset: 2.6ch;
+		padding-left: var(--md-list-offset);
+		text-indent: calc(-1 * var(--md-list-offset));
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-ol-item) {
+		--md-list-offset: 3.6ch;
+	}
+	.tiptap-editor :global(.md-list-marker) {
+		display: inline-block;
+		color: var(--text-faint);
+		font-weight: 600;
+		opacity: 0.72;
+	}
+	.tiptap-editor :global(.md-bullet) {
+		width: 1.7ch;
+		margin-right: 0.55ch;
+		text-align: right;
+	}
+	.tiptap-editor :global(.md-ordered-marker) {
+		width: 3ch;
+		margin-right: 0.45ch;
+		text-align: right;
+	}
+	.tiptap-editor :global(.tiptap-plain p.md-hr) {
+		border-bottom: 1px solid var(--border-light);
+		line-height: 0.5;
+		opacity: 0.5;
 	}
 </style>

--- a/src/lib/editor/diff-overlay.ts
+++ b/src/lib/editor/diff-overlay.ts
@@ -176,6 +176,15 @@ function buildLineAlignmentMap(anchorMd: string, currentMd: string): Map<number,
 // PM's default handling instead of jumping to a sibling.
 const DIFF_NODE_SELECTOR =
 	'.diff-added-line, .diff-removed-line, .diff-removed-widget';
+const DIFF_THREAD_SELECTOR = [
+	'.diff-thread-btn[data-thread-id]',
+	'.diff-added[data-thread-id]',
+	'.diff-added-line[data-thread-id]',
+	'.diff-removed[data-thread-id]',
+	'.diff-removed-line[data-thread-id]',
+	'.diff-removed-widget[data-thread-id]',
+	'.diff-insert-caret[data-thread-id]'
+].join(',');
 
 function isDiffNode(el: Element | null): boolean {
 	return !!el?.matches?.(DIFF_NODE_SELECTOR);
@@ -297,6 +306,27 @@ function placeCaretFromClick(
 	return true;
 }
 
+function dispatchOpenThread(view: EditorView, source: HTMLElement, threadId: string): void {
+	const rect = source.getBoundingClientRect();
+	view.dom.dispatchEvent(
+		new CustomEvent('docwriter:open-thread', {
+			detail: { threadId, x: rect.right, y: rect.top },
+			bubbles: true
+		})
+	);
+}
+
+function openThreadFromDiff(view: EditorView, event: MouseEvent): boolean {
+	const target = event.target as Element | null;
+	const el = target?.closest(DIFF_THREAD_SELECTOR) as HTMLElement | null;
+	const threadId = el?.getAttribute('data-thread-id');
+	if (!el || !threadId) return false;
+	event.preventDefault();
+	event.stopPropagation();
+	dispatchOpenThread(view, el, threadId);
+	return true;
+}
+
 export const DiffOverlay = Extension.create({
 	name: 'diffOverlay',
 
@@ -319,6 +349,7 @@ export const DiffOverlay = Extension.create({
 					handleDOMEvents: {
 						mousedown(view, event) {
 							const target = event.target as Element | null;
+							if (openThreadFromDiff(view, event)) return true;
 							if (!target?.closest(DIFF_NODE_SELECTOR)) return false;
 							return placeCaretFromClick(editor, view, event);
 						}
@@ -378,6 +409,7 @@ export const DiffOverlay = Extension.create({
 									interface DiffBlock {
 										id: string;
 										roundId: string;
+										threadId: string | null;
 										insertionPos: number;
 										removedParagraphIdxs: number[];
 										addedLines: string[];
@@ -385,6 +417,7 @@ export const DiffOverlay = Extension.create({
 									interface ModifiedPara {
 										id: string;
 										roundId: string;
+										threadId: string | null;
 										para: ParagraphTextSpan;
 										afterText: string;
 										stale: boolean;
@@ -416,6 +449,7 @@ export const DiffOverlay = Extension.create({
 											currentBlock = {
 												id: `block:${round.id}:${docLine}`,
 												roundId: round.id,
+												threadId: round.feedbackThreadId ?? null,
 												insertionPos: 0,
 												removedParagraphIdxs: [],
 												addedLines: []
@@ -468,6 +502,7 @@ export const DiffOverlay = Extension.create({
 														modified.push({
 															id: `mod:${round.id}:${docLine}`,
 															roundId: round.id,
+															threadId: round.feedbackThreadId ?? null,
 															para,
 															afterText: addedLines[j],
 															stale,
@@ -505,6 +540,8 @@ export const DiffOverlay = Extension.create({
 									// left so they don't stack on top of each other.
 									const numberedRoundsDone = new Set<string>();
 									const badgeStackAtPos = new Map<number, number>();
+									const threadButtonsDone = new Set<string>();
+									const threadButtonStackAtPos = new Map<number, number>();
 									const pushNumberBadge = (roundId: string, pos: number) => {
 										const num = roundNumbers.get(roundId);
 										if (num == null || numberedRoundsDone.has(roundId)) return;
@@ -526,6 +563,27 @@ export const DiffOverlay = Extension.create({
 											)
 										);
 									};
+									const pushThreadButton = (
+										roundId: string,
+										threadId: string | null,
+										pos: number
+									) => {
+										if (!threadId || threadButtonsDone.has(roundId)) return;
+										threadButtonsDone.add(roundId);
+										const stackIdx = threadButtonStackAtPos.get(pos) ?? 0;
+										threadButtonStackAtPos.set(pos, stackIdx + 1);
+										decorations.push(
+											Decoration.widget(
+												pos,
+												(view) => createThreadButton(view, threadId, stackIdx),
+												{
+													side: -1,
+													ignoreSelection: true,
+													key: `threadbtn:${roundId}:${threadId}`
+												}
+											)
+										);
+									};
 
 									for (const block of blocks) {
 										const expanded = revealedRoundIds.has(block.roundId);
@@ -540,11 +598,18 @@ export const DiffOverlay = Extension.create({
 													Decoration.node(
 														paragraph.pos,
 														paragraph.pos + paragraph.nodeSize,
-														{ class: flashing ? 'diff-removed-line diff-flash' : 'diff-removed-line' }
+														{
+															class: flashing ? 'diff-removed-line diff-flash' : 'diff-removed-line',
+															...(block.threadId ? { 'data-thread-id': block.threadId } : {})
+														}
 													)
 												);
 												pushNumberBadge(block.roundId, paragraph.pos + 1);
+												pushThreadButton(block.roundId, block.threadId, paragraph.pos + 1);
 											}
+										}
+										if (block.removedParagraphIdxs.length === 0) {
+											pushThreadButton(block.roundId, block.threadId, block.insertionPos);
 										}
 										// Proposed (green) lines: only when expanded.
 										if (expanded && block.addedLines.length > 0) {
@@ -556,7 +621,7 @@ export const DiffOverlay = Extension.create({
 													Decoration.widget(
 														block.insertionPos,
 														(view, getPos) =>
-															createAddedLineWidget(view, getPos, line, className),
+															createAddedLineWidget(view, getPos, line, className, block.threadId),
 														{
 															side: -1,
 															ignoreSelection: true,
@@ -599,7 +664,7 @@ export const DiffOverlay = Extension.create({
 													Decoration.widget(
 														m.para.pos + m.para.nodeSize,
 														(view, getPos) =>
-															createAddedLineWidget(view, getPos, value, className),
+															createAddedLineWidget(view, getPos, value, className, m.threadId),
 														{
 															side: 1,
 															ignoreSelection: true,
@@ -614,7 +679,8 @@ export const DiffOverlay = Extension.create({
 												m.para,
 												m.afterText,
 												expanded,
-												addedClass
+												addedClass,
+												m.threadId
 											);
 										}
 										if (changeGroups <= 0) continue;
@@ -629,11 +695,13 @@ export const DiffOverlay = Extension.create({
 													class:
 														m.roundId === flashRoundId
 															? 'diff-modified-line diff-flash'
-															: 'diff-modified-line'
+															: 'diff-modified-line',
+													...(m.threadId ? { 'data-thread-id': m.threadId } : {})
 												}
 											)
 										);
 										pushNumberBadge(m.roundId, m.para.pos + 1);
+										pushThreadButton(m.roundId, m.threadId, m.para.pos + 1);
 									}
 								} else if (proposedText !== null && proposedText !== undefined) {
 									let baselineIdx = 0;
@@ -743,7 +811,8 @@ function applyInlineClassRange(
 	charPositions: number[],
 	start: number,
 	end: number,
-	cls: string
+	cls: string,
+	attrs?: Record<string, string>
 ) {
 	let i = start;
 	const clampedEnd = Math.min(end, charPositions.length);
@@ -758,7 +827,7 @@ function applyInlineClassRange(
 		const from = charPositions[i];
 		const to = charPositions[j] + 1;
 		if (from !== undefined && to > from) {
-			decorations.push(Decoration.inline(from, to, { class: cls }));
+			decorations.push(Decoration.inline(from, to, { ...attrs, class: cls }));
 		}
 		i = j + 1;
 	}
@@ -921,10 +990,12 @@ function renderModifiedParagraph(
 	para: ParagraphTextSpan,
 	afterText: string,
 	expanded: boolean,
-	addedClass: string
+	addedClass: string,
+	threadId?: string | null
 ): number {
 	const parts = cachedWordDiff(para.text, afterText);
 	const charPositions = para.localCharPositions;
+	const threadAttrs = threadId ? { 'data-thread-id': threadId } : undefined;
 
 	// Threshold fallback: when most of the paragraph is being rewritten,
 	// the per-token diff turns into a confetti of small strikes around
@@ -947,7 +1018,7 @@ function renderModifiedParagraph(
 	const denom = Math.max(1, para.text.length + afterText.length);
 	const churnRatio = (removedChars + addedChars) / denom;
 	if (churnRatio > 0.8 || groupCount > 6) {
-		applyInlineClassRange(decorations, charPositions, 0, para.text.length, 'diff-removed');
+		applyInlineClassRange(decorations, charPositions, 0, para.text.length, 'diff-removed', threadAttrs);
 		if (expanded && afterText.length > 0) {
 			const widgetPos = ghostPosLocal(para, para.text.length);
 			decorations.push(
@@ -958,6 +1029,7 @@ function renderModifiedParagraph(
 						span.className = addedClass;
 						span.textContent = afterText;
 						span.setAttribute('contenteditable', 'false');
+						if (threadId) span.setAttribute('data-thread-id', threadId);
 						applyProposedLinkAttrs(span, afterText);
 						return span;
 					},
@@ -989,7 +1061,8 @@ function renderModifiedParagraph(
 				charPositions,
 				cursor,
 				cursor + p.text.length,
-				'diff-removed'
+				'diff-removed',
+				threadAttrs
 			);
 			cursor += p.text.length;
 		} else if (expanded) {
@@ -1008,6 +1081,7 @@ function renderModifiedParagraph(
 						span.className = addedClass;
 						span.textContent = value;
 						span.setAttribute('contenteditable', 'false');
+						if (threadId) span.setAttribute('data-thread-id', threadId);
 						applyProposedLinkAttrs(span, value);
 						return span;
 					},
@@ -1035,6 +1109,7 @@ function renderModifiedParagraph(
 						el.className = 'diff-insert-caret';
 						el.setAttribute('contenteditable', 'false');
 						el.setAttribute('aria-hidden', 'true');
+						if (threadId) el.setAttribute('data-thread-id', threadId);
 						return el;
 					},
 					{ side: -1, ignoreSelection: true, key: `inscaret:${para.pos}:${cursor}` }
@@ -1050,7 +1125,8 @@ function createAddedLineWidget(
 	_view: EditorView,
 	_getPos: () => number | undefined,
 	line: string,
-	className: string
+	className: string,
+	threadId?: string | null
 ): HTMLElement {
 	const block = document.createElement('div');
 	block.className = className;
@@ -1061,7 +1137,34 @@ function createAddedLineWidget(
 	// `handleDOMEvents.mousedown` so we don't need a per-widget listener
 	// (and so the closure stays out of the way of HMR / view re-mounts).
 	block.setAttribute('contenteditable', 'false');
+	if (threadId) block.setAttribute('data-thread-id', threadId);
 	return block;
+}
+
+function createThreadButton(view: EditorView, threadId: string, stackIdx: number): HTMLElement {
+	const button = document.createElement('button');
+	button.className = 'diff-thread-btn';
+	button.type = 'button';
+	button.title = 'Open comment thread';
+	button.setAttribute('aria-label', 'Open comment thread');
+	button.setAttribute('contenteditable', 'false');
+	button.setAttribute('data-thread-id', threadId);
+	button.style.setProperty('--thread-i', String(stackIdx));
+	button.innerHTML = `
+		<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+		</svg>
+	`;
+	button.addEventListener('mousedown', (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		dispatchOpenThread(view, button, threadId);
+	});
+	button.addEventListener('click', (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+	});
+	return button;
 }
 
 /** Strip markdown syntax to plain text, matching node.textContent semantics. */

--- a/src/lib/editor/markdown-render.ts
+++ b/src/lib/editor/markdown-render.ts
@@ -1,0 +1,541 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+
+interface LineRange {
+	readonly from: number;
+	readonly to: number;
+}
+
+interface MarkdownTable {
+	readonly id: string;
+	readonly key: string;
+	readonly insertAt: number;
+	readonly sourceLines: readonly LineRange[];
+	readonly headers: readonly string[];
+	readonly rows: readonly string[][];
+	readonly alignments: readonly ('left' | 'center' | 'right')[];
+}
+
+interface MarkdownRenderState {
+	readonly tables: readonly MarkdownTable[];
+	readonly expandedTableIds: ReadonlySet<string>;
+}
+
+interface TableToggleMeta {
+	readonly type: 'table-toggle';
+	readonly id: string;
+}
+
+const mdRenderKey = new PluginKey<MarkdownRenderState>('markdownRender');
+
+/** Regex patterns for inline markdown syntax. */
+const BOLD_RE = /(\*\*|__)(.+?)\1/g;
+const ITALIC_RE = /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)|(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g;
+const CODE_RE = /`([^`]+)`/g;
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+const STRIKETHROUGH_RE = /~~(.+?)~~/g;
+
+function hashString(value: string): string {
+	let hash = 2166136261;
+	for (let i = 0; i < value.length; i += 1) {
+		hash ^= value.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(36);
+}
+
+function splitTableRow(line: string): string[] {
+	let text = line.trim();
+	if (text.startsWith('|')) text = text.slice(1);
+	if (text.endsWith('|')) text = text.slice(0, -1);
+	const cells: string[] = [];
+	let current = '';
+	for (let i = 0; i < text.length; i += 1) {
+		const ch = text[i];
+		if (ch === '\\' && text[i + 1] === '|') {
+			current += '|';
+			i += 1;
+		} else if (ch === '|') {
+			cells.push(current.trim());
+			current = '';
+		} else {
+			current += ch;
+		}
+	}
+	cells.push(current.trim());
+	return cells;
+}
+
+function isPipeRow(line: string): boolean {
+	const cells = splitTableRow(line);
+	return line.includes('|') && cells.length >= 2 && cells.some((cell) => cell.length > 0);
+}
+
+function isSeparatorCell(cell: string): boolean {
+	return /^:?-{3,}:?$/.test(cell.trim());
+}
+
+function parseAlignment(cell: string): 'left' | 'center' | 'right' {
+	const trimmed = cell.trim();
+	if (trimmed.startsWith(':') && trimmed.endsWith(':')) return 'center';
+	if (trimmed.endsWith(':')) return 'right';
+	return 'left';
+}
+
+function normalizeRow(cells: string[], width: number): string[] {
+	return Array.from({ length: width }, (_, i) => cells[i] ?? '');
+}
+
+function scanTables(doc: PMNode): MarkdownTable[] {
+	const lines: Array<{ index: number; pos: number; end: number; text: string }> = [];
+	let pos = 0;
+	for (let i = 0; i < doc.childCount; i += 1) {
+		const child = doc.child(i);
+		const end = pos + child.nodeSize;
+		if (child.type.name === 'paragraph') {
+			lines.push({ index: i, pos, end, text: child.textContent });
+		}
+		pos = end;
+	}
+
+	const tables: MarkdownTable[] = [];
+	for (let i = 0; i < lines.length - 1; i += 1) {
+		const headerLine = lines[i];
+		const separatorLine = lines[i + 1];
+		if (!isPipeRow(headerLine.text) || !isPipeRow(separatorLine.text)) continue;
+		const headers = splitTableRow(headerLine.text);
+		const separator = splitTableRow(separatorLine.text);
+		if (
+			headers.length < 2 ||
+			separator.length !== headers.length ||
+			!separator.every(isSeparatorCell)
+		) {
+			continue;
+		}
+
+		const sourceLines: LineRange[] = [
+			{ from: headerLine.pos, to: headerLine.end },
+			{ from: separatorLine.pos, to: separatorLine.end }
+		];
+		const rows: string[][] = [];
+		let j = i + 2;
+		while (j < lines.length && isPipeRow(lines[j].text)) {
+			const cells = splitTableRow(lines[j].text);
+			sourceLines.push({ from: lines[j].pos, to: lines[j].end });
+			rows.push(normalizeRow(cells, headers.length));
+			j += 1;
+		}
+
+		const raw = lines.slice(i, j).map((line) => line.text).join('\n');
+		const id = `table:${tables.length}`;
+		tables.push({
+			id,
+			key: `${id}:${hashString(raw)}`,
+			insertAt: sourceLines[sourceLines.length - 1].to,
+			sourceLines,
+			headers: normalizeRow(headers, headers.length),
+			rows,
+			alignments: separator.map(parseAlignment)
+		});
+		i = j - 1;
+	}
+	return tables;
+}
+
+function appendInlineMarkdown(parent: HTMLElement, text: string): void {
+	let i = 0;
+	while (i < text.length) {
+		const candidates = [
+			{ marker: '**', tag: 'strong' },
+			{ marker: '__', tag: 'strong' },
+			{ marker: '`', tag: 'code' },
+			{ marker: '*', tag: 'em' },
+			{ marker: '_', tag: 'em' }
+		]
+			.map((candidate) => ({ ...candidate, index: text.indexOf(candidate.marker, i) }))
+			.filter((candidate) => candidate.index >= 0)
+			.sort((a, b) => a.index - b.index || b.marker.length - a.marker.length);
+
+		const next = candidates[0];
+		if (!next) {
+			parent.append(document.createTextNode(text.slice(i)));
+			return;
+		}
+		if (next.index > i) {
+			parent.append(document.createTextNode(text.slice(i, next.index)));
+		}
+		const contentStart = next.index + next.marker.length;
+		const close = text.indexOf(next.marker, contentStart);
+		if (close === -1) {
+			parent.append(document.createTextNode(text.slice(next.index)));
+			return;
+		}
+		const el = document.createElement(next.tag);
+		el.textContent = text.slice(contentStart, close);
+		parent.append(el);
+		i = close + next.marker.length;
+	}
+}
+
+function renderTableWidget(table: MarkdownTable): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'md-table-widget';
+	wrap.setAttribute('contenteditable', 'false');
+
+	const label = document.createElement('div');
+	label.className = 'md-table-label';
+	label.textContent = 'Markdown table';
+	wrap.appendChild(label);
+
+	const scroller = document.createElement('div');
+	scroller.className = 'md-table-scroll';
+	const tableEl = document.createElement('table');
+	tableEl.className = 'md-table-preview';
+
+	const thead = document.createElement('thead');
+	const headTr = document.createElement('tr');
+	table.headers.forEach((header, i) => {
+		const th = document.createElement('th');
+		th.style.textAlign = table.alignments[i] ?? 'left';
+		appendInlineMarkdown(th, header);
+		headTr.appendChild(th);
+	});
+	thead.appendChild(headTr);
+	tableEl.appendChild(thead);
+
+	const tbody = document.createElement('tbody');
+	for (const row of table.rows) {
+		const tr = document.createElement('tr');
+		row.forEach((cell, i) => {
+			const td = document.createElement('td');
+			td.style.textAlign = table.alignments[i] ?? 'left';
+			appendInlineMarkdown(td, cell);
+			tr.appendChild(td);
+		});
+		tbody.appendChild(tr);
+	}
+	tableEl.appendChild(tbody);
+
+	scroller.appendChild(tableEl);
+	wrap.appendChild(scroller);
+	return wrap;
+}
+
+function dispatchTableToggle(view: EditorView, tableId: string): void {
+	view.dispatch(view.state.tr.setMeta(mdRenderKey, { type: 'table-toggle', id: tableId } satisfies TableToggleMeta));
+	requestAnimationFrame(() => {
+		view.dom.dispatchEvent(new CustomEvent('docwriter:markdown-layout-changed', { bubbles: true }));
+	});
+}
+
+function renderTableSourceToggle(table: MarkdownTable, expanded: boolean, view: EditorView): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'md-table-source-toggle';
+	wrap.setAttribute('contenteditable', 'false');
+
+	const button = document.createElement('button');
+	button.className = 'md-table-source-toggle-btn';
+	button.type = 'button';
+	button.textContent = expanded ? 'hide table source' : 'show table source';
+	button.setAttribute('aria-label', expanded ? 'Hide table source' : 'Show table source');
+	button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+	button.addEventListener('click', (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		dispatchTableToggle(view, table.id);
+	});
+	wrap.appendChild(button);
+	return wrap;
+}
+
+function buildDecorations(state: MarkdownRenderState, doc: PMNode): DecorationSet {
+	const decorations: Decoration[] = [];
+	const tableLineStarts = new Set<number>();
+
+	for (const table of state.tables) {
+		if (table.insertAt > doc.content.size) continue;
+		const expanded = state.expandedTableIds.has(table.id);
+		const firstLine = table.sourceLines[0];
+		if (firstLine) {
+			decorations.push(
+				Decoration.widget(firstLine.to, (view) => renderTableSourceToggle(table, expanded, view), {
+					side: 1,
+					key: `${table.key}:source-toggle:${expanded ? 'open' : 'closed'}`,
+					ignoreSelection: true
+				})
+			);
+		}
+		for (const line of table.sourceLines) {
+			tableLineStarts.add(line.from);
+			decorations.push(
+				Decoration.node(line.from, line.to, {
+					class: expanded
+						? 'md-table-source-line md-table-source-line-expanded'
+						: 'md-table-source-line md-table-source-line-hidden'
+				})
+			);
+		}
+		decorations.push(
+			Decoration.widget(table.insertAt, () => renderTableWidget(table), {
+				side: 1,
+				key: `${table.key}:preview`,
+				ignoreSelection: true
+			})
+		);
+	}
+
+	doc.descendants((node, pos) => {
+		if (node.type.name !== 'paragraph') return;
+		const text = node.textContent;
+		if (!text) return;
+		const start = pos + 1;
+		if (tableLineStarts.has(pos)) {
+			addInlineDecorations(text, start, decorations);
+			return false;
+		}
+
+		// Heading lines: # through ######
+		const headingMatch = text.match(/^(#{1,6})\s/);
+		if (headingMatch) {
+			const level = headingMatch[1].length;
+			decorations.push(
+				Decoration.node(pos, pos + node.nodeSize, {
+					class: `md-heading md-h${level}`
+				})
+			);
+			decorations.push(
+				Decoration.inline(start, start + headingMatch[0].length, {
+					class: 'md-syntax'
+				})
+			);
+			addInlineDecorations(text, start, decorations);
+			return false;
+		}
+
+		// Blockquote lines: >
+		const bqMatch = text.match(/^(>\s?)/);
+		if (bqMatch) {
+			decorations.push(
+				Decoration.node(pos, pos + node.nodeSize, {
+					class: 'md-blockquote'
+				})
+			);
+			decorations.push(
+				Decoration.inline(start, start + bqMatch[0].length, {
+					class: 'md-syntax'
+				})
+			);
+			addInlineDecorations(text, start, decorations);
+			return false;
+		}
+
+		// Unordered list: - or * at start
+		const ulMatch = text.match(/^(\s*[-*+]\s)/);
+		if (ulMatch) {
+			decorations.push(
+				Decoration.node(pos, pos + node.nodeSize, {
+					class: 'md-list-item'
+				})
+			);
+			decorations.push(
+				Decoration.inline(start, start + ulMatch[0].length, {
+					class: 'md-syntax md-list-marker md-bullet'
+				})
+			);
+			addInlineDecorations(text, start, decorations);
+			return false;
+		}
+
+		// Ordered list: 1. 2. etc.
+		const olMatch = text.match(/^(\s*\d+[.)]\s)/);
+		if (olMatch) {
+			decorations.push(
+				Decoration.node(pos, pos + node.nodeSize, {
+					class: 'md-list-item md-ol-item'
+				})
+			);
+			decorations.push(
+				Decoration.inline(start, start + olMatch[0].length, {
+					class: 'md-syntax md-list-marker md-ordered-marker'
+				})
+			);
+			addInlineDecorations(text, start, decorations);
+			return false;
+		}
+
+		// Horizontal rule
+		if (/^(---|\*\*\*|___)\s*$/.test(text)) {
+			decorations.push(
+				Decoration.node(pos, pos + node.nodeSize, {
+					class: 'md-hr'
+				})
+			);
+			return false;
+		}
+
+		// Regular paragraph: just inline decorations
+		addInlineDecorations(text, start, decorations);
+		return false;
+	});
+
+	return DecorationSet.create(doc, decorations);
+}
+
+function addInlineDecorations(
+	text: string,
+	start: number,
+	decorations: Decoration[]
+) {
+	// Track which character positions are already decorated to avoid overlaps
+	const claimed = new Set<number>();
+
+	function claim(from: number, to: number): boolean {
+		for (let i = from; i < to; i++) {
+			if (claimed.has(i)) return false;
+		}
+		for (let i = from; i < to; i++) claimed.add(i);
+		return true;
+	}
+
+	// Bold: **text** or __text__
+	let m: RegExpExecArray | null;
+	BOLD_RE.lastIndex = 0;
+	while ((m = BOLD_RE.exec(text)) !== null) {
+		const mLen = m[1].length; // 2 for ** or __
+		const from = m.index;
+		const to = from + m[0].length;
+		if (!claim(from, to)) continue;
+		// Dim opening marker
+		decorations.push(
+			Decoration.inline(start + from, start + from + mLen, { class: 'md-syntax' })
+		);
+		// Bold content
+		decorations.push(
+			Decoration.inline(start + from + mLen, start + to - mLen, { class: 'md-bold' })
+		);
+		// Dim closing marker
+		decorations.push(
+			Decoration.inline(start + to - mLen, start + to, { class: 'md-syntax' })
+		);
+	}
+
+	// Italic: *text* or _text_ (not ** or __)
+	ITALIC_RE.lastIndex = 0;
+	while ((m = ITALIC_RE.exec(text)) !== null) {
+		const from = m.index;
+		const to = from + m[0].length;
+		if (!claim(from, to)) continue;
+		decorations.push(
+			Decoration.inline(start + from, start + from + 1, { class: 'md-syntax' })
+		);
+		decorations.push(
+			Decoration.inline(start + from + 1, start + to - 1, { class: 'md-italic' })
+		);
+		decorations.push(
+			Decoration.inline(start + to - 1, start + to, { class: 'md-syntax' })
+		);
+	}
+
+	// Inline code: `text`
+	CODE_RE.lastIndex = 0;
+	while ((m = CODE_RE.exec(text)) !== null) {
+		const from = m.index;
+		const to = from + m[0].length;
+		if (!claim(from, to)) continue;
+		decorations.push(
+			Decoration.inline(start + from, start + from + 1, { class: 'md-syntax' })
+		);
+		decorations.push(
+			Decoration.inline(start + from + 1, start + to - 1, { class: 'md-code' })
+		);
+		decorations.push(
+			Decoration.inline(start + to - 1, start + to, { class: 'md-syntax' })
+		);
+	}
+
+	// Strikethrough: ~~text~~
+	STRIKETHROUGH_RE.lastIndex = 0;
+	while ((m = STRIKETHROUGH_RE.exec(text)) !== null) {
+		const from = m.index;
+		const to = from + m[0].length;
+		if (!claim(from, to)) continue;
+		decorations.push(
+			Decoration.inline(start + from, start + from + 2, { class: 'md-syntax' })
+		);
+		decorations.push(
+			Decoration.inline(start + from + 2, start + to - 2, { class: 'md-strikethrough' })
+		);
+		decorations.push(
+			Decoration.inline(start + to - 2, start + to, { class: 'md-syntax' })
+		);
+	}
+
+	// Links: [text](url)
+	LINK_RE.lastIndex = 0;
+	while ((m = LINK_RE.exec(text)) !== null) {
+		const from = m.index;
+		const to = from + m[0].length;
+		if (!claim(from, to)) continue;
+		const linkTextEnd = from + 1 + m[1].length;
+		// [ syntax
+		decorations.push(
+			Decoration.inline(start + from, start + from + 1, { class: 'md-syntax' })
+		);
+		// link text
+		decorations.push(
+			Decoration.inline(start + from + 1, start + linkTextEnd, { class: 'md-link-text' })
+		);
+		// ](url) part
+		decorations.push(
+			Decoration.inline(start + linkTextEnd, start + to, { class: 'md-syntax md-link-url' })
+		);
+	}
+}
+
+export const MarkdownRender = Extension.create({
+	name: 'markdownRender',
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<MarkdownRenderState>({
+				key: mdRenderKey,
+				state: {
+					init: (_config, instance): MarkdownRenderState => ({
+						tables: scanTables(instance.doc),
+						expandedTableIds: new Set()
+					}),
+					apply(tr, prev): MarkdownRenderState {
+						const meta = tr.getMeta(mdRenderKey) as TableToggleMeta | undefined;
+						let next = prev;
+						if (tr.docChanged) {
+							const tables = scanTables(tr.doc);
+							const tableIds = new Set(tables.map((table) => table.id));
+							next = {
+								tables,
+								expandedTableIds: new Set(
+									Array.from(prev.expandedTableIds).filter((id) => tableIds.has(id))
+								)
+							};
+						}
+						if (meta?.type === 'table-toggle') {
+							const expandedTableIds = new Set(next.expandedTableIds);
+							if (expandedTableIds.has(meta.id)) expandedTableIds.delete(meta.id);
+							else expandedTableIds.add(meta.id);
+							next = { ...next, expandedTableIds };
+						}
+						return next;
+					}
+				},
+				props: {
+					decorations(state) {
+						const s = mdRenderKey.getState(state);
+						if (!s) return null;
+						return buildDecorations(s, state.doc);
+					}
+				}
+			})
+		];
+	}
+});

--- a/src/lib/editor/media-overlay.ts
+++ b/src/lib/editor/media-overlay.ts
@@ -71,6 +71,23 @@ interface ParagraphMedia {
 	readonly tokens: readonly MediaToken[];
 }
 
+interface BlockLineRange {
+	readonly from: number;
+	readonly to: number;
+}
+
+interface SvgBlock {
+	readonly id: string;
+	/** PM position immediately after the closing </svg> paragraph. */
+	readonly insertAt: number;
+	/** Raw SVG markup reconstructed from the markdown source lines. */
+	readonly markup: string;
+	/** Paragraph ranges for the raw SVG source lines. */
+	readonly sourceLines: readonly BlockLineRange[];
+	/** Stable key so the preview updates when the SVG source changes. */
+	readonly key: string;
+}
+
 type OgState =
 	| { readonly kind: 'loading' }
 	| {
@@ -97,6 +114,8 @@ interface InlineLink {
 
 interface MediaOverlayState {
 	readonly paragraphs: readonly ParagraphMedia[];
+	readonly svgBlocks: readonly SvgBlock[];
+	readonly expandedSvgIds: ReadonlySet<string>;
 	readonly inlineLinks: readonly InlineLink[];
 	/** og fetch results keyed by URL. Survives across transactions so a
 	 * fetch that resolves three keystrokes after it was started still
@@ -128,6 +147,15 @@ const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg|bmp|avif)(\?.*)?$/i;
  * a WeakMap on the node lets us skip the regex pass for paragraphs the
  * user didn't touch. Same trick the diff overlay uses for word diffs. */
 const scanCache = new WeakMap<PMNode, MediaToken[]>();
+
+function hashString(value: string): string {
+	let hash = 2166136261;
+	for (let i = 0; i < value.length; i += 1) {
+		hash ^= value.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(36);
+}
 
 function scanParagraphTokens(node: PMNode): MediaToken[] {
 	const cached = scanCache.get(node);
@@ -183,6 +211,63 @@ function scanDoc(doc: PMNode): ParagraphMedia[] {
 					key: `${i}:${child.textContent.length}:${tokens.map(tokenKey).join('|')}`,
 					tokens
 				});
+			}
+		}
+		pos = childEnd;
+	}
+	return out;
+}
+
+/** Detect raw SVG blocks written directly in markdown:
+ *
+ *   <svg ...>
+ *     ...
+ *   </svg>
+ *
+ * The editor still stores and edits those lines as plain text; this only
+ * adds a rendered preview after the closing tag. */
+function scanSvgBlocks(doc: PMNode): SvgBlock[] {
+	const out: SvgBlock[] = [];
+	let pos = 0;
+	let inSvg = false;
+	let lines: string[] = [];
+	let sourceLines: BlockLineRange[] = [];
+	let blockIndex = 0;
+
+	function finishSvgBlock(insertAt: number) {
+		const markup = lines.join('\n');
+		const id = `svg:${blockIndex}`;
+		out.push({
+			id,
+			insertAt,
+			markup,
+			sourceLines,
+			key: `${id}:${hashString(markup)}`
+		});
+		blockIndex += 1;
+		inSvg = false;
+		lines = [];
+		sourceLines = [];
+	}
+
+	for (let i = 0; i < doc.childCount; i += 1) {
+		const child = doc.child(i);
+		const childEnd = pos + child.nodeSize;
+		if (child.type.name === 'paragraph') {
+			const text = child.textContent;
+			if (!inSvg && /^\s*<svg\b/i.test(text)) {
+				inSvg = true;
+				lines = [text];
+				sourceLines = [{ from: pos, to: childEnd }];
+				if (/<\/svg>\s*$/i.test(text)) {
+					finishSvgBlock(childEnd);
+				}
+			} else if (inSvg) {
+				lines.push(text);
+				sourceLines.push({ from: pos, to: childEnd });
+				if (/<\/svg>\s*$/i.test(text)) {
+					finishSvgBlock(childEnd);
+				}
 			}
 		}
 		pos = childEnd;
@@ -288,6 +373,61 @@ function renderImageWidget(token: ImageToken): HTMLElement {
 		wrap.replaceChildren(note);
 	});
 	wrap.appendChild(img);
+	return wrap;
+}
+
+function renderSvgWidget(block: SvgBlock): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'media-widget media-svg-widget';
+	wrap.setAttribute('contenteditable', 'false');
+
+	const label = document.createElement('div');
+	label.className = 'media-svg-label';
+	label.textContent = 'SVG preview';
+	wrap.appendChild(label);
+
+	const img = document.createElement('img');
+	img.className = 'media-thumb media-svg-thumb';
+	img.loading = 'eager';
+	img.alt = 'SVG preview';
+	img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(block.markup)}`;
+	img.draggable = false;
+	img.addEventListener('error', () => {
+		wrap.classList.add('media-thumb-error');
+		const note = document.createElement('div');
+		note.className = 'media-thumb-error-label';
+		note.textContent = "Couldn't render SVG preview";
+		wrap.replaceChildren(note);
+	});
+	wrap.appendChild(img);
+	return wrap;
+}
+
+function dispatchSvgToggle(view: EditorView, blockId: string): void {
+	view.dispatch(view.state.tr.setMeta(mediaKey, { type: 'svg-toggle', id: blockId } satisfies SvgToggleMeta));
+	requestAnimationFrame(() => {
+		view.dom.dispatchEvent(new CustomEvent('docwriter:media-layout-changed', { bubbles: true }));
+	});
+}
+
+function renderSvgSourceToggle(block: SvgBlock, expanded: boolean, view: EditorView): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'svg-source-toggle';
+	wrap.setAttribute('contenteditable', 'false');
+
+	const button = document.createElement('button');
+	button.className = 'svg-source-toggle-btn';
+	button.type = 'button';
+	button.textContent = expanded ? 'hide SVG source' : 'show SVG source';
+	button.setAttribute('aria-label', expanded ? 'Hide SVG source' : 'Show SVG source');
+	button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+	button.addEventListener('click', (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		dispatchSvgToggle(view, block.id);
+	});
+	wrap.appendChild(button);
+
 	return wrap;
 }
 
@@ -416,6 +556,34 @@ function buildDecorations(state: MediaOverlayState, doc: PMNode): DecorationSet 
 			}
 		}
 	}
+	for (const block of state.svgBlocks) {
+		if (block.insertAt > doc.content.size) continue;
+		const expanded = state.expandedSvgIds.has(block.id);
+		const firstLine = block.sourceLines[0];
+		if (firstLine) {
+			decorations.push(
+				Decoration.widget(firstLine.to, (view) => renderSvgSourceToggle(block, expanded, view), {
+					side: 1,
+					key: `${block.key}:source-toggle:${expanded ? 'open' : 'closed'}`,
+					ignoreSelection: true
+				})
+			);
+		}
+		for (const line of block.sourceLines) {
+			decorations.push(
+				Decoration.node(line.from, line.to, {
+					class: expanded ? 'svg-source-line svg-source-line-expanded' : 'svg-source-line svg-source-line-hidden'
+				})
+			);
+		}
+		decorations.push(
+			Decoration.widget(block.insertAt, () => renderSvgWidget(block), {
+				side: 1,
+				key: `${block.key}:preview`,
+				ignoreSelection: true
+			})
+		);
+	}
 	// Inline link marks. Both safe attributes (`class`, `data-url`) make
 	// it trivially easy for the view-level hover handler to find the
 	// hovered link's URL without any extra plugin state lookups.
@@ -460,6 +628,13 @@ interface OgFetchedMeta {
 	readonly value: Exclude<OgState, { kind: 'loading' }>;
 }
 
+interface SvgToggleMeta {
+	readonly type: 'svg-toggle';
+	readonly id: string;
+}
+
+type MediaOverlayMeta = OgFetchedMeta | SvgToggleMeta;
+
 export const MediaOverlay = Extension.create({
 	name: 'mediaOverlay',
 	addProseMirrorPlugins() {
@@ -469,24 +644,37 @@ export const MediaOverlay = Extension.create({
 				state: {
 					init: (_config, instance): MediaOverlayState => ({
 						paragraphs: scanDoc(instance.doc),
+						svgBlocks: scanSvgBlocks(instance.doc),
+						expandedSvgIds: new Set(),
 						inlineLinks: scanInlineLinks(instance.doc),
 						ogByUrl: new Map(),
 						version: 0
 					}),
 					apply(tr, prev): MediaOverlayState {
-						const meta = tr.getMeta(mediaKey) as OgFetchedMeta | undefined;
+						const meta = tr.getMeta(mediaKey) as MediaOverlayMeta | undefined;
 						let next = prev;
 						if (tr.docChanged) {
 							// `tr.doc` is the post-transaction doc — same as the
 							// in-flight newState's doc but doesn't require us to
 							// rely on partial-state semantics during construction.
+							const svgBlocks = scanSvgBlocks(tr.doc);
+							const svgBlockIds = new Set(svgBlocks.map((block) => block.id));
 							next = {
 								...next,
 								paragraphs: scanDoc(tr.doc),
+								svgBlocks,
+								expandedSvgIds: new Set(
+									Array.from(next.expandedSvgIds).filter((id) => svgBlockIds.has(id))
+								),
 								inlineLinks: scanInlineLinks(tr.doc)
 							};
 						}
-						if (meta?.type === 'og-fetched') {
+						if (meta?.type === 'svg-toggle') {
+							const expandedSvgIds = new Set(next.expandedSvgIds);
+							if (expandedSvgIds.has(meta.id)) expandedSvgIds.delete(meta.id);
+							else expandedSvgIds.add(meta.id);
+							next = { ...next, expandedSvgIds };
+						} else if (meta?.type === 'og-fetched') {
 							const ogByUrl = new Map(next.ogByUrl);
 							ogByUrl.set(meta.url, meta.value);
 							next = { ...next, ogByUrl, version: next.version + 1 };
@@ -702,4 +890,3 @@ async function fetchOgInto(view: EditorView, url: string): Promise<void> {
 		/* editor destroyed mid-fetch; nothing to update */
 	}
 }
-

--- a/src/lib/editor/source-comment-overlay.ts
+++ b/src/lib/editor/source-comment-overlay.ts
@@ -1,0 +1,162 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import type { Node as PMNode } from '@tiptap/pm/model';
+
+export type SourceCommentStyle =
+	| { kind: 'line'; marker: string }
+	| { kind: 'block'; open: string; close: string };
+
+interface SourceCommentOptions {
+	style: SourceCommentStyle | null;
+}
+
+const sourceCommentKey = new PluginKey('sourceCommentOverlay');
+
+function isEscaped(text: string, index: number): boolean {
+	let slashCount = 0;
+	for (let i = index - 1; i >= 0 && text[i] === '\\'; i -= 1) {
+		slashCount += 1;
+	}
+	return slashCount % 2 === 1;
+}
+
+function findUnescapedMarker(text: string, marker: string): number {
+	let index = text.indexOf(marker);
+	while (index >= 0) {
+		if (!isEscaped(text, index)) return index;
+		index = text.indexOf(marker, index + marker.length);
+	}
+	return -1;
+}
+
+function findLineCommentStart(text: string, marker: string): number {
+	const indentLength = text.match(/^\s*/)?.[0].length ?? 0;
+	if (text.slice(indentLength).startsWith(marker)) return indentLength;
+
+	// TeX comments are often inline (`text % note`). Other languages need
+	// real parsers to avoid false positives in strings and URLs, so keep
+	// those to full-line comments for now.
+	if (marker === '%') return findUnescapedMarker(text, marker);
+	return -1;
+}
+
+function addLineCommentDecorations(
+	doc: PMNode,
+	marker: string,
+	decorations: Decoration[]
+) {
+	doc.descendants((node, pos) => {
+		if (node.type.name !== 'paragraph') return;
+		const text = node.textContent;
+		if (!text) return false;
+		const commentStart = findLineCommentStart(text, marker);
+		if (commentStart < 0) return false;
+		const start = pos + 1;
+		decorations.push(
+			Decoration.inline(start + commentStart, start + text.length, {
+				class: 'source-comment'
+			})
+		);
+		return false;
+	});
+}
+
+function addBlockCommentDecorations(
+	doc: PMNode,
+	openToken: string,
+	closeToken: string,
+	decorations: Decoration[]
+) {
+	const open = openToken.trim();
+	const close = closeToken.trim();
+	if (!open || !close) return;
+
+	let inBlock = false;
+	doc.descendants((node, pos) => {
+		if (node.type.name !== 'paragraph') return;
+		const text = node.textContent;
+		if (!text && !inBlock) return false;
+		const start = pos + 1;
+		let cursor = 0;
+
+		while (cursor < text.length) {
+			if (inBlock) {
+				const closeIndex = text.indexOf(close, cursor);
+				if (closeIndex < 0) {
+					decorations.push(
+						Decoration.inline(start + cursor, start + text.length, {
+							class: 'source-comment'
+						})
+					);
+					return false;
+				}
+				decorations.push(
+					Decoration.inline(start + cursor, start + closeIndex + close.length, {
+						class: 'source-comment'
+					})
+				);
+				cursor = closeIndex + close.length;
+				inBlock = false;
+				continue;
+			}
+
+			const openIndex = text.indexOf(open, cursor);
+			if (openIndex < 0) return false;
+			const closeIndex = text.indexOf(close, openIndex + open.length);
+			if (closeIndex < 0) {
+				decorations.push(
+					Decoration.inline(start + openIndex, start + text.length, {
+						class: 'source-comment'
+					})
+				);
+				inBlock = true;
+				return false;
+			}
+			decorations.push(
+				Decoration.inline(start + openIndex, start + closeIndex + close.length, {
+					class: 'source-comment'
+				})
+			);
+			cursor = closeIndex + close.length;
+		}
+
+		return false;
+	});
+}
+
+function buildDecorations(style: SourceCommentStyle | null, doc: PMNode): DecorationSet {
+	if (!style) return DecorationSet.empty;
+	const decorations: Decoration[] = [];
+	if (style.kind === 'line') {
+		addLineCommentDecorations(doc, style.marker, decorations);
+	} else {
+		addBlockCommentDecorations(doc, style.open, style.close, decorations);
+	}
+	if (decorations.length === 0) return DecorationSet.empty;
+	return DecorationSet.create(doc, decorations);
+}
+
+export const SourceCommentOverlay = Extension.create<SourceCommentOptions>({
+	name: 'sourceCommentOverlay',
+
+	addOptions() {
+		return {
+			style: null
+		};
+	},
+
+	addProseMirrorPlugins() {
+		const style = this.options.style;
+		return [
+			new Plugin({
+				key: sourceCommentKey,
+				props: {
+					decorations(state) {
+						return buildDecorations(style, state.doc);
+					}
+				}
+			})
+		];
+	}
+});

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -29,6 +29,8 @@ import {
 	type HookEvent
 } from '$lib/server/hooks-config';
 import { runHookCommand, type HookRunEmitter } from '$lib/server/hook-runner';
+import { addCustomSkill } from '$lib/server/skills-config';
+import { executeReviewAction } from './tool-handlers';
 
 const PROPOSE_RULE_TOOL_NAME = 'mcp__docwriter__propose_rule';
 const PROPOSE_HOOK_TOOL_NAME = 'mcp__docwriter__propose_hook';
@@ -68,6 +70,49 @@ function buildDocwriterMcp() {
 					reason: z.string().optional().describe('Explanation.')
 				},
 				async () => ({ content: [{ type: 'text', text: 'Hook proposal sent to the user for review.' }] })
+			),
+			tool(
+				'add_skill',
+				'Add an Agent Skill to DocWriter from a GitHub repository URL or local skill path.',
+				{
+					source: z.string().describe('A GitHub repository URL, local skill directory, or local SKILL.md path.')
+				},
+				async ({ source }) => {
+					try {
+						addCustomSkill(source);
+						return {
+							content: [{
+								type: 'text',
+								text: `Added skill from ${source}. It is now enabled and synced to native skill folders.`
+							}]
+						};
+					} catch (err) {
+						return {
+							content: [{
+								type: 'text',
+								text: `add_skill failed: ${(err as Error).message}`
+							}],
+							isError: true
+						};
+					}
+				}
+			),
+			tool(
+				'review_action',
+				'Accept/reject pending review edits or resolve/reopen comment threads ONLY when the user explicitly asks you to do that action. This mutates document review state.',
+				{
+					path: z.string().describe('Workspace-relative path or absolute path inside the workspace.'),
+					action: z.enum(['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread']).describe('The explicit review action requested by the user.'),
+					round_id: z.string().optional().describe('Required for accept_round or reject_round.'),
+					thread_id: z.string().optional().describe('Required for resolve_thread or reopen_thread.')
+				},
+				async (input) => {
+					const result = await executeReviewAction(input);
+					return {
+						content: result.content.map((c) => ({ type: 'text' as const, text: c.text })),
+						...(result.isError ? { isError: true } : {})
+					};
+				}
 			)
 		]
 	});
@@ -111,7 +156,7 @@ export class ClaudeProvider implements AgentProvider {
 			agentProgressSummaries: true,
 			effort: options.effort || 'low',
 			...(options.abortSignal ? { abortController: { signal: options.abortSignal, abort() { /* unused */ } } } : {}),
-			...(options.hooks || {}),
+			...(options.hooks ? { hooks: options.hooks } : {}),
 			...(canUseToolCb ? {
 				canUseTool: async (toolName: string, toolInput: any) => {
 					const result = await canUseToolCb(toolName, toolInput);

--- a/src/lib/server/providers/codex.ts
+++ b/src/lib/server/providers/codex.ts
@@ -11,6 +11,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { WORKSPACE_ROOT } from '$lib/server/document-files';
 import type {
 	AgentProvider,
 	ProviderEvent,
@@ -242,7 +243,7 @@ export class CodexProvider implements AgentProvider {
 	private async getThread(options: ProviderQueryOptions): Promise<any> {
 		const client = await this.getClient();
 		const threadOptions = {
-			workingDirectory: process.cwd(),
+			workingDirectory: WORKSPACE_ROOT,
 			skipGitRepoCheck: true,
 			sandboxMode: 'read-only',
 			approvalPolicy: 'never',

--- a/src/lib/server/providers/cursor.ts
+++ b/src/lib/server/providers/cursor.ts
@@ -13,6 +13,7 @@ import type {
 } from './types';
 import { buildToolDefinitions } from './tool-handlers';
 import { randomUUID } from 'node:crypto';
+import { WORKSPACE_ROOT } from '$lib/server/document-files';
 
 /** Cursor wraps custom-tool results in a synthetic-MCP envelope, e.g.
  * `{status, value:{content:[{text:{text:"…"}}], isError}}` or
@@ -113,7 +114,7 @@ export class CursorProvider implements AgentProvider {
 				apiKey: process.env.CURSOR_API_KEY,
 				model: { id: model },
 				local: {
-					cwd: process.cwd(),
+					cwd: WORKSPACE_ROOT,
 					customTools
 				}
 			});

--- a/src/lib/server/providers/pi.ts
+++ b/src/lib/server/providers/pi.ts
@@ -15,6 +15,7 @@ import type {
 } from './types';
 import { buildToolDefinitions } from './tool-handlers';
 import { randomUUID } from 'node:crypto';
+import { WORKSPACE_ROOT } from '$lib/server/document-files';
 
 let sdkLoaded = false;
 let createAgentSession: any = null;
@@ -133,11 +134,12 @@ export class PiProvider implements AgentProvider {
 		const modelRegistry = ModelRegistry.create(authStorage);
 
 		const sessionOpts: any = {
+			cwd: WORKSPACE_ROOT,
 			sessionManager: SessionManager.inMemory(),
 			authStorage,
 			modelRegistry,
 			customTools: piTools,
-			noTools: 'builtin'
+			tools: ['read', ...allTools.map((toolDef) => toolDef.name)]
 		};
 
 		if (options.model) {

--- a/src/lib/server/providers/tool-handlers.ts
+++ b/src/lib/server/providers/tool-handlers.ts
@@ -33,12 +33,92 @@ import type {
 	CommentThread
 } from '$lib/types';
 import { resolveWorkspacePath } from '$lib/server/workspace-path';
+import { addCustomSkill, readEnabledSkill } from '$lib/server/skills-config';
+import {
+	acceptTabRounds,
+	flushTabMarkdownNow,
+	rejectTabRounds,
+	setThreadResolution
+} from '$lib/server/ws-server';
 
 function toToolResult(r: any): ToolResult {
 	const textContent = (r.content ?? [])
 		.filter((c: any) => c.type === 'text' && typeof c.text === 'string')
 		.map((c: any) => ({ type: 'text' as const, text: c.text as string }));
 	return { content: textContent, isError: r.isError };
+}
+
+export async function executeReviewAction(input: unknown): Promise<ToolResult> {
+	const { path, action, round_id, thread_id } = input as {
+		path?: string;
+		action?: string;
+		round_id?: string;
+		thread_id?: string;
+	};
+	if (!path) {
+		return { isError: true, content: [{ type: 'text' as const, text: 'review_action requires `path`.' }] };
+	}
+	const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
+	if (!opened.ok) return toToolResult(opened.error);
+	const tabId = opened.tabId;
+
+	try {
+		if (action === 'accept_round' || action === 'accept_all') {
+			if (action === 'accept_round' && !round_id) {
+				return { isError: true, content: [{ type: 'text' as const, text: 'accept_round requires `round_id`.' }] };
+			}
+			const result = await acceptTabRounds(tabId, action === 'accept_round' ? round_id : undefined);
+			try { flushTabMarkdownNow(tabId); } catch { /* best effort */ }
+			return {
+				content: [{
+					type: 'text' as const,
+					text: `Accepted ${result.acceptedCount} review edit${result.acceptedCount === 1 ? '' : 's'} in ${path}.`
+				}]
+			};
+		}
+		if (action === 'reject_round' || action === 'reject_all') {
+			if (action === 'reject_round' && !round_id) {
+				return { isError: true, content: [{ type: 'text' as const, text: 'reject_round requires `round_id`.' }] };
+			}
+			const result = await rejectTabRounds(tabId, action === 'reject_round' ? round_id : undefined);
+			return {
+				content: [{
+					type: 'text' as const,
+					text: `Rejected ${result.rejectedCount} review edit${result.rejectedCount === 1 ? '' : 's'} in ${path}.`
+				}]
+			};
+		}
+		if (action === 'resolve_thread' || action === 'reopen_thread') {
+			if (!thread_id) {
+				return { isError: true, content: [{ type: 'text' as const, text: `${action} requires \`thread_id\`.` }] };
+			}
+			const result = await setThreadResolution(tabId, thread_id, action === 'resolve_thread');
+			if (!result.ok) {
+				return { isError: true, content: [{ type: 'text' as const, text: `Thread "${thread_id}" was not found in ${path}.` }] };
+			}
+			return {
+				content: [{
+					type: 'text' as const,
+					text: `${action === 'resolve_thread' ? 'Resolved' : 'Reopened'} thread ${thread_id} in ${path}.`
+				}]
+			};
+		}
+		return {
+			isError: true,
+			content: [{
+				type: 'text' as const,
+				text: 'Unknown review action. Use accept_round, accept_all, reject_round, reject_all, resolve_thread, or reopen_thread.'
+			}]
+		};
+	} catch (err) {
+		return {
+			isError: true,
+			content: [{
+				type: 'text' as const,
+				text: `review_action failed: ${(err as Error).message}`
+			}]
+		};
+	}
 }
 
 export function buildToolDefinitions(): ToolDefinition[] {
@@ -189,6 +269,87 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			}
 		},
 		{
+			name: 'read_skill',
+			description: 'Read the full instructions for an enabled DocWriter skill by name.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					name: { type: 'string', description: 'Skill name, e.g. plain-writing.' }
+				},
+				required: ['name']
+			},
+			execute: async (input) => {
+				const { name } = input as { name: string };
+				const skill = readEnabledSkill(name);
+				if (!skill) {
+					return {
+						isError: true,
+						content: [{ type: 'text' as const, text: `Skill "${name}" is not enabled or does not exist.` }]
+					};
+				}
+				return {
+					content: [{
+						type: 'text' as const,
+						text: `Skill: ${skill.name}\nPath: ${skill.path}\n\n${skill.content}`
+					}]
+				};
+			}
+		},
+		{
+			name: 'add_skill',
+			description: 'Add an Agent Skill to DocWriter from a GitHub repository URL or local skill path.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					source: {
+						type: 'string',
+						description: 'A GitHub repository URL, local skill directory, or local SKILL.md path.'
+					}
+				},
+				required: ['source']
+			},
+			execute: async (input) => {
+				const { source } = input as { source: string };
+				try {
+					addCustomSkill(source);
+					return {
+						content: [{
+							type: 'text' as const,
+							text: `Added skill from ${source}. It is now enabled and synced to the native skill folders.`
+						}]
+					};
+				} catch (err) {
+					return {
+						isError: true,
+						content: [{
+							type: 'text' as const,
+							text: `add_skill failed: ${(err as Error).message}`
+						}]
+					};
+				}
+			}
+		},
+		{
+			name: 'review_action',
+			description:
+				'Accept/reject pending review edits or resolve/reopen comment threads ONLY when the user explicitly asks you to do that action. This mutates document review state.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					path: { type: 'string', description: 'Workspace-relative path or absolute path inside the workspace.' },
+					action: {
+						type: 'string',
+						enum: ['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread'],
+						description: 'The explicit review action requested by the user.'
+					},
+					round_id: { type: 'string', description: 'Required for accept_round or reject_round.' },
+					thread_id: { type: 'string', description: 'Required for resolve_thread or reopen_thread.' }
+				},
+				required: ['path', 'action']
+			},
+			execute: executeReviewAction
+		},
+		{
 			name: 'propose_rule',
 			description: 'Propose a writing rule for the user to review.',
 			inputSchema: {
@@ -315,6 +476,9 @@ export const TOOL_NAMES = {
 	EDIT_DOC: 'edit_doc',
 	READ_DOC: 'read_doc',
 	WRITE_DOC: 'write_doc',
+	READ_SKILL: 'read_skill',
+	ADD_SKILL: 'add_skill',
+	REVIEW_ACTION: 'review_action',
 	PROPOSE_RULE: 'propose_rule',
 	PROPOSE_HOOK: 'propose_hook',
 	REPLY_TO_COMMENT: 'reply_to_comment',

--- a/src/lib/server/skills-config.ts
+++ b/src/lib/server/skills-config.ts
@@ -1,0 +1,417 @@
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync
+} from 'fs';
+import { dirname, basename, isAbsolute, join, resolve } from 'path';
+import { execFileSync } from 'child_process';
+import { homedir, tmpdir } from 'os';
+import { parse as parseYaml } from 'yaml';
+import { DOCWRITER_DIR, WORKSPACE_ROOT, ensureDocWriterDir } from './document-files';
+import { writeJsonAtomic } from './file-utils';
+import hooksCreatorSkill from './skills/hooks-creator/SKILL.md?raw';
+import plainWritingSkill from './skills/plain-writing/SKILL.md?raw';
+import plainWritingTemplate from './skills/plain-writing/assets/revision_template.html?raw';
+
+const hooksCreatorExamples = import.meta.glob(
+	'./skills/hooks-creator/examples/*.json',
+	{ query: '?raw', import: 'default', eager: true }
+) as Record<string, string>;
+
+const SKILLS_FILE = join(DOCWRITER_DIR, 'skills.json');
+const CUSTOM_SKILLS_DIR = join(DOCWRITER_DIR, 'skills');
+const CLAUDE_SKILLS_DIR = join(WORKSPACE_ROOT, '.claude', 'skills');
+const AGENTS_SKILLS_DIR = join(WORKSPACE_ROOT, '.agents', 'skills');
+const NATIVE_SKILL_DIRS = [CLAUDE_SKILLS_DIR, AGENTS_SKILLS_DIR];
+const BUNDLED_MARKER = '.docwriter-bundled-skill';
+
+export interface SkillConfig {
+	disabledBundled: string[];
+	customSkills: CustomSkillConfig[];
+}
+
+export interface CustomSkillConfig {
+	id: string;
+	source: string;
+	path: string;
+	enabled?: boolean;
+	addedAt: number;
+}
+
+export interface SkillSummary {
+	id: string;
+	name: string;
+	description: string;
+	enabled: boolean;
+	origin: 'bundled' | 'custom';
+	path: string;
+	source?: string;
+	missing?: boolean;
+}
+
+interface BundledSkill {
+	id: string;
+	source: string;
+	files: Array<{ relativePath: string; content: string }>;
+}
+
+const BUNDLED_SKILLS: BundledSkill[] = [
+	{
+		id: 'hooks-creator',
+		source: 'docwriter',
+		files: [
+			{ relativePath: 'SKILL.md', content: hooksCreatorSkill },
+			...Object.entries(hooksCreatorExamples).map(([path, content]) => ({
+				relativePath: join('examples', basename(path)),
+				content
+			}))
+		]
+	},
+	{
+		id: 'plain-writing',
+		source: 'https://github.com/shreyashankar/plain-writing-skill',
+		files: [
+			{ relativePath: 'SKILL.md', content: plainWritingSkill },
+			{ relativePath: join('assets', 'revision_template.html'), content: plainWritingTemplate }
+		]
+	}
+];
+
+const DEFAULT_CONFIG: SkillConfig = {
+	disabledBundled: [],
+	customSkills: []
+};
+
+function normalizeConfig(raw: unknown): SkillConfig {
+	const obj = raw && typeof raw === 'object' ? raw as Partial<SkillConfig> : {};
+	return {
+		disabledBundled: Array.isArray(obj.disabledBundled)
+			? obj.disabledBundled.filter((id): id is string => typeof id === 'string')
+			: [],
+		customSkills: Array.isArray(obj.customSkills)
+			? obj.customSkills
+					.filter((s): s is CustomSkillConfig =>
+						!!s &&
+						typeof s === 'object' &&
+						typeof (s as CustomSkillConfig).id === 'string' &&
+						typeof (s as CustomSkillConfig).path === 'string'
+					)
+					.map((s) => ({
+						id: s.id,
+						source: typeof s.source === 'string' ? s.source : s.path,
+						path: s.path,
+						enabled: s.enabled !== false,
+						addedAt: typeof s.addedAt === 'number' ? s.addedAt : Date.now()
+					}))
+			: []
+	};
+}
+
+export function readSkillsConfig(): SkillConfig {
+	ensureDocWriterDir();
+	if (!existsSync(SKILLS_FILE)) return { ...DEFAULT_CONFIG, customSkills: [] };
+	try {
+		return normalizeConfig(JSON.parse(readFileSync(SKILLS_FILE, 'utf-8')));
+	} catch {
+		return { ...DEFAULT_CONFIG, customSkills: [] };
+	}
+}
+
+function writeSkillsConfig(config: SkillConfig) {
+	ensureDocWriterDir();
+	writeJsonAtomic(SKILLS_FILE, normalizeConfig(config));
+}
+
+function stripFrontmatter(raw: string): { frontmatter: Record<string, unknown>; body: string } {
+	const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+	if (!match) return { frontmatter: {}, body: raw };
+	try {
+		return {
+			frontmatter: (parseYaml(match[1]) ?? {}) as Record<string, unknown>,
+			body: raw.slice(match[0].length)
+		};
+	} catch {
+		return { frontmatter: {}, body: raw.slice(match[0].length) };
+	}
+}
+
+function firstParagraph(body: string): string {
+	return body
+		.split(/\n\s*\n/)
+		.map((p) => p.replace(/\s+/g, ' ').replace(/^#+\s*/, '').trim())
+		.find(Boolean) ?? '';
+}
+
+function parseSkillMetadata(skillPath: string, fallbackName: string): { name: string; description: string; body: string } {
+	const raw = readFileSync(skillPath, 'utf-8');
+	const { frontmatter, body } = stripFrontmatter(raw);
+	const name = typeof frontmatter.name === 'string' && frontmatter.name.trim()
+		? frontmatter.name.trim()
+		: fallbackName;
+	const description = typeof frontmatter.description === 'string' && frontmatter.description.trim()
+		? frontmatter.description.trim().replace(/\s+/g, ' ')
+		: firstParagraph(body);
+	return { name, description, body: body.trim() };
+}
+
+function parseBundledMetadata(skill: BundledSkill) {
+	const file = skill.files.find((f) => f.relativePath === 'SKILL.md');
+	if (!file) return { name: skill.id, description: '', body: '' };
+	const { frontmatter, body } = stripFrontmatter(file.content);
+	return {
+		name: typeof frontmatter.name === 'string' ? frontmatter.name : skill.id,
+		description:
+			typeof frontmatter.description === 'string'
+				? frontmatter.description.trim().replace(/\s+/g, ' ')
+				: firstParagraph(body),
+		body: body.trim()
+	};
+}
+
+function writeBundledSkill(targetDir: string, skill: BundledSkill) {
+	rmSync(targetDir, { recursive: true, force: true });
+	for (const file of skill.files) {
+		const target = join(targetDir, file.relativePath);
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileAtomicText(target, file.content);
+	}
+	writeFileAtomicText(join(targetDir, BUNDLED_MARKER), skill.id);
+}
+
+function writeFileAtomicText(path: string, text: string) {
+	const tempPath = `${path}.tmp`;
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(tempPath, text, 'utf-8');
+	renameSync(tempPath, path);
+}
+
+function copySkillDir(sourceDir: string, targetDir: string) {
+	rmSync(targetDir, { recursive: true, force: true });
+	cpSync(sourceDir, targetDir, {
+		recursive: true,
+		filter: (src) => !src.split('/').includes('.git')
+	});
+}
+
+export function syncSkillInstallations(config = readSkillsConfig()) {
+	for (const nativeDir of NATIVE_SKILL_DIRS) {
+		mkdirSync(nativeDir, { recursive: true });
+
+		for (const bundled of BUNDLED_SKILLS) {
+			const target = join(nativeDir, bundled.id);
+			if (config.disabledBundled.includes(bundled.id)) {
+				rmSync(target, { recursive: true, force: true });
+			} else {
+				writeBundledSkill(target, bundled);
+			}
+		}
+
+		for (const custom of config.customSkills) {
+			const target = join(nativeDir, custom.id);
+			if (custom.enabled === false || !existsSync(join(custom.path, 'SKILL.md'))) {
+				rmSync(target, { recursive: true, force: true });
+			} else {
+				copySkillDir(custom.path, target);
+			}
+		}
+	}
+}
+
+export function listSkills(): { skills: SkillSummary[]; nativeDirs: string[] } {
+	const config = readSkillsConfig();
+	const disabled = new Set(config.disabledBundled);
+	const skills: SkillSummary[] = BUNDLED_SKILLS.map((skill) => {
+		const meta = parseBundledMetadata(skill);
+		return {
+			id: skill.id,
+			name: meta.name,
+			description: meta.description,
+			enabled: !disabled.has(skill.id),
+			origin: 'bundled' as const,
+			path: join(CLAUDE_SKILLS_DIR, skill.id),
+			source: skill.source
+		};
+	});
+
+	for (const custom of config.customSkills) {
+		const skillPath = join(custom.path, 'SKILL.md');
+		if (!existsSync(skillPath)) {
+			skills.push({
+				id: custom.id,
+				name: custom.id,
+				description: 'Missing SKILL.md',
+				enabled: false,
+				origin: 'custom',
+				path: custom.path,
+				source: custom.source,
+				missing: true
+			});
+			continue;
+		}
+		const meta = parseSkillMetadata(skillPath, custom.id);
+		skills.push({
+			id: custom.id,
+			name: meta.name,
+			description: meta.description,
+			enabled: custom.enabled !== false,
+			origin: 'custom',
+			path: custom.path,
+			source: custom.source
+		});
+	}
+
+	return { skills, nativeDirs: NATIVE_SKILL_DIRS };
+}
+
+export function setSkillEnabled(id: string, enabled: boolean): SkillConfig {
+	const config = readSkillsConfig();
+	if (BUNDLED_SKILLS.some((s) => s.id === id)) {
+		const disabled = new Set(config.disabledBundled);
+		if (enabled) disabled.delete(id);
+		else disabled.add(id);
+		config.disabledBundled = [...disabled];
+	} else {
+		config.customSkills = config.customSkills.map((s) =>
+			s.id === id ? { ...s, enabled } : s
+		);
+	}
+	writeSkillsConfig(config);
+	syncSkillInstallations(config);
+	return config;
+}
+
+export function removeCustomSkill(id: string): SkillConfig {
+	const config = readSkillsConfig();
+	const removed = config.customSkills.find((s) => s.id === id);
+	config.customSkills = config.customSkills.filter((s) => s.id !== id);
+	writeSkillsConfig(config);
+	if (removed?.path.startsWith(CUSTOM_SKILLS_DIR)) {
+		rmSync(removed.path, { recursive: true, force: true });
+	}
+	for (const nativeDir of NATIVE_SKILL_DIRS) {
+		rmSync(join(nativeDir, id), { recursive: true, force: true });
+	}
+	syncSkillInstallations(config);
+	return config;
+}
+
+function expandHome(path: string): string {
+	return path === '~' || path.startsWith('~/')
+		? join(homedir(), path.slice(2))
+		: path;
+}
+
+function isGitHubSource(source: string): boolean {
+	return /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+(?:\.git)?\/?$/.test(source.trim());
+}
+
+function sanitizeSkillId(value: string): string {
+	const id = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.replace(/-{2,}/g, '-');
+	return id || 'skill';
+}
+
+function uniqueSkillId(base: string, config: SkillConfig): string {
+	const used = new Set([
+		...BUNDLED_SKILLS.map((s) => s.id),
+		...config.customSkills.map((s) => s.id)
+	]);
+	let id = sanitizeSkillId(base);
+	let i = 2;
+	while (used.has(id)) {
+		id = `${sanitizeSkillId(base)}-${i}`;
+		i += 1;
+	}
+	return id;
+}
+
+function resolveLocalSource(source: string): string {
+	const expanded = expandHome(source.trim());
+	return isAbsolute(expanded) ? expanded : resolve(WORKSPACE_ROOT, expanded);
+}
+
+function cloneGitHubSkill(source: string): string {
+	const tmp = mkdtempSync(join(tmpdir(), 'docwriter-skill-'));
+	const target = join(tmp, 'repo');
+	execFileSync('git', ['clone', '--depth=1', source, target], { stdio: 'ignore' });
+	return target;
+}
+
+function resolveSkillRoot(source: string): string {
+	if (isGitHubSource(source)) return cloneGitHubSkill(source.trim());
+	const local = resolveLocalSource(source);
+	if (!existsSync(local)) throw new Error(`${source} does not exist.`);
+	const stat = statSync(local);
+	if (stat.isFile() && basename(local) === 'SKILL.md') return dirname(local);
+	if (stat.isDirectory()) return local;
+	throw new Error(`${source} is not a skill directory or SKILL.md file.`);
+}
+
+export function addCustomSkill(source: string): SkillConfig {
+	const trimmed = source.trim();
+	if (!trimmed) throw new Error('Skill source is required.');
+	const config = readSkillsConfig();
+	const sourceDir = resolveSkillRoot(trimmed);
+	const skillPath = join(sourceDir, 'SKILL.md');
+	if (!existsSync(skillPath)) {
+		throw new Error('Skill source must contain a SKILL.md file at its root.');
+	}
+	const meta = parseSkillMetadata(skillPath, basename(sourceDir));
+	const id = uniqueSkillId(meta.name || basename(sourceDir), config);
+	const target = join(CUSTOM_SKILLS_DIR, id);
+	mkdirSync(CUSTOM_SKILLS_DIR, { recursive: true });
+	copySkillDir(sourceDir, target);
+	config.customSkills = [
+		...config.customSkills,
+		{ id, source: trimmed, path: target, enabled: true, addedAt: Date.now() }
+	];
+	writeSkillsConfig(config);
+	syncSkillInstallations(config);
+	return config;
+}
+
+export function readEnabledSkill(nameOrId: string): { name: string; path: string; content: string } | null {
+	const needle = nameOrId.trim().toLowerCase();
+	if (!needle) return null;
+	for (const skill of listSkills().skills) {
+		if (!skill.enabled || skill.missing) continue;
+		const names = [skill.id, skill.name].map((s) => s.toLowerCase());
+		if (!names.includes(needle)) continue;
+		if (skill.origin === 'bundled') {
+			const bundled = BUNDLED_SKILLS.find((s) => s.id === skill.id);
+			const file = bundled?.files.find((f) => f.relativePath === 'SKILL.md');
+			if (!file) return null;
+			return {
+				name: skill.name,
+				path: join(AGENTS_SKILLS_DIR, skill.id, 'SKILL.md'),
+				content: file.content
+			};
+		}
+		const skillPath = join(skill.path, 'SKILL.md');
+		if (!existsSync(skillPath)) continue;
+		return { name: skill.name, path: skillPath, content: readFileSync(skillPath, 'utf-8') };
+	}
+	return null;
+}
+
+export function buildSkillsPromptBlock(): string | null {
+	const enabled = listSkills().skills.filter((s) => s.enabled && !s.missing);
+	if (enabled.length === 0) return null;
+	return [
+		'## Available skills',
+		'',
+		'Use these reusable skill instructions when they match the task. For OpenAI or Cursor provider runs, call `read_skill` with the skill name before following the full instructions.',
+		'If the user message is exactly or primarily `/<skill-name>` (for example `/plain-writing`), call `read_skill` for that skill and apply it to the current document/task.',
+		'',
+		...enabled.map((skill) => `- ${skill.name}: ${skill.description}`)
+	].join('\n');
+}

--- a/src/lib/server/skills-install.ts
+++ b/src/lib/server/skills-install.ts
@@ -1,58 +1,14 @@
 /**
- * Install DocWriter's built-in project skills into the workspace's
- * `.claude/skills/` directory. The Claude Agent SDK auto-discovers skills
- * there when settingSources includes 'project', so we drop the files and the
- * agent learns about them on the next render.
- *
- * Skill files are imported as raw strings via Vite's `?raw` (and `?raw`
- * through `import.meta.glob` for the examples folder) so they live as real
- * markdown/JSON in the repo — editable, grep-able, reviewable — AND get
- * bundled into the server build.
- *
- * We always overwrite built-in skill files: they are ours, shipped with the
- * package. User-owned writing samples live separately under
- * `.docwriter/references/`, not in `.claude/skills/`.
+ * Sync DocWriter-managed skills into the native discovery folders used by
+ * provider harnesses. Claude reads `.claude/skills`; Codex and Pi both read
+ * `.agents/skills`.
  */
-import { mkdirSync, writeFileSync } from 'fs';
-import { join, dirname, basename } from 'path';
-import hooksCreatorSkill from './skills/hooks-creator/SKILL.md?raw';
-
-const hooksCreatorExamples = import.meta.glob(
-	'./skills/hooks-creator/examples/*.json',
-	{ query: '?raw', import: 'default', eager: true }
-) as Record<string, string>;
-
-const ROOT = process.env.DOCWRITER_ROOT || process.cwd();
-const SKILLS_DIR = join(ROOT, '.claude', 'skills');
-
-interface BundledSkill {
-	dir: string;
-	files: Array<{ relativePath: string; content: string }>;
-}
-
-const SKILLS: BundledSkill[] = [
-	{
-		dir: join(SKILLS_DIR, 'hooks-creator'),
-		files: [
-			{ relativePath: 'SKILL.md', content: hooksCreatorSkill },
-			...Object.entries(hooksCreatorExamples).map(([path, content]) => ({
-				relativePath: join('examples', basename(path)),
-				content
-			}))
-		]
-	}
-];
+import { syncSkillInstallations } from './skills-config';
 
 export function installBundledSkills() {
-	for (const skill of SKILLS) {
-		for (const f of skill.files) {
-			try {
-				const p = join(skill.dir, f.relativePath);
-				mkdirSync(dirname(p), { recursive: true });
-				writeFileSync(p, f.content, 'utf-8');
-			} catch (e) {
-				console.warn('[skills-install] Failed to install', f.relativePath, e);
-			}
-		}
+	try {
+		syncSkillInstallations();
+	} catch (e) {
+		console.warn('[skills-install] Failed to sync skills', e);
 	}
 }

--- a/src/lib/server/skills/plain-writing/SKILL.md
+++ b/src/lib/server/skills/plain-writing/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: plain-writing
+description: >-
+  Write and edit prose in the user's plain style: simple everyday words,
+  complete sentences, no dashes, no jargon, no analogies, no filler, and full
+  clear explanations. Use this whenever you draft or revise any prose for the
+  user, such as documents, Notion pages, reports, summaries, README files,
+  research notes, proposals, slide text, emails, or commit and PR descriptions.
+  Also use it whenever the user asks to simplify, clean up, tighten, reword, or
+  make writing clearer or easier to read. Default to this style for prose
+  written for the user unless they ask for a different one. Do not apply it to
+  code itself, only to the words around it.
+---
+
+# Plain writing
+
+This skill captures how the user wants written prose to read. The goal is text
+that anyone can read once and understand. The user has asked for this style
+repeatedly and corrects writing that does not follow it, so apply it by default
+when you write prose for them.
+
+## The rules
+
+1. **Use simple, everyday words.** Prefer the common word over the fancy one,
+   e.g., write "use" rather than "leverage". Short familiar words are faster to
+   read. Avoid the words AI tools overuse, e.g., "delve", "tapestry",
+   "landscape", "robust", and "leverage". Also, repeat a word rather than
+   swapping in a synonym just to avoid repeating it.
+
+2. **Write complete sentences.** Each sentence states one clear thing and has a
+   subject and a verb. Do not write fragments, and do not stitch several ideas
+   together with colons or semicolons into one dense line. If a sentence states
+   two things, split it into two sentences.
+
+3. **No dashes, and limit colons.** Do not use em dashes or en dashes, including
+   in number ranges. Join clauses with a period, or with a word such as "and".
+   Write ranges with the word "to", e.g., "0.94 to 0.96". Use a colon only to
+   introduce a list. Do not use a colon to join clauses or to set up a point,
+   e.g., "Read for the schema: the feature fires". Dashes, and colons used for a
+   point, invite the clever phrasing the user does not want. Use straight quotes,
+   not curly quotes, e.g., "the agent" rather than “the agent”.
+
+4. **No jargon.** Do not use shorthand from a field when a plain phrase works.
+   If a technical term is truly needed, say it once and explain it in plain
+   words. Avoid a word such as "calibrated" unless you define it simply.
+
+5. **No analogies or imagery.** Do not explain something by comparing it to a
+   different thing. Do not use a metaphor or any phrase meant to sound smart.
+   Describe the actual thing in literal terms. Avoid the "not just X, it is Y"
+   pattern, e.g., "it is not just a parser, it is a toolchain". State what the
+   thing is.
+
+6. **No filler.** Cut words and phrases that add nothing, e.g., "it is worth
+   noting that". Every sentence should add something the reader needs. Watch for
+   an "-ing" tail that adds fake analysis, e.g., "stores results, highlighting
+   its value". Cut it, or say the plain reason.
+
+7. **Explain things fully and clearly.** Plain also does not mean terse. If an
+   idea is compressed into one cramped sentence, expand it so each point gets
+   its own sentence and the reader can follow it. When you have several distinct
+   things to list, give each one a clear sentence or its own bullet, not one
+   long line. Clarity comes before both shortness and length.
+
+8. **Do not make an inanimate thing do an action it cannot do.** An inanimate
+   subject should usually only take "is" or "are", not an action verb, e.g., do
+   not write "logs become searchable records". Make a person the actor instead,
+   e.g., "you can search the logs". An exception to this is a common phrase like
+   "the paper argues".
+
+9. **Do not invent hyphenated adjectives.** A common compound adjective that
+   people already use is fine, e.g., "well-crafted". Avoid a phrase you make up
+   by joining words with a hyphen to sound compact or clever, e.g.,
+   "reveal-style colon". When you catch yourself coining one, reword it in plain
+   words. A good test is whether you would find the term in a dictionary or hear
+   it in normal speech. If not, write it out.
+
+10. **Do not pad with empty emphasis or puffery words.** Words like "really" and
+    "real" add emphasis but no information, so drop them. Do not say that
+    something "matters" or "carries weight". Do not puff something up with words
+    like "boasts", "a testament to", "pivotal", or "renowned". State the actual
+    point, or cut the sentence.
+
+11. **Keep lists and examples simple.**
+    - Do not write a three-part series in a sentence, e.g., "it is simple,
+      clear, and direct". It sounds practiced. When you have items to list, use
+      a bullet list. Do not pad a list to three just for rhythm.
+    - When you use an example to make a point, give one example and introduce it
+      with "e.g.". Do not stack several examples for the same point.
+
+12. **Do not attribute a claim to no one.** Do not hide a claim behind a vague
+    source, e.g., "experts say" or "studies show". Name the source, or cut the
+    claim.
+
+13. **Keep the formatting plain.** Use sentence case in a heading, e.g., "How to
+    install the skill", not "How To Install The Skill". Do not use boldface as
+    decoration, such as bolding the first phrase of every bullet.
+
+## How to revise
+
+Revise in two passes.
+
+First pass. Read the text once and fix anything that breaks the rules above.
+
+Second pass. Read the result again as if you had never seen it. Go clause by
+clause and ask whether each clause adds something the reader needs. If a clause
+or a whole sentence does not earn its place, remove it. Then check that a reader
+seeing the text for the first time would understand every sentence.
+
+## The revision artifact
+
+When the second pass removes or rewrites anything, also make a small HTML file
+so the user can see what changed. Skip this for tiny edits where the second pass
+did not cut or rewrite anything.
+
+Build a list of the changes at the level of whole sentences. Group the entries
+into paragraphs, and give each paragraph a "para" number. Each entry is one of
+these kinds:
+
+- keep. The sentence is unchanged. Fields: `type` is "keep", and `text`.
+- edit. The sentence was rewritten. Fields: `type` is "edit", `old`, `new`, and
+  `why`.
+- del. The sentence was removed. Fields: `type` is "del", plus `old` and `why`.
+
+The `why` is a short plain reason for the change, e.g., "filler, adds nothing".
+Here is the shape of the list:
+
+```json
+[
+  { "para": 1, "items": [
+    { "type": "edit", "old": "...", "new": "...", "why": "..." },
+    { "type": "del",  "old": "...", "why": "..." }
+  ]},
+  { "para": 2, "items": [
+    { "type": "keep", "text": "..." }
+  ]}
+]
+```
+
+Then take the template at `assets/revision_template.html`, replace the exact
+line `const DATA = __DATA__;` with `const DATA = <json>;`, and save the result
+to a new file in `/tmp`, e.g., `/tmp/revision-<short-name>.html`. Do not write
+it into the skill folder. Check that no `__DATA__` text remains in the saved
+file.
+Tell the user where the file is. The file has three tabs:
+
+- First draft
+- Second draft
+- Diff
+
+In the Diff tab the removed text is red and the rewritten text is green. The
+reason for each change appears when the user hovers the colored text.
+
+## Examples
+
+These are before and after pairs.
+
+**Example 1. Dashes and jargon.**
+Before: Fresh-annotation re-scoring (cache bypassed) moved means by less than
+0.004. Read for the schema: "feature fires" is a calibrated proxy for "the
+property holds" at F1 of 0.94 to 0.96 for coherent features.
+After: We ran the scoring again with new language model calls and no caching.
+The average scores changed by less than 0.004, so they are not an effect of
+caching. For most features, the description agrees with how the feature actually
+behaves, at an F1 of about 0.94 to 0.96.
+
+**Example 2. Filler.**
+Before: It is worth noting that the second pass actually removes quite a lot of
+words, and this matters.
+After: The second pass removes a lot of words.
+
+**Example 3. One cramped sentence split into clear ones.**
+Before: The groups the features were sorted into were the authors' own reading,
+the example posts were written by hand, and finer detail meant training extra
+small models and labeling again.
+After: First, the authors sorted the features into groups themselves, based on
+their own reading of the results. Second, they wrote the example posts by hand
+after reading many of the posts. Third, when they wanted finer detail, they
+trained another small model and labeled the posts again.
+
+**Example 4. Analogy removed.**
+Before: The feature index is like a card catalog that the optimizer can flip
+through.
+After: The feature index is a list of named features. The optimizer can look up
+which feature matches a request.
+
+**Example 5. An inanimate thing doing an action it cannot do.**
+Before: The logs become searchable records once the job finishes.
+After: You can search the logs once the job finishes.
+
+**Example 6. A group of three.**
+Before: Configuring things is usually messy: random files, infinite pickers, and
+knobs you didn't even know existed.
+After: Configuring things is usually messy, e.g., the settings are scattered
+across many files.
+
+**Example 7. Empty importance words.**
+Before: This result matters, and it carries weight for the design.
+After: As a result, the system can skip the model on most documents.
+
+**Example 8. Puffery.**
+Before: This release stands as a testament to the team and plays a pivotal role
+in parsing.
+After: We added streaming in this release, and other teams now use it.
+
+**Example 9. An "-ing" tail that adds fake analysis.**
+Before: The cache stores results, highlighting its value for speed.
+After: The cache stores results, so repeated queries are faster.
+
+**Example 10. Negative parallelism.**
+Before: It is not just a parser, it is a full toolchain.
+After: It is a parser and a formatter.
+
+**Example 11. Vague attribution.**
+Before: Experts say this approach scales well.
+After: In our benchmark, this approach handled a million rows.
+
+**Example 12. Elegant variation.**
+Before: Upload the document. The file is parsed, and the record is saved.
+After: Upload the document. The document is parsed and saved.

--- a/src/lib/server/skills/plain-writing/assets/revision_template.html
+++ b/src/lib/server/skills/plain-writing/assets/revision_template.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Writing revision</title>
+<style>
+  :root {
+    --keep: #222; --del-bg: #fdecec; --del: #b3261e; --ins-bg: #e9f6ec; --ins: #1e7d32;
+    --line: #e6e6e6;
+  }
+  body { font-family: 'Inter', -apple-system, Helvetica, Arial, sans-serif; max-width: 820px;
+         margin: 0 auto; padding: 2em 1.2em; color: var(--keep); line-height: 1.6; background: #fafafa; }
+  h1 { font-size: 1.4em; margin-bottom: 0.4em; }
+  .bar { position: sticky; top: 0; background: #fafafa; padding: 0.8em 0; border-bottom: 1px solid var(--line);
+         display: flex; align-items: center; gap: 1em; flex-wrap: wrap; z-index: 5; }
+  .toggle { display: inline-flex; border: 1px solid #ccc; border-radius: 8px; overflow: hidden; }
+  .toggle button { border: 0; border-right: 1px solid #ccc; background: #fff; padding: 0.45em 0.9em;
+                   font-size: 0.9em; cursor: pointer; color: #444; }
+  .toggle button:last-child { border-right: 0; }
+  .toggle button.active { background: #2e7d32; color: #fff; }
+  .summary { font-size: 0.88em; color: #666; }
+  .legend { font-size: 0.8em; color: #666; display: none; gap: 1.2em; margin: 0.6em 0 0; }
+  .legend.show { display: flex; flex-wrap: wrap; }
+  .legend span.k { padding: 0 4px; border-radius: 3px; }
+  .doc { background: #fff; border: 1px solid var(--line); border-radius: 10px; padding: 1.2em 1.4em; margin-top: 1em; }
+  p.para { margin: 0 0 1em; }
+  del { color: var(--del); background: var(--del-bg); text-decoration: line-through; border-radius: 2px; padding: 0 2px; }
+  ins { color: var(--ins); background: var(--ins-bg); text-decoration: none; border-radius: 2px; padding: 0 2px; }
+  .chg { position: relative; cursor: help; }
+  .chg:hover::after {
+    content: attr(data-why); position: absolute; left: 0; bottom: 130%;
+    background: #222; color: #fff; font-size: 0.74em; line-height: 1.35; font-style: normal;
+    padding: 5px 9px; border-radius: 6px; white-space: normal; width: max-content; max-width: 280px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.18); z-index: 10;
+  }
+</style>
+</head>
+<body>
+
+<h1>Writing revision</h1>
+
+<div class="bar">
+  <span class="toggle">
+    <button id="btn-first" onclick="setView('first')">First draft</button>
+    <button id="btn-second" class="active" onclick="setView('second')">Second draft</button>
+    <button id="btn-diff" onclick="setView('diff')">Diff</button>
+  </span>
+  <span class="summary" id="summary"></span>
+</div>
+<div class="legend" id="legend">
+  <span><span class="k" style="background:var(--del-bg);color:var(--del);text-decoration:line-through">removed</span> cut in the second pass</span>
+  <span><span class="k" style="background:var(--ins-bg);color:var(--ins)">added</span> rewritten in the second pass</span>
+  <span>hover the green or red text to see why it changed</span>
+</div>
+
+<div class="doc" id="doc"></div>
+
+<script>
+const DATA = __DATA__;
+
+function para(text) { return `<p class="para">${text}</p>`; }
+
+function renderFirst() {
+  return DATA.map(p => para(
+    p.items.map(it => it.type === "keep" ? it.text : it.old).join(" ")
+  )).join("");
+}
+
+function renderSecond() {
+  return DATA.map(p => para(
+    p.items.map(it => it.type === "keep" ? it.text : it.type === "edit" ? it.new : "")
+            .filter(Boolean).join(" ")
+  )).join("");
+}
+
+function attr(s) { return s.replace(/"/g, "&quot;"); }
+
+function renderDiff() {
+  return DATA.map(p => para(
+    p.items.map(it => {
+      if (it.type === "keep") return it.text;
+      if (it.type === "del") return `<del class="chg" data-why="${attr(it.why)}">${it.old}</del>`;
+      return `<del>${it.old}</del> <ins class="chg" data-why="${attr(it.why)}">${it.new}</ins>`;
+    }).join(" ")
+  )).join("");
+}
+
+const RENDER = { first: renderFirst, second: renderSecond, diff: renderDiff };
+
+function setView(v) {
+  ["first", "second", "diff"].forEach(k =>
+    document.getElementById("btn-" + k).classList.toggle("active", k === v));
+  document.getElementById("legend").classList.toggle("show", v === "diff");
+  document.getElementById("doc").innerHTML = RENDER[v]();
+}
+
+const nEdit = DATA.flatMap(p => p.items).filter(i => i.type === "edit").length;
+const nDel = DATA.flatMap(p => p.items).filter(i => i.type === "del").length;
+document.getElementById("summary").textContent =
+  `Second pass: ${nEdit} sentence${nEdit === 1 ? "" : "s"} rewritten, ${nDel} removed.`;
+setView("second");
+</script>
+</body>
+</html>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,6 +22,7 @@
 	import Dialog from '$lib/components/Dialog.svelte';
 	import AgentSettingsPanel from '$lib/components/AgentSettingsPanel.svelte';
 	import HooksPanel from '$lib/components/HooksPanel.svelte';
+	import SkillsPanel from '$lib/components/SkillsPanel.svelte';
 	import ApiKeysPanel from '$lib/components/ApiKeysPanel.svelte';
 	import CustomModelDialog from '$lib/components/CustomModelDialog.svelte';
 	import { themes, applyTheme } from '$lib/themes';
@@ -680,6 +681,72 @@
 		activeTabIsPdf = activeTabFilePath ? isPdfPath(activeTabFilePath) : false;
 	});
 
+	let splitPreviewPath = $state<string | null>(null);
+	let splitPreviewSourcePath = $state<string | null>(null);
+	let splitPreviewOpen = $derived(!!splitPreviewPath && !activeTabIsPdf);
+	let splitPreviewWidth = $state(820);
+	let splitLayoutEl: HTMLDivElement | null = $state(null);
+	const MIN_SPLIT_PREVIEW_WIDTH = 480;
+	const MIN_SPLIT_SOURCE_WIDTH = 620;
+
+	function maxSplitPreviewWidth() {
+		const layoutWidth =
+			splitLayoutEl?.clientWidth ??
+			(typeof window === 'undefined' ? 1440 : Math.max(0, window.innerWidth - leftWidth));
+		return Math.max(MIN_SPLIT_PREVIEW_WIDTH, layoutWidth - MIN_SPLIT_SOURCE_WIDTH);
+	}
+
+	function clampSplitPreviewWidth(width: number) {
+		return Math.max(MIN_SPLIT_PREVIEW_WIDTH, Math.min(maxSplitPreviewWidth(), width));
+	}
+
+	function resizeSplitPreview(deltaX: number) {
+		splitPreviewWidth = clampSplitPreviewWidth(splitPreviewWidth - deltaX);
+	}
+
+	async function resolvePreviewOutputForTab(tabPath: string | null): Promise<string | null> {
+		if (!tabPath) return null;
+		try {
+			const res = await fetch(
+				`/api/hooks/preview-match?file=${encodeURIComponent(tabPath)}`
+			);
+			if (!res.ok) return null;
+			const data = await res.json();
+			return typeof data?.outputPath === 'string' ? data.outputPath : null;
+		} catch {
+			return null;
+		}
+	}
+
+	function openSplitPreview(path: string) {
+		splitPreviewPath = path;
+		splitPreviewSourcePath = activeTabFilePath;
+	}
+
+	function closeSplitPreview() {
+		splitPreviewPath = null;
+		splitPreviewSourcePath = null;
+	}
+
+	async function refreshSplitPreviewForTab(tabPath: string) {
+		const nextPath = await resolvePreviewOutputForTab(tabPath);
+		if (activeTabFilePath !== tabPath) return;
+		splitPreviewPath = nextPath;
+		splitPreviewSourcePath = nextPath ? tabPath : null;
+	}
+
+	$effect(() => {
+		const tabPath = activeTabFilePath;
+		if (!splitPreviewPath) return;
+		if (!tabPath || activeTabIsPdf) {
+			closeSplitPreview();
+			return;
+		}
+		if (tabPath !== splitPreviewSourcePath) {
+			void refreshSplitPreviewForTab(tabPath);
+		}
+	});
+
 	/** Open a file from the FileTree. Any text file becomes an agent-
 	 * editable tab: either switch to it (if already open) or register it
 	 * via POST /api/tabs (which creates the file if missing). */
@@ -1267,6 +1334,10 @@
 			currentAbort = null;
 			submitInFlight = false;
 			isRendering.set(false);
+			// Agent shell tools can create folders/files without opening tabs.
+			// Refresh visible file-tree nodes at the end of each run so those
+			// filesystem changes show up even without a tab-count change.
+			void fileTreeRef?.refresh();
 			// If the render failed, push one visible error entry. Otherwise
 			// the mascot already tells the user it's done.
 			if (!success) {
@@ -1951,6 +2022,7 @@
 					onClick: () => editorSoftWrap.update((v) => !v)
 				},
 				{ kind: 'panel', label: 'Writing references', panelKey: 'references' },
+				{ kind: 'panel', label: 'Skills', panelKey: 'skills' },
 				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' },
 				{ kind: 'divider' },
 				{
@@ -2154,7 +2226,8 @@
 
 		// Subscribe to the file-watcher event bus (used by `docwriter --watch`).
 		// When the bin's fs.watch sees external changes it POSTs to /api/live,
-		// which streams a `reload` event here and we refresh the active tab.
+		// which streams a `reload` event here and we refresh the active tab
+		// plus the visible file tree.
 		void connectLive();
 
 		// Listen for SyncTeX jump messages from the preview popup so a
@@ -2234,6 +2307,7 @@
 				return;
 			}
 			es.addEventListener('reload', async () => {
+				void fileTreeRef?.refresh();
 				const tabId = getCurrentActiveTab();
 				if (!tabId) return;
 				await remountActiveTabFromServer(tabId);
@@ -2285,7 +2359,12 @@
 		const handler = async (ev: MessageEvent) => {
 			if (ev.origin !== window.location.origin) return;
 			const data = ev.data as { kind?: string; file?: string; line?: number } | null;
-			if (!data || data.kind !== 'docwriter-synctex-jump') return;
+			if (!data) return;
+			if (data.kind === 'docwriter-close-preview-pane') {
+				closeSplitPreview();
+				return;
+			}
+			if (data.kind !== 'docwriter-synctex-jump') return;
 			if (typeof data.file !== 'string' || typeof data.line !== 'number') return;
 			const tabId = data.file;
 			const line = data.line;
@@ -2397,6 +2476,7 @@
 					rules: rulesPanelSnippet,
 					agentSettings: agentSettingsSnippet,
 					hooks: hooksPanelSnippet,
+					skills: skillsPanelSnippet,
 					apiKeys: apiKeysPanelSnippet
 				}}
 			/>
@@ -2438,6 +2518,10 @@
 		<HooksPanel />
 	{/snippet}
 
+	{#snippet skillsPanelSnippet()}
+		<SkillsPanel onSubmit={(trigger) => void submit(trigger)} />
+	{/snippet}
+
 	{#snippet apiKeysPanelSnippet()}
 		<ApiKeysPanel />
 	{/snippet}
@@ -2473,61 +2557,77 @@
 		<PanelResizer onResize={resizeLeft} />
 		{/if}
 		<main class="center-pane">
-			<!-- Align the tab strip over the page column (same geometry as
-			     `.plain-editor-shell`) so the active tab sits on the page. -->
-			<div class="tab-align">
-				<div class="tab-slot">
-					<TabBar
-						onSwitch={switchTab}
-						onClose={closeTab}
-						onDelete={deleteTab}
-						onRename={renameTabAction}
-						pendingTabs={mergedPendingTabs}
-						onDropFile={handleDropFiles}
-					/>
-				</div>
-			</div>
-			{#if docLoaded && activeTabFilePath}
-				{#key activeTabFilePath}
-				<AgentModal
-					onAnswerQuestion={(id, answers) => answerUserQuestion(id, answers)}
-					onRunPlan={(id) => runPlanProposal(id)}
-					onDismissPlan={(id) => dismissPlanProposal(id)}
-					onRejectPlan={(id, feedback) => rejectPlanProposal(id, feedback)}
-				/>
-				{#if activeTabIsPdf}
-					<PdfViewerPane path={activeTabFilePath} />
-				{:else}
-					<TiptapEditor
-						tabId={activeTabFilePath}
-						bind:this={editorRef}
-						onSubmit={(trigger) => submit(trigger)}
-						initialScrollTop={pendingScrollRestore}
-						onAcceptInlineEdit={(roundId) => {
-							const rounds = currentRounds();
-							if (rounds.length === 0 || !roundId) return;
-							void acceptAgentEdit(roundId);
-						}}
-						onRejectInlineEdit={(roundId) => {
-							const rounds = currentRounds();
-							if (rounds.length === 0 || !roundId) return;
-							void rejectAgentEdit(roundId);
-						}}
-						onAcceptFeedbackEdits={(roundIds) => {
-							if (roundIds.length > 0) void acceptAgentEdit(roundIds);
-						}}
-						onResolveThread={(threadId, resolved) => void resolveThread(threadId, resolved)}
-					/>
-				{/if}
-				{/key}
-			{:else if docLoaded}
-				<div class="empty-editor-state">
-					<div class="empty-editor-title">No file open</div>
-					<div class="empty-editor-copy">
-						Open a file from the left sidebar, or create a new one there.
+			<div class="source-preview-layout" class:split-preview-open={splitPreviewOpen} bind:this={splitLayoutEl}>
+				<section class="source-workspace" aria-label="Source editor">
+					<!-- Align the tab strip over the page column (same geometry as
+					     `.plain-editor-shell`) so the active tab sits on the page. -->
+					<div class="tab-align">
+						<div class="tab-slot">
+							<TabBar
+								onSwitch={switchTab}
+								onClose={closeTab}
+								onDelete={deleteTab}
+								onRename={renameTabAction}
+								pendingTabs={mergedPendingTabs}
+								onDropFile={handleDropFiles}
+							/>
+						</div>
 					</div>
-				</div>
-			{/if}
+					{#if docLoaded && activeTabFilePath}
+						{#key activeTabFilePath}
+						<AgentModal
+							onAnswerQuestion={(id, answers) => answerUserQuestion(id, answers)}
+							onRunPlan={(id) => runPlanProposal(id)}
+							onDismissPlan={(id) => dismissPlanProposal(id)}
+							onRejectPlan={(id, feedback) => rejectPlanProposal(id, feedback)}
+						/>
+						{#if activeTabIsPdf}
+							<PdfViewerPane path={activeTabFilePath} />
+						{:else}
+							<TiptapEditor
+								tabId={activeTabFilePath}
+								bind:this={editorRef}
+								onSubmit={(trigger) => submit(trigger)}
+								initialScrollTop={pendingScrollRestore}
+								onAcceptInlineEdit={(roundId) => {
+									const rounds = currentRounds();
+									if (rounds.length === 0 || !roundId) return;
+									void acceptAgentEdit(roundId);
+								}}
+								onRejectInlineEdit={(roundId) => {
+									const rounds = currentRounds();
+									if (rounds.length === 0 || !roundId) return;
+									void rejectAgentEdit(roundId);
+								}}
+								onAcceptFeedbackEdits={(roundIds) => {
+									if (roundIds.length > 0) void acceptAgentEdit(roundIds);
+								}}
+								onResolveThread={(threadId, resolved) => void resolveThread(threadId, resolved)}
+								onOpenSplitPreview={openSplitPreview}
+								splitPreviewOpen={splitPreviewOpen}
+							/>
+						{/if}
+						{/key}
+					{:else if docLoaded}
+						<div class="empty-editor-state">
+							<div class="empty-editor-title">No file open</div>
+							<div class="empty-editor-copy">
+								Open a file from the left sidebar, or create a new one there.
+							</div>
+						</div>
+					{/if}
+				</section>
+				{#if splitPreviewOpen && splitPreviewPath}
+					<PanelResizer onResize={resizeSplitPreview} />
+					<aside
+						class="split-preview-pane"
+						aria-label="PDF preview"
+						style:--split-preview-width="{splitPreviewWidth}px"
+					>
+						<PdfViewerPane path={splitPreviewPath} />
+					</aside>
+				{/if}
+			</div>
 		</main>
 	</div>
 </div>
@@ -2586,6 +2686,8 @@
 		 * grid and the tab-align grid both read these. */
 		--paper-width: 900px;
 		--gutter-width: 240px;
+		--line-gutter-width: 52px;
+		--editor-grid-gap: 18px;
 		background: var(--canvas);
 		color: var(--text);
 		font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -2705,12 +2807,63 @@
 		min-width: 0;
 		background: var(--canvas);
 	}
+	.source-preview-layout {
+		flex: 1;
+		min-width: 0;
+		min-height: 0;
+		display: flex;
+		overflow: hidden;
+	}
+	.source-workspace {
+		position: relative;
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+	}
+	.source-preview-layout.split-preview-open .source-workspace {
+		flex: 1 1 auto;
+		min-width: 620px;
+		max-width: none;
+		--line-gutter-width: 34px;
+		--line-number-width: 28px;
+		--line-number-pad-right: 6px;
+		--editor-grid-gap: 10px;
+	}
+	.source-preview-layout.split-preview-open > :global(.resizer) {
+		z-index: 30;
+	}
+	.split-preview-pane {
+		position: relative;
+		flex: 0 0 var(--split-preview-width, 820px);
+		width: var(--split-preview-width, 820px);
+		min-width: 520px;
+		max-width: none;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-surface);
+		border-left: 0;
+		box-shadow: -12px 0 28px rgba(15, 23, 42, 0.08);
+	}
+	.source-preview-layout.split-preview-open .tab-align {
+		justify-content: start;
+		padding-left: 12px;
+	}
+	.source-preview-layout.split-preview-open .source-workspace :global(.plain-editor-shell) {
+		justify-content: start;
+	}
+	.source-preview-layout.split-preview-open .source-workspace :global(.tiptap-wrapper) {
+		padding-left: 12px;
+		padding-right: 16px;
+	}
 	/* Mirrors `.plain-editor-shell`'s columns + centering + horizontal padding
 	 * so the tab strip lands directly over the page column below it. */
 	.tab-align {
 		display: grid;
-		grid-template-columns: 52px minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
-		gap: 18px;
+		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
+		gap: var(--editor-grid-gap, 18px);
 		justify-content: center;
 		padding: 10px 32px 0;
 		flex-shrink: 0;
@@ -2741,5 +2894,27 @@
 		font-size: 14px;
 		line-height: 1.5;
 		color: var(--text-faint);
+	}
+	@media (max-width: 1600px) {
+		.source-preview-layout.split-preview-open {
+			flex-direction: column;
+		}
+		.source-preview-layout.split-preview-open > :global(.resizer) {
+			display: none;
+		}
+		.source-preview-layout.split-preview-open .source-workspace {
+			min-width: 0;
+			min-height: 50%;
+			max-width: none;
+		}
+		.split-preview-pane {
+			flex: 0 0 42vh;
+			min-width: 0;
+			max-width: none;
+			min-height: 320px;
+			border-left: 0;
+			border-top: 1px solid var(--border-light);
+			box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
+		}
 	}
 </style>

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -86,7 +86,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		const outcomeBox: { threadId?: string } = {};
 		const outcome = await mutateTabYDoc(tabId, (doc) => {
 			const liveText = serializeYDoc(doc);
-			if (countOccurrences(liveText, anchorText) === 0) {
+			const hasRelAnchor = !!(relStart && relEnd);
+			if (!hasRelAnchor && countOccurrences(liveText, anchorText) === 0) {
 				return { ok: false, error: 'anchorText was not found in the document', status: 409 };
 			}
 			const threadId = 'thread_' + cryptoRandomId();

--- a/src/routes/api/history/+server.ts
+++ b/src/routes/api/history/+server.ts
@@ -28,8 +28,9 @@ export const GET: RequestHandler = async () => {
 	const systemPrompt = getLastSystemPrompt();
 	const sessionId = getSessionId();
 	const provider = kvGet('provider') || 'claude';
+	const model = kvGet('model') || null;
 
-	if (!sessionId) return json({ sessionId: null, raw: [], messages: [], systemPrompt, provider });
+	if (!sessionId) return json({ sessionId: null, raw: [], messages: [], systemPrompt, provider, model });
 
 	// Non-Claude providers: load from the conversation_events DB table.
 	if (provider !== 'claude') {
@@ -37,7 +38,7 @@ export const GET: RequestHandler = async () => {
 		const raw = events.map((e) => {
 			try { return JSON.parse(e.data); } catch { return null; }
 		}).filter(Boolean);
-		return json({ sessionId, raw, messages: [], systemPrompt, provider });
+		return json({ sessionId, raw, messages: [], systemPrompt, provider, model });
 	}
 
 	// Claude: try the direct JSONL path first.
@@ -47,7 +48,7 @@ export const GET: RequestHandler = async () => {
 	if (existsSync(jsonlPath)) {
 		try {
 			const raw = await readJsonlFile(jsonlPath);
-			return json({ sessionId, raw, systemPrompt, provider });
+			return json({ sessionId, raw, systemPrompt, provider, model });
 		} catch (e) {
 			console.error('[history] raw JSONL read failed:', e);
 		}
@@ -61,7 +62,7 @@ export const GET: RequestHandler = async () => {
 				dir: process.cwd(),
 				limit: 500
 			});
-			return json({ sessionId, raw: [], messages, systemPrompt, provider });
+			return json({ sessionId, raw: [], messages, systemPrompt, provider, model });
 		}
 	} catch (e) {
 		console.error('[history] getSessionMessages failed:', e);
@@ -73,10 +74,10 @@ export const GET: RequestHandler = async () => {
 		const raw = events.map((e) => {
 			try { return JSON.parse(e.data); } catch { return null; }
 		}).filter(Boolean);
-		return json({ sessionId, raw, messages: [], systemPrompt, provider });
+		return json({ sessionId, raw, messages: [], systemPrompt, provider, model });
 	}
 
-	return json({ sessionId, raw: [], messages: [], systemPrompt, provider });
+	return json({ sessionId, raw: [], messages: [], systemPrompt, provider, model });
 };
 
 function readJsonlFile(filePath: string): Promise<unknown[]> {

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -26,6 +26,7 @@ import { replayUpdatesInto } from '$lib/server/ydoc-persistence';
 import { registerPendingAskUser } from '$lib/server/ask-user-state';
 import { unifiedLineDiff } from '$lib/diff';
 import { listStyleReferences } from '$lib/server/references';
+import { buildSkillsPromptBlock } from '$lib/server/skills-config';
 import { materializePendingReviewText } from '$lib/review-rounds';
 import {
 	EDIT_DOC_TOOL_NAME,
@@ -333,7 +334,8 @@ When the same user message carries both a clear directive AND ambient uncertaint
 - **Write / Edit** has two channels:
   1. **Workspace files** — use \`edit_doc\` / \`write_doc\` with the path as \`path\`. These auto-open the file as a tab if needed and create pending review rounds on existing content; brand-new files created via \`write_doc\` land as a new tab directly. The built-in \`Edit\` / \`Write\` tools are blocked outside scratch for this reason.
   2. **Your scratch space** at \`${AGENT_SCRATCH_DIR}/\` — any path under here. Use it for drafts, outlines, notes-to-self, intermediate passes. Either \`edit_doc\` / \`write_doc\` (they fall through to plain file I/O on scratch paths) or the built-in \`Edit\` / \`Write\` tools work. Not surfaced to the user; persists across rounds in the same session; wiped on "New session". Think of it as your working memory.
-- For adding **hooks** → call \`propose_hook\`. For **rules** → \`propose_rule\`. Don't try to edit \`.docwriter/hooks.json\` directly.
+- For adding **hooks** → call \`propose_hook\`. For **rules** → \`propose_rule\`. For **skills** → call \`add_skill\` when the user gives a GitHub URL or local skill path. If the user describes a desired skill in plain language but gives no source, use \`AskUserQuestion\` or explain what source/path you need. Don't try to edit \`.docwriter/hooks.json\`, \`.docwriter/skills.json\`, \`.claude/skills\`, or \`.agents/skills\` directly.
+- For review state mutations — accepting/rejecting pending edits or resolving/reopening comment threads — call \`review_action\` ONLY when the user's current message explicitly asks you to perform that action. Never accept, reject, resolve, or reopen as part of normal writing assistance.
 
 ## When to use subagents (Agent tool)
 
@@ -620,6 +622,50 @@ const USER_HOOK_TIMEOUT_SEC = 60;
 type HookCallback = (input: any) => Promise<any>;
 type HookEntry = { matcher: string; hooks: HookCallback[]; timeout?: number };
 
+function hookToolInputFilePath(toolInput: unknown): string | undefined {
+	if (!toolInput || typeof toolInput !== 'object') return undefined;
+	const input = toolInput as Record<string, unknown>;
+	for (const key of ['file_path', 'path', 'file', 'target', 'source']) {
+		const value = input[key];
+		if (typeof value === 'string' && value.trim()) return value;
+	}
+	return undefined;
+}
+
+function hookMatchesTool(hook: Hook, toolName: string): boolean {
+	if (!hook.matcher?.trim()) return true;
+	if (!toolName) return false;
+	try {
+		// Case-insensitive so `Edit|Write` matches both built-in tools and
+		// namespaced MCP variants like `mcp__docwriter-doc__edit_doc`.
+		return new RegExp(hook.matcher, 'i').test(toolName);
+	} catch {
+		return false;
+	}
+}
+
+async function runUserHooksForEvent(
+	event: HookEvent,
+	emitHookRun: HookRunEmitter,
+	opts: { toolName?: string; toolInput?: unknown } = {}
+): Promise<void> {
+	const userHooks = readHooks().hooks.filter((h) => h.enabled !== false && h.event === event);
+	const isToolEvent =
+		event === 'PreToolUse' ||
+		event === 'PostToolUse' ||
+		event === 'PostToolUseFailure';
+	const toolName = opts.toolName ?? '';
+	for (const hook of userHooks) {
+		if (isToolEvent && !hookMatchesTool(hook, toolName)) continue;
+		await runHookCommand(
+			hook,
+			toolName,
+			hookToolInputFilePath(opts.toolInput),
+			emitHookRun
+		);
+	}
+}
+
 /** Build the hook map for this render. Only user-defined shell hooks
  * (from `.docwriter/hooks.json`) are wired in. Agent writes to open tabs
  * go through `edit_doc` / `write_doc`, which mutate the live Y.Doc
@@ -634,22 +680,12 @@ function buildHooks(
 		return async (input) => {
 			const toolInput = (input as any).tool_input;
 			const toolName: string = (input as any).tool_name || '';
-			const filePath: string | undefined = toolInput?.file_path;
 			// For tool-based hooks, filter by matcher (regex over tool name).
 			// For non-tool hooks (Stop, UserPromptSubmit, Session*, etc.) the
 			// matcher is ignored here — the SDK handles event-type matching
 			// via the top-level matcher on the hook entry.
-			if (toolName && hook.matcher && hook.matcher.trim()) {
-				try {
-					// Case-insensitive so `Edit|Write` matches both the built-in
-					// `Edit`/`Write` tools and the agent's MCP tool variants
-					// like `mcp__docwriter-doc__edit_doc`.
-					if (!new RegExp(hook.matcher, 'i').test(toolName)) return {};
-				} catch {
-					return {};
-				}
-			}
-			await runHookCommand(hook, toolName, filePath, emitHookRun);
+			if (toolName && !hookMatchesTool(hook, toolName)) return {};
+			await runHookCommand(hook, toolName, hookToolInputFilePath(toolInput), emitHookRun);
 			return {};
 		};
 	}
@@ -747,7 +783,14 @@ export const POST: RequestHandler = async ({ request }) => {
 		const prompt = warmup
 			? `You are a writing assistant. The user has a set of files open as tabs. Acknowledge you're ready in 1-2 sentences. Don't edit anything.`
 			: buildMultiTabPrompt(active, tabsForPrompt, message) + planModeInstruction;
-		const systemPromptBlock = warmup ? undefined : buildSystemPrompt();
+		const baseSystemPromptBlock = warmup ? undefined : buildSystemPrompt();
+		const skillsPromptBlock =
+			!warmup && (providerId === 'openai' || providerId === 'cursor')
+				? buildSkillsPromptBlock()
+				: null;
+		const systemPromptBlock = [baseSystemPromptBlock, skillsPromptBlock]
+			.filter(Boolean)
+			.join('\n\n') || undefined;
 		if (systemPromptBlock) setLastSystemPrompt(systemPromptBlock);
 		const openTabPaths = new Set(allTabIds.map((tabId) => normalizeToolPath(tabFile(tabId))));
 
@@ -784,7 +827,8 @@ export const POST: RequestHandler = async ({ request }) => {
 					}
 				}
 
-				const hooks = buildHooks((entry) => send('hook_run', entry));
+				const emitHookRun: HookRunEmitter = (entry) => send('hook_run', entry);
+				const hooks = buildHooks(emitHookRun);
 
 				try {
 					const resolvedModel =
@@ -862,15 +906,15 @@ export const POST: RequestHandler = async ({ request }) => {
 						'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'Agent',
 						'AskUserQuestion', 'ExitPlanMode',
 						READ_DOC_TOOL_NAME, REPLY_TO_COMMENT_TOOL_NAME,
-						'read_doc', 'reply_to_comment', 'list_threads'
+						'read_doc', 'reply_to_comment', 'list_threads', TOOL_NAMES.READ_SKILL
 					];
 					const fullAllowedTools = [
 						'Read', 'Bash', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'Agent',
-						'mcp__docwriter__propose_rule', 'mcp__docwriter__propose_hook',
+						'mcp__docwriter__propose_rule', 'mcp__docwriter__propose_hook', 'mcp__docwriter__add_skill', 'mcp__docwriter__review_action',
 						'AskUserQuestion', 'ExitPlanMode',
 						EDIT_DOC_TOOL_NAME, READ_DOC_TOOL_NAME, WRITE_DOC_TOOL_NAME, REPLY_TO_COMMENT_TOOL_NAME,
 						'edit_doc', 'read_doc', 'write_doc', 'reply_to_comment', 'list_threads',
-						'propose_rule', 'propose_hook'
+						'propose_rule', 'propose_hook', TOOL_NAMES.READ_SKILL, TOOL_NAMES.ADD_SKILL, TOOL_NAMES.REVIEW_ACTION
 					];
 					const allowedTools = warmup
 						? ['Read', 'Glob', 'WebSearch', 'WebFetch']
@@ -889,6 +933,10 @@ export const POST: RequestHandler = async ({ request }) => {
 						roundImages?: ImageAttachmentPayload[]
 					): Promise<QueryRoundOutcome> {
 						let usedDocMutationTool = false;
+						const toolInputsForHooks = new Map<string, {
+							toolName: string;
+							input: Record<string, unknown>;
+						}>();
 
 						for await (const event of provider.query({
 							prompt: roundPrompt,
@@ -911,6 +959,12 @@ export const POST: RequestHandler = async ({ request }) => {
 							if (event.type === 'tool_call' && mutationToolNames.has(event.tool_name)) {
 								usedDocMutationTool = true;
 							}
+							if (providerId !== 'claude' && event.type === 'tool_call') {
+								toolInputsForHooks.set(event.tool_use_id, {
+									toolName: event.tool_name,
+									input: event.input
+								});
+							}
 							// Forward session IDs to runtime state. The session event
 							// arrives first, so this is also where we log the user
 							// message — under the now-established session id, so it
@@ -926,6 +980,20 @@ export const POST: RequestHandler = async ({ request }) => {
 							}
 							// Forward the event as-is to the SSE stream
 							send(event.type, event);
+							if (providerId !== 'claude' && event.type === 'tool_result') {
+								const toolCall = toolInputsForHooks.get(event.tool_use_id);
+								const hookEvent: HookEvent = event.is_error
+									? 'PostToolUseFailure'
+									: 'PostToolUse';
+								await runUserHooksForEvent(hookEvent, emitHookRun, {
+									toolName: toolCall?.toolName ?? '',
+									toolInput: toolCall?.input
+								});
+							}
+						}
+
+						if (providerId !== 'claude' && !warmup) {
+							await runUserHooksForEvent('Stop', emitHookRun);
 						}
 
 						return { usedDocMutationTool };

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -801,6 +801,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			async start(controller) {
 				const encoder = new TextEncoder();
 				const renderStart = Date.now();
+				let currentModelForTranscript = '';
 
 				const persistableEvents = new Set([
 					'assistant_text', 'assistant_thinking', 'tool_call_start',
@@ -809,7 +810,11 @@ export const POST: RequestHandler = async ({ request }) => {
 				]);
 
 				function send(event: string, data: unknown) {
-					const payload = { ...(data as object), _elapsed: Date.now() - renderStart };
+					const payload = {
+						...(data as object),
+						...(currentModelForTranscript ? { model: currentModelForTranscript } : {}),
+						_elapsed: Date.now() - renderStart
+					};
 					controller.enqueue(
 						encoder.encode(
 							`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`
@@ -833,6 +838,8 @@ export const POST: RequestHandler = async ({ request }) => {
 				try {
 					const resolvedModel =
 						model || process.env.DOCWRITER_DEFAULT_MODEL || undefined;
+					kvSet('model', resolvedModel ?? '');
+					currentModelForTranscript = resolvedModel ?? '';
 
 					const provider = await getProvider(providerId);
 					const tools = buildToolDefinitions();

--- a/src/routes/api/skills/+server.ts
+++ b/src/routes/api/skills/+server.ts
@@ -1,0 +1,47 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+	addCustomSkill,
+	listSkills,
+	removeCustomSkill,
+	setSkillEnabled
+} from '$lib/server/skills-config';
+
+export const GET: RequestHandler = async () => {
+	return json(listSkills());
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const body = await request.json().catch(() => ({}));
+		const source = typeof body?.source === 'string' ? body.source : '';
+		addCustomSkill(source);
+		return json({ ok: true, ...listSkills() });
+	} catch (e) {
+		return json({ ok: false, error: (e as Error).message }, { status: 400 });
+	}
+};
+
+export const PUT: RequestHandler = async ({ request }) => {
+	try {
+		const body = await request.json().catch(() => ({}));
+		const id = typeof body?.id === 'string' ? body.id : '';
+		const enabled = body?.enabled === true;
+		if (!id) return json({ ok: false, error: 'id required' }, { status: 400 });
+		setSkillEnabled(id, enabled);
+		return json({ ok: true, ...listSkills() });
+	} catch (e) {
+		return json({ ok: false, error: (e as Error).message }, { status: 400 });
+	}
+};
+
+export const DELETE: RequestHandler = async ({ url }) => {
+	try {
+		const id = url.searchParams.get('id') || '';
+		if (!id) return json({ ok: false, error: 'id required' }, { status: 400 });
+		removeCustomSkill(id);
+		return json({ ok: true, ...listSkills() });
+	} catch (e) {
+		return json({ ok: false, error: (e as Error).message }, { status: 400 });
+	}
+};

--- a/src/routes/preview/+page.svelte
+++ b/src/routes/preview/+page.svelte
@@ -25,10 +25,16 @@
 	let connectionState = $state<'connecting' | 'connected' | 'disconnected'>('connecting');
 	let lastReloadAt = $state<number | null>(null);
 	let themeName = $state('light');
+	let embedded = $state(false);
+	let closePdfSidebar = $state(false);
 
 	let sseSource: EventSource | null = null;
 	let saved: { kind: 'html' | 'pdf' | 'image'; data: unknown } | null = null;
 	let broadcastChannel: BroadcastChannel | null = null;
+	let pendingPdfJump: { page: number; x: number; y: number } | null = null;
+	let pendingPdfJumpAttempts = 0;
+	let pendingPdfJumpTimer: ReturnType<typeof setTimeout> | null = null;
+	let pdfSearchSerial = 0;
 
 	function inferKind(p: string): typeof kind {
 		const ext = p.toLowerCase().split('.').pop() ?? '';
@@ -41,7 +47,7 @@
 
 	function makePdfSrc(path: string, buster: number): string {
 		const fileUrl = `/api/preview?path=${encodeURIComponent(path)}&v=${buster}`;
-		return `/pdfjs/web/viewer.html?file=${encodeURIComponent(fileUrl)}`;
+		return `/pdfjs/web/viewer.html?file=${encodeURIComponent(fileUrl)}${closePdfSidebar ? '#pagemode=none' : ''}`;
 	}
 	function makeDirectSrc(path: string, buster: number): string {
 		return `/api/preview?path=${encodeURIComponent(path)}&v=${buster}`;
@@ -210,9 +216,41 @@
 		}
 	}
 
+	function closePdfSidebarIfRequested() {
+		if (!closePdfSidebar || !iframeEl || kind !== 'pdf') return;
+		const win = iframeEl.contentWindow as unknown as
+			| {
+					PDFViewerApplication?: {
+						pdfSidebar?: {
+							isOpen?: boolean;
+							close?: () => void;
+							switchView?: (view: number, forceOpen?: boolean) => void;
+						};
+					};
+			  }
+			| null;
+		const start = Date.now();
+		const attempt = () => {
+			try {
+				const sidebar = win?.PDFViewerApplication?.pdfSidebar;
+				if (sidebar) {
+					sidebar.switchView?.(0, false);
+					if (sidebar.isOpen) sidebar.close?.();
+					return;
+				}
+			} catch {
+				/* PDF.js may still be initializing — retry briefly. */
+			}
+			if (Date.now() - start < 3000) {
+				setTimeout(attempt, 50);
+			}
+		};
+		attempt();
+	}
+
 	/** Attach a dblclick listener to the PDF.js viewer that resolves the
 	 * click to a source location via /api/synctex and relays it to the
-	 * docwriter opener window. PDF.js renders each page as a
+	 * docwriter host window. PDF.js renders each page as a
 	 * `<div class="page" data-page-number="N">`; we compute the click's
 	 * page-relative coordinates, divide by the current scale to get PDF
 	 * points (synctex expects points, not CSS pixels), and POST to the
@@ -248,7 +286,7 @@
 				});
 				const data = await res.json();
 				if (data?.ok && typeof data.file === 'string' && typeof data.line === 'number') {
-					relayJumpToOpener(data.file, data.line);
+					relayJumpToHost(data.file, data.line);
 				}
 			} catch {
 				/* synctex CLI missing, .synctex.gz missing, network error — silent */
@@ -262,17 +300,19 @@
 		doc.addEventListener('dblclick', listener, true);
 	}
 
-	function relayJumpToOpener(file: string, line: number) {
+	function relayJumpToHost(file: string, line: number) {
 		const opener = window.opener as Window | null;
-		if (!opener || opener.closed) return;
+		const embeddedParent = window.parent !== window ? window.parent : null;
+		const target = opener && !opener.closed ? opener : embeddedParent;
+		if (!target) return;
 		try {
-			opener.postMessage(
+			target.postMessage(
 				{ kind: 'docwriter-synctex-jump', file, line },
 				window.location.origin
 			);
-			opener.focus();
+			if (target === opener) opener.focus();
 		} catch {
-			/* opener navigated away or different origin — ignore */
+			/* host navigated away or different origin — ignore */
 		}
 	}
 
@@ -291,15 +331,23 @@
 		}
 		broadcastChannel.onmessage = (ev: MessageEvent) => {
 			const data = ev.data as
-				| { kind?: string; page?: number; x?: number; y?: number; h?: number; v?: number }
+				| { kind?: string; page?: number; x?: number; y?: number; h?: number; v?: number; queries?: string[] }
 				| null;
-			if (!data || data.kind !== 'pdf-jump') return;
+			if (!data) return;
+			if (data.kind === 'pdf-search') {
+				const queries = Array.isArray(data.queries)
+					? data.queries.filter((q): q is string => typeof q === 'string' && q.trim().length > 0)
+					: [];
+				if (queries.length > 0) void searchPdf(queries);
+				return;
+			}
+			if (data.kind !== 'pdf-jump') return;
 			scrollPdfTo(data.page ?? 1, data.x ?? 0, data.v ?? data.y ?? 0);
 		};
 	}
 
-	function scrollPdfTo(page: number, x: number, y: number) {
-		if (!iframeEl) return;
+	function tryScrollPdfTo(jump: { page: number; x: number; y: number }): boolean {
+		if (!iframeEl || kind !== 'pdf') return false;
 		const w = iframeEl.contentWindow as unknown as {
 			PDFViewerApplication?: {
 				pdfViewer?: {
@@ -311,8 +359,8 @@
 			};
 		};
 		const app = w?.PDFViewerApplication;
-		if (!app?.pdfViewer) return;
-		// destArray: ['XYZ', x, top, zoom]. PDF.js uses bottom-left origin
+		if (!app?.pdfViewer) return false;
+		// destArray: [ref, { name: 'XYZ' }, x, top, zoom]. PDF.js uses bottom-left origin
 		// for PDF coords; synctex Y is from the top of the page in points,
 		// so we leave it as `y` (PDF.js does the conversion internally
 		// when interpreting XYZ dest with `top` measured from page bottom?
@@ -325,12 +373,109 @@
 		// conversion. If it's slightly off vertically that's the cause.)
 		try {
 			app.pdfViewer.scrollPageIntoView({
-				pageNumber: page,
-				destArray: ['XYZ', x, y, null]
+				pageNumber: jump.page,
+				destArray: [null, { name: 'XYZ' }, jump.x, jump.y, null]
 			});
 			window.focus();
+			return true;
 		} catch {
-			/* PDF not ready yet — ignore */
+			return false;
+		}
+	}
+
+	function flushPendingPdfJump() {
+		if (!pendingPdfJump) return;
+		if (tryScrollPdfTo(pendingPdfJump)) {
+			pendingPdfJump = null;
+			pendingPdfJumpAttempts = 0;
+			if (pendingPdfJumpTimer) clearTimeout(pendingPdfJumpTimer);
+			pendingPdfJumpTimer = null;
+			return;
+		}
+		if (pendingPdfJumpAttempts >= 40) {
+			pendingPdfJump = null;
+			pendingPdfJumpAttempts = 0;
+			pendingPdfJumpTimer = null;
+			return;
+		}
+		pendingPdfJumpAttempts += 1;
+		if (pendingPdfJumpTimer) clearTimeout(pendingPdfJumpTimer);
+		pendingPdfJumpTimer = setTimeout(flushPendingPdfJump, 100);
+	}
+
+	function scrollPdfTo(page: number, x: number, y: number) {
+		pendingPdfJump = { page, x, y };
+		pendingPdfJumpAttempts = 0;
+		flushPendingPdfJump();
+	}
+
+	function getPdfApplication():
+		| {
+				eventBus?: { dispatch: (name: string, data: Record<string, unknown>) => void };
+				findController?: { _matchesCountTotal?: number };
+				pdfViewer?: { container?: HTMLElement };
+		  }
+		| null {
+		if (!iframeEl || kind !== 'pdf') return null;
+		try {
+			const w = iframeEl.contentWindow as unknown as {
+				PDFViewerApplication?: {
+					eventBus?: { dispatch: (name: string, data: Record<string, unknown>) => void };
+					findController?: { _matchesCountTotal?: number };
+					pdfViewer?: { container?: HTMLElement };
+				};
+			};
+			return w?.PDFViewerApplication ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	function dispatchPdfFind(query: string): boolean {
+		const app = getPdfApplication();
+		if (!app?.eventBus) return false;
+		app.eventBus.dispatch('find', {
+			source: window,
+			type: '',
+			query,
+			caseSensitive: false,
+			entireWord: false,
+			highlightAll: true,
+			findPrevious: false,
+			matchDiacritics: false,
+			phraseSearch: true
+		});
+		return true;
+	}
+
+	async function searchPdf(queries: string[]) {
+		const serial = ++pdfSearchSerial;
+		const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+		for (let attempt = 0; attempt < 40; attempt += 1) {
+			if (serial !== pdfSearchSerial) return;
+			const app = getPdfApplication();
+			if (app?.eventBus && app.findController) {
+				for (const query of queries) {
+					if (serial !== pdfSearchSerial) return;
+					if (!dispatchPdfFind(query)) break;
+					await sleep(450);
+					if ((app.findController._matchesCountTotal ?? 0) > 0) return;
+				}
+				return;
+			}
+			await sleep(100);
+		}
+	}
+
+	function closeEmbeddedPreview() {
+		if (!embedded || window.parent === window) return;
+		try {
+			window.parent.postMessage(
+				{ kind: 'docwriter-close-preview-pane' },
+				window.location.origin
+			);
+		} catch {
+			/* parent navigated away or different origin — ignore */
 		}
 	}
 
@@ -338,6 +483,10 @@
 		const url = new URL(window.location.href);
 		path = url.searchParams.get('path') ?? '';
 		kind = inferKind(path);
+		embedded = url.searchParams.get('embedded') === '1';
+		closePdfSidebar =
+			url.searchParams.get('pdfSidebar') === '0' ||
+			url.searchParams.get('pdfSidebar') === 'closed';
 		const themeParam = url.searchParams.get('theme');
 		applyDocwriterTheme(themeParam ?? 'light');
 		if (path) {
@@ -352,6 +501,8 @@
 		sseSource = null;
 		broadcastChannel?.close();
 		broadcastChannel = null;
+		if (pendingPdfJumpTimer) clearTimeout(pendingPdfJumpTimer);
+		pendingPdfJumpTimer = null;
 	});
 
 	let src = $derived(
@@ -375,6 +526,9 @@
 		</span>
 		<button onclick={manualReload} title="Reload now">Reload</button>
 		<button onclick={openInNewWindow} title="Open raw file in a new tab">Raw</button>
+		{#if embedded}
+			<button onclick={closeEmbeddedPreview} title="Close side preview">Close</button>
+		{/if}
 		{#if lastReloadAt}
 			<span class="last-reload">updated {new Date(lastReloadAt).toLocaleTimeString()}</span>
 		{/if}
@@ -391,7 +545,9 @@
 				onload={() => {
 					restoreScroll();
 					injectThemeIntoIframe();
+					closePdfSidebarIfRequested();
 					attachSynctexHandler();
+					flushPendingPdfJump();
 				}}
 			></iframe>
 		{:else if kind === 'image'}
@@ -406,7 +562,9 @@
 				onload={() => {
 					restoreScroll();
 					injectThemeIntoIframe();
+					closePdfSidebarIfRequested();
 					attachSynctexHandler();
+					flushPendingPdfJump();
 				}}
 			></iframe>
 		{:else}


### PR DESCRIPTION
## Summary

This PR bundles the DocWriter UI and agent-harness updates from the current iteration:

- Adds a Skills settings panel with preset skills, install/sync APIs, and native folder syncing for Claude/Codex/Pi-style discovery.
- Adds the bundled `plain-writing` skill and routes active skills into provider prompts/tool handling.
- Improves writing-rule UI, comment/thread visibility, feedback actions, outline styling, and source comment toggling/styling.
- Adds richer markdown/source rendering for lists, tables, SVG/D3/source previews, and muted source comments.
- Adds split PDF preview support with a resizable editor/PDF divider, embedded PDF sidebar closure, preview window parity, live reload, and SyncTeX locate support.
- Adds session transcript JSON export from the transcript viewer, using the browser Save dialog when available with a download fallback.
- Includes provider/model metadata in the session transcript display and JSON export.
- Fixes hook execution/reload behavior and expands tool/provider support for review actions and skill commands.

## Why

The editor now supports the writing workflows discussed in the session: persistent rules that are editable without cramped pills, actionable comments from preset feedback buttons, markdown/source rendering that behaves more like a writing surface, Overleaf-style source/PDF work for LaTeX, and shareable transcript exports for debugging or collaboration.

## Validation

- `npm run check` passes with the existing `OutlinePane` line-clamp and `TabBar` tablist warnings.
- `npm run build` passes with existing chunk-size and dependency circularity warnings.

## Notes

`CLAUDE.md` had unrelated local sample-markdown changes and is intentionally not included in this PR.