### PR TITLE
fix: stop cascading through stale pending review rounds

### DIFF
--- a/src/lib/review-rounds.ts
+++ b/src/lib/review-rounds.ts
@@ -130,7 +130,16 @@ export function materializePendingReviewText(
 ): string {
 	let currentText = baseText;
 	for (const round of rounds) {
-		currentText = applyPendingReviewRound(currentText, round).nextText;
+		const applied = applyPendingReviewRound(currentText, round);
+		if (applied.stale) {
+			// Stop cascading: once a round is stale, subsequent rounds likely
+			// depend on it and would produce incorrect matches. Return the
+			// current text (committed + successfully-applied rounds) so that
+			// `read_doc` / `edit_doc` see a consistent snapshot rather than
+			// a broken chain where some edits silently failed to apply.
+			break;
+		}
+		currentText = applied.nextText;
 	}
 	return currentText;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `edit_doc` failures when multiple micro-edits are stacked on the same paragraph (common with directive markers like `[[...]]`).

## Problem

When using the agent to make multiple edits on the same paragraph:

1. Agent stacks rounds 1, 2, 3 on paragraph P
2. User edits committed text or rejects round 1
3. Round 1 becomes stale (its `old_string` no longer matches)
4. **Before this fix:** `materializePendingReviewText` silently skipped the stale round and continued to rounds 2, 3. These rounds also failed because their `old_string` was constructed assuming round 1 had applied. The agent saw "hybrid" text that didn't match its expectations → repeated `edit_doc` failures.

## Solution

`materializePendingReviewText` now **stops at the first stale round** instead of silently skipping it. This ensures:

- `read_doc` and `edit_doc` see the same consistent snapshot
- Agents don't get confused by partially-applied round chains
- The snapshot is: committed text + successfully-applied rounds only

## Root Cause Analysis

The issue was identified as the **review proposal layer**, not typography normalization. Key insight from investigation:

> Repeated failures on the same paragraph after "diagnostic trims" fit this pattern: early `edit_doc` calls succeed and stack pending rounds; later calls still use stale `old_string` from memory or the opening prompt diff.

The `[[...]]` directive markers and typography (en-dashes, curly quotes) were symptoms, not causes — those paragraphs get many small edits where one stale/skipped round breaks all following `old_string` matches.

## Testing

- Type check passes (`npm run check`)
- Verified logic with test scenarios for stale round cascading
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-people-group.slack.com/archives/C0B3XN8TY90/p1782029568081719?thread_ts=1782029568.081719&cid=C0B3XN8TY90)

<div><a href="https://cursor.com/agents/bc-ca06e8e7-8619-53a2-890b-793ada36a821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca06e8e7-8619-53a2-890b-793ada36a821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

