### PR TITLE
Fix spurious em-dash diff after accepting agent edits

### DIFF
--- a/src/lib/review-rounds.ts
+++ b/src/lib/review-rounds.ts
@@ -1,5 +1,6 @@
 import type { PendingReviewOperation, PendingReviewRound } from './types';
 import { classifyRoundKind } from './review-diff';
+import { normalizeTypography } from '$lib/shared/ydoc-codec';
 
 export interface MaterializedPendingReviewRound extends PendingReviewRound {
 	beforeMd: string;
@@ -35,7 +36,7 @@ export function reviewTextHash(text: string): string {
 
 function applyOperation(currentText: string, operation: PendingReviewOperation): AppliedReviewRound {
 	if (operation.type === 'write') {
-		return { nextText: operation.content, stale: false };
+		return { nextText: normalizeTypography(operation.content), stale: false };
 	}
 
 	const hits = countOccurrences(currentText, operation.oldString);
@@ -62,9 +63,11 @@ function applyOperation(currentText: string, operation: PendingReviewOperation):
 	// any other content with literal $-with-trailing-quote sequences. The
 	// replaceAll path uses split/join which goes through a different code
 	// path and isn't affected.
-	const nextText = operation.replaceAll
-		? currentText.split(operation.oldString).join(operation.newString)
-		: currentText.replace(operation.oldString, () => operation.newString);
+	const nextText = normalizeTypography(
+		operation.replaceAll
+			? currentText.split(operation.oldString).join(operation.newString)
+			: currentText.replace(operation.oldString, () => operation.newString)
+	);
 	return { nextText, stale: false };
 }
 
@@ -132,5 +135,5 @@ export function materializePendingReviewText(
 	for (const round of rounds) {
 		currentText = applyPendingReviewRound(currentText, round).nextText;
 	}
-	return currentText;
+	return normalizeTypography(currentText);
 }

--- a/src/lib/server/last-seen.ts
+++ b/src/lib/server/last-seen.ts
@@ -1,0 +1,22 @@
+import * as Y from 'yjs';
+import { kvSet } from './db-writes';
+import { materializePendingReviewText } from '$lib/review-rounds';
+import { serializeYDoc, readReviewRounds } from '$lib/shared/ydoc-codec';
+
+const LAST_SEEN_PREFIX = 'last_seen:';
+
+export function lastSeenKey(tabId: string): string {
+	return LAST_SEEN_PREFIX + tabId;
+}
+
+/** Agent-facing markdown for a tab: committed Y.Doc text plus any pending
+ * review rounds, with typography normalized to match `serializeYDoc`. */
+export function readTabMarkdownForAgent(ydoc: Y.Doc): string {
+	return materializePendingReviewText(serializeYDoc(ydoc), readReviewRounds(ydoc));
+}
+
+/** Refresh the agent's diff baseline after accept/reject changes what
+ * `read_doc` would return (e.g. pending proposal removed). */
+export function touchLastSeen(tabId: string, ydoc: Y.Doc): void {
+	kvSet(lastSeenKey(tabId), readTabMarkdownForAgent(ydoc));
+}

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -28,7 +28,8 @@ import {
 	getReviewArray,
 	readReviewRounds,
 	getCommentsMap,
-	AGENT_ORIGIN
+	AGENT_ORIGIN,
+	normalizeTypography
 } from '$lib/shared/ydoc-codec';
 import { isScratchPath, resolveTabFromPath, isOpenTab } from './path-router';
 import { classifyRoundKind } from '$lib/review-diff';
@@ -548,6 +549,8 @@ const editDocTool = tool(
 	},
 	async ({ file_path, old_string, new_string, replace_all, thread_id }) => {
 		const replaceAll = replace_all === true;
+		old_string = normalizeTypography(old_string);
+		new_string = normalizeTypography(new_string);
 		if (isScratchPath(file_path)) return editScratch(file_path, old_string, new_string, replaceAll);
 
 		const opened = ensureWorkspaceTabOpen(file_path, { createIfMissing: false });
@@ -702,6 +705,8 @@ const writeDocTool = tool(
 	},
 	async ({ file_path, content }) => {
 		if (isScratchPath(file_path)) return writeScratch(file_path, content);
+
+		content = normalizeTypography(content);
 
 		const opened = ensureWorkspaceTabOpen(file_path, { createIfMissing: true });
 		if (!opened.ok) return opened.error;

--- a/src/lib/server/providers/tool-handlers.ts
+++ b/src/lib/server/providers/tool-handlers.ts
@@ -26,7 +26,8 @@ import { readFileSync, existsSync } from 'fs';
 import * as Y from 'yjs';
 import {
 	getCommentsMap,
-	AGENT_ORIGIN
+	AGENT_ORIGIN,
+	normalizeTypography
 } from '$lib/shared/ydoc-codec';
 import type {
 	CommentMessage,
@@ -144,7 +145,9 @@ export function buildToolDefinitions(): ToolDefinition[] {
 					replace_all?: boolean; thread_id?: string;
 				};
 				const replaceAll = replace_all === true;
-				if (isScratchPath(path)) return toToolResult(editScratch(path, old_string, new_string, replaceAll));
+				const normOld = normalizeTypography(old_string);
+				const normNew = normalizeTypography(new_string);
+				if (isScratchPath(path)) return toToolResult(editScratch(path, normOld, normNew, replaceAll));
 
 				const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
 				if (!opened.ok) return toToolResult(opened.error);
@@ -156,7 +159,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 				let failure: string | null = null;
 				let appliedHits = 0;
 				const result = await runTabWrite(tabId, 'agent_edit_doc', (currentMd) => {
-					const hits = countOccurrences(currentMd, old_string);
+					const hits = countOccurrences(currentMd, normOld);
 					if (hits === 0) {
 						failure = `old_string not found in ${path}. The user may have edited this area — read_doc to see the current state and retry.`;
 						return null;
@@ -167,10 +170,10 @@ export function buildToolDefinitions(): ToolDefinition[] {
 					}
 					appliedHits = hits;
 					const afterMd = replaceAll
-						? currentMd.split(old_string).join(new_string)
-						: currentMd.replace(old_string, () => new_string);
+						? currentMd.split(normOld).join(normNew)
+						: currentMd.replace(normOld, () => normNew);
 					return {
-						operation: { type: 'edit' as const, oldString: old_string, newString: new_string, ...(replaceAll ? { replaceAll: true } : {}) },
+						operation: { type: 'edit' as const, oldString: normOld, newString: normNew, ...(replaceAll ? { replaceAll: true } : {}) },
 						afterMd
 					};
 				});
@@ -256,11 +259,12 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			execute: async (input) => {
 				const { path, content } = input as { path: string; content: string };
 				if (isScratchPath(path)) return toToolResult(writeScratch(path, content));
+				const normalized = normalizeTypography(content);
 				const opened = ensureWorkspaceTabOpen(path, { createIfMissing: true });
 				if (!opened.ok) return toToolResult(opened.error);
 				const result = await runTabWrite(opened.tabId, 'agent_write_doc', () => ({
-					operation: { type: 'write' as const, content },
-					afterMd: content
+					operation: { type: 'write' as const, content: normalized },
+					afterMd: normalized
 				}));
 				if ('error' in result) {
 					return { isError: true, content: [{ type: 'text' as const, text: `write_doc failed: ${result.error}` }] };

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -27,6 +27,7 @@ import {
 	applyEditToFragment
 } from '$lib/shared/ydoc-codec';
 import { applyPendingReviewRound } from '$lib/review-rounds';
+import { touchLastSeen } from '$lib/server/last-seen';
 import {
 	appendUpdate,
 	replayUpdatesInto,
@@ -314,6 +315,8 @@ export async function acceptTabRounds(
 		const deltaBytes = Y.encodeStateAsUpdate(ydoc, beforeStateVector);
 		const yjsUpdate = Buffer.from(deltaBytes).toString('base64');
 
+		touchLastSeen(tabId, ydoc);
+
 		return { acceptedCount: accepted.length, rounds: remaining, yjsUpdate };
 	});
 }
@@ -343,6 +346,7 @@ export async function rejectTabRounds(
 			}, USER_ORIGIN);
 			const deltaBytes = Y.encodeStateAsUpdate(ydoc, beforeStateVector);
 			const yjsUpdate = Buffer.from(deltaBytes).toString('base64');
+			touchLastSeen(tabId, ydoc);
 			return { rejectedCount: current.length, rounds: [], yjsUpdate };
 		}
 		const idx = current.findIndex((r) => r.id === roundId);
@@ -354,6 +358,7 @@ export async function rejectTabRounds(
 		const remaining = current.slice(0, idx).concat(current.slice(idx + 1));
 		const deltaBytes = Y.encodeStateAsUpdate(ydoc, beforeStateVector);
 		const yjsUpdate = Buffer.from(deltaBytes).toString('base64');
+		touchLastSeen(tabId, ydoc);
 		return { rejectedCount: 1, rounds: remaining, yjsUpdate };
 	});
 }

--- a/src/lib/shared/ydoc-codec.ts
+++ b/src/lib/shared/ydoc-codec.ts
@@ -140,7 +140,7 @@ export function applyEditToFragment(
 		// asking for it.
 		const fullText = normalizeTypography(paraTexts.join('\n'));
 		if (fullText.indexOf(oldString) < 0) return false;
-		const replaced = fullText.split(oldString).join(newString);
+		const replaced = fullText.split(oldString).join(normalizeTypography(newString));
 		if (replaced === fullText) return false;
 		const newParas = buildParagraphElements(replaced);
 		fragment.delete(0, fragment.length);
@@ -180,7 +180,7 @@ export function applyEditToFragment(
 
 	const before = paraTexts[firstAffected].slice(0, startInFirst);
 	const after = paraTexts[lastAffected].slice(endInLast);
-	const splicedText = before + newString + after;
+	const splicedText = before + normalizeTypography(newString) + after;
 	const newParas = buildParagraphElements(splicedText);
 	const count = lastAffected - firstAffected + 1;
 	fragment.delete(firstAffected, count);
@@ -195,7 +195,7 @@ export function seedYDoc(ydoc: Y.Doc, content: string): void {
 	const fragment = getFragment(ydoc);
 	if (fragment.length > 0) return;
 	if (!content) return;
-	fragment.insert(0, buildParagraphElements(content));
+	fragment.insert(0, buildParagraphElements(normalizeTypography(content)));
 }
 
 /** Replace the fragment's content wholesale. Callers must wrap this in
@@ -203,5 +203,5 @@ export function seedYDoc(ydoc: Y.Doc, content: string): void {
 export function replaceYDocText(ydoc: Y.Doc, content: string): void {
 	const fragment = getFragment(ydoc);
 	if (fragment.length > 0) fragment.delete(0, fragment.length);
-	if (content) fragment.insert(0, buildParagraphElements(content));
+	if (content) fragment.insert(0, buildParagraphElements(normalizeTypography(content)));
 }

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -20,14 +20,14 @@ import { runHookCommand, type HookRunEmitter } from '$lib/server/hook-runner';
 import { getSessionId, setSessionId, setLastSystemPrompt, getTabsState } from '$lib/server/runtime-state';
 import { readMeta } from '$lib/server/document-io';
 import { kvGet, kvSet, dbAppendConversationEvent } from '$lib/server/db-writes';
-import { serializeYDoc, readReviewRounds, readCommentThreads } from '$lib/shared/ydoc-codec';
+import { readCommentThreads, readReviewRounds } from '$lib/shared/ydoc-codec';
 import type { CommentThread } from '$lib/types';
 import { replayUpdatesInto } from '$lib/server/ydoc-persistence';
 import { registerPendingAskUser } from '$lib/server/ask-user-state';
 import { unifiedLineDiff } from '$lib/diff';
 import { listStyleReferences } from '$lib/server/references';
 import { buildSkillsPromptBlock } from '$lib/server/skills-config';
-import { materializePendingReviewText } from '$lib/review-rounds';
+import { lastSeenKey, readTabMarkdownForAgent } from '$lib/server/last-seen';
 import {
 	EDIT_DOC_TOOL_NAME,
 	READ_DOC_TOOL_NAME,
@@ -49,12 +49,12 @@ function readLiveTabMarkdown(tabId: string): string {
 	const hp = holder.__docwriterWsServer?.hocuspocus;
 	const liveDoc = hp?.documents?.get(tabId) as Y.Doc | undefined;
 	if (liveDoc) {
-		return materializePendingReviewText(serializeYDoc(liveDoc), readReviewRounds(liveDoc));
+		return readTabMarkdownForAgent(liveDoc);
 	}
 	const ydoc = new Y.Doc();
 	try {
 		replayUpdatesInto(ydoc, tabId);
-		return materializePendingReviewText(serializeYDoc(ydoc), readReviewRounds(ydoc));
+		return readTabMarkdownForAgent(ydoc);
 	} finally {
 		ydoc.destroy();
 	}
@@ -108,7 +108,6 @@ function readLiveTabPendingEditThreadIds(tabId: string): Set<string> {
 	}
 }
 
-const LAST_SEEN_PREFIX = 'last_seen:';
 const GENERIC_WAKEUP_MESSAGE =
 	'The user clicked Wake-up without a specific request. Decide what (if anything) to do per the agency guidance above.';
 const WORKSPACE_ROOT = resolve(process.env.DOCWRITER_ROOT || process.cwd());
@@ -124,10 +123,6 @@ interface ImageAttachmentPayload {
 const KV_LAST_RULES = 'last_render:rules';
 const KV_LAST_REFS = 'last_render:refs';
 const KV_LAST_AGENCY = 'last_render:agency';
-
-function lastSeenKey(tabId: string): string {
-	return LAST_SEEN_PREFIX + tabId;
-}
 
 function normalizeToolPath(pathLike: string): string {
 	return normalize(resolve(WORKSPACE_ROOT, pathLike));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the agent proposed an edit containing an em dash (`—`) and the user accepted it, the next auto-wake showed a diff that looked like the **user** had replaced the em dash with a hyphen. The agent then misread this as a style preference and tried to propose a rule about avoiding em dashes — even though it was the agent's own edit.

## Root cause

`normalizeTypography()` in `ydoc-codec.ts` converts typographic dashes/quotes to ASCII when serializing the Y.Doc (`read_doc`, disk flush, prompt diffs). But agent `edit_doc` calls stored the raw Unicode `new_string` in pending review rounds. That created a mismatch:

1. End of agent render → `last_seen` stored the materialized proposal (with `—`)
2. User accepts → Y.Doc committed, pending round removed
3. Auto-wake → `read_doc` / current markdown serialized with normalization (`-`)
4. Diff: `—` removed, `-` added → attributed to the user

## Fix

- Normalize typography at **edit ingress** (`edit_doc` / `write_doc` in both MCP and provider tool handlers)
- Normalize typography when **materializing** pending review text (`review-rounds.ts`)
- Normalize typography when **writing** to the Y.Doc (`applyEditToFragment`, `seedYDoc`, `replaceYDocText`)
- **Refresh `last_seen`** on accept/reject so the agent diff baseline stays aligned when pending proposals are removed

## Verification

- `npm run check` passes (0 errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00d31b88-a865-4651-9a77-624a1563a145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00d31b88-a865-4651-9a77-624a1563a145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

