### PR TITLE
Persist theme selection across page refresh

### DIFF
--- a/src/lib/server/db-writes.ts
+++ b/src/lib/server/db-writes.ts
@@ -82,6 +82,15 @@ export function dbSetEditorSoftWrap(enabled: boolean) {
 	}
 }
 
+export function dbSetTheme(theme: string) {
+	try {
+		const db = getDb();
+		db.prepare('INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)').run('theme', theme);
+	} catch (err) {
+		logDbError('setTheme', err);
+	}
+}
+
 export function dbClearSessionState() {
 	try {
 		const db = getDb();

--- a/src/lib/server/runtime-state.ts
+++ b/src/lib/server/runtime-state.ts
@@ -6,9 +6,11 @@ import {
 	dbSetAgentSettings,
 	dbSetSessionId,
 	dbSetEditorSoftWrap,
+	dbSetTheme,
 	dbUpsertTabs,
 	kvGet
 } from './db-writes';
+import { resolveThemeName } from '$lib/themes';
 import { getDb } from './db';
 import { syncRulesToClaudeMemory } from './claude-memory';
 
@@ -160,6 +162,14 @@ export function getEditorSoftWrap(): boolean {
 
 export function setEditorSoftWrap(enabled: boolean) {
 	dbSetEditorSoftWrap(enabled);
+}
+
+export function getTheme(): string {
+	return resolveThemeName(kvGet('theme'));
+}
+
+export function setTheme(theme: string) {
+	dbSetTheme(resolveThemeName(theme));
 }
 
 export function getTabsState(): TabsState {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -481,6 +481,8 @@ export async function loadAvailableModels(providerId?: string) {
 	}
 }
 
+/** Active UI theme. Persisted through the server runtime-state layer
+ * (SQLite-backed) via /api/session whenever the user changes it. */
 export const selectedTheme = writable<string>('light');
 
 /** History pane verbosity. `verbose` = every tool call, assistant monologue,

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -4,6 +4,14 @@ export interface Theme {
 	vars: Record<string, string>;
 }
 
+export const DEFAULT_THEME_NAME = 'light';
+
+/** Return a known theme name, falling back to the default when missing or invalid. */
+export function resolveThemeName(name: string | null | undefined): string {
+	if (name && themes.some((t) => t.name === name)) return name;
+	return DEFAULT_THEME_NAME;
+}
+
 export const themes: Theme[] = [
 	{
 		name: 'light',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2134,6 +2134,9 @@
 			if (typeof data.editorSoftWrap === 'boolean') {
 				editorSoftWrap.set(data.editorSoftWrap);
 			}
+			if (typeof data.theme === 'string') {
+				selectedTheme.set(data.theme);
+			}
 		} catch (e) {
 			console.error('Failed to restore session state:', e);
 		}
@@ -2155,6 +2158,8 @@
 			actionUsageCounts.subscribe((v) => (counts = v))();
 			let wrapLongLines = false;
 			editorSoftWrap.subscribe((v) => (wrapLongLines = v))();
+			let theme = 'light';
+			selectedTheme.subscribe((v) => (theme = v))();
 			try {
 				await fetch('/api/session', {
 					method: 'PUT',
@@ -2162,7 +2167,8 @@
 					body: JSON.stringify({
 						recentActions: recent,
 						actionUsageCounts: counts,
-						editorSoftWrap: wrapLongLines
+						editorSoftWrap: wrapLongLines,
+						theme
 					})
 				});
 			} catch (e) {
@@ -2187,8 +2193,6 @@
 			window.removeEventListener('resize', clampSidebarPanels);
 		};
 
-		const initialTheme = themes.find((t) => t.name === themeName) || themes[0];
-		applyTheme(initialTheme);
 		// HMR safety: if the module was hot-reloaded during a render, the
 		// store could still say we're rendering. Clamp it to false so the
 		// submit button unlocks.
@@ -2199,10 +2203,13 @@
 		// docLoaded flips true, so by then the right Y.Doc is registered.
 		// Restore the selection-toolbar recents + LRU usage counts from
 		// server state so refresh doesn't wipe cached feedback pills or editor
-		// view prefs like soft wrap. Must complete BEFORE the editor mounts and
-		// before we attach the persist subscribers, otherwise defaults could
-		// overwrite the real values.
+		// view prefs like soft wrap and theme. Must complete BEFORE the editor
+		// mounts and before we attach the persist subscribers, otherwise
+		// defaults could overwrite the real values.
 		await restoreSessionState();
+
+		const initialTheme = themes.find((t) => t.name === themeName) || themes[0];
+		applyTheme(initialTheme);
 
 		const active = await loadTabs();
 		if (active) await loadTab(active);
@@ -2223,6 +2230,7 @@
 		recentActions.subscribe(() => schedulePersistSession());
 		actionUsageCounts.subscribe(() => schedulePersistSession());
 		editorSoftWrap.subscribe(() => schedulePersistSession());
+		selectedTheme.subscribe(() => schedulePersistSession());
 
 		// Subscribe to the file-watcher event bus (used by `docwriter --watch`).
 		// When the bin's fs.watch sees external changes it POSTs to /api/live,

--- a/src/routes/api/session/+server.ts
+++ b/src/routes/api/session/+server.ts
@@ -9,7 +9,9 @@ import {
 	setActionUsageCounts,
 	clearSessionState,
 	getEditorSoftWrap,
-	setEditorSoftWrap
+	setEditorSoftWrap,
+	getTheme,
+	setTheme
 } from '$lib/server/runtime-state';
 import { AGENT_SCRATCH_DIR } from '$lib/server/document-files';
 import { existsSync, readdirSync, rmSync } from 'fs';
@@ -21,7 +23,8 @@ export const GET: RequestHandler = async () => {
 		serverInstanceId: getServerInstanceId(),
 		recentActions: getRecentActions(),
 		actionUsageCounts: getActionUsageCounts(),
-		editorSoftWrap: getEditorSoftWrap()
+		editorSoftWrap: getEditorSoftWrap(),
+		theme: getTheme()
 	});
 };
 
@@ -30,6 +33,7 @@ export const PUT: RequestHandler = async ({ request }) => {
 	if (body.recentActions) setRecentActions(body.recentActions);
 	if (body.actionUsageCounts) setActionUsageCounts(body.actionUsageCounts);
 	if (typeof body.editorSoftWrap === 'boolean') setEditorSoftWrap(body.editorSoftWrap);
+	if (typeof body.theme === 'string') setTheme(body.theme);
 	return json({ ok: true });
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Choosing a theme in Settings → Theme and refreshing the page reset the UI back to Light. `selectedTheme` was an in-memory Svelte store with no persistence.

## Design

Theme is a **workspace-level editor display preference**, not a browser chrome toggle. It belongs alongside `editorSoftWrap` in DocWriter's SQLite-backed runtime state (`.docwriter/docwriter.db`, `kv` table), loaded/saved through `/api/session`.

This avoids `localStorage`, which would:
- Not travel with the workspace when opening the same project elsewhere
- Split persistence between per-browser and per-workspace settings inconsistently

Pane visibility (`showSidebar`, `showFilesPane`) and history verbosity stay in `localStorage` because they are browser-layout preferences. Theme affects the whole editing surface and should follow the project.

## Changes

- Add `getTheme` / `setTheme` in `runtime-state.ts` with `resolveThemeName()` validation in `themes.ts`
- Return `theme` from `GET /api/session` and accept it on `PUT /api/session`
- On mount, restore theme from the server before applying CSS variables
- Debounce-persist theme changes alongside `editorSoftWrap`

## Verification

- `npm run check` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://data-people-group.slack.com/archives/C0B3XN8TY90/p1782256762746249?thread_ts=1782256762.746249&cid=C0B3XN8TY90)

<div><a href="https://cursor.com/agents/bc-f9538ee8-c7fd-53b4-a68c-6a73204c2a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9538ee8-c7fd-53b4-a68c-6a73204c2a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

