### PR TITLE
Harden landing sync against package.json merge conflicts

### DIFF
--- a/.github/workflows/sync-landing.yml
+++ b/.github/workflows/sync-landing.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main landing
           git checkout landing
-          git merge origin/main -m "chore: merge main into landing"
+          node scripts/merge-main-into-landing.mjs
           git push origin landing

--- a/scripts/merge-main-into-landing.mjs
+++ b/scripts/merge-main-into-landing.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Merge origin/main into the current (landing) branch for CI.
+ * Auto-resolves the recurring package.json scripts/deps conflict by unioning
+ * landing-only entries with main's updates for shared keys.
+ */
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const MERGE_MSG = 'chore: merge main into landing';
+
+function run(cmd, { inherit = false } = {}) {
+	return execSync(cmd, {
+		encoding: 'utf8',
+		stdio: inherit ? 'inherit' : 'pipe'
+	});
+}
+
+function unmergedFiles() {
+	return run('git diff --name-only --diff-filter=U')
+		.trim()
+		.split('\n')
+		.filter(Boolean);
+}
+
+function mergePackageJson() {
+	const landing = JSON.parse(run('git show :2:package.json'));
+	const main = JSON.parse(run('git show :3:package.json'));
+	const merged = {
+		...main,
+		scripts: { ...main.scripts, ...landing.scripts },
+		devDependencies: { ...landing.devDependencies, ...main.devDependencies },
+		dependencies: { ...landing.dependencies, ...main.dependencies }
+	};
+	writeFileSync('package.json', `${JSON.stringify(merged, null, '\t')}\n`);
+	run('git add package.json');
+}
+
+execSync('git fetch origin main landing', { stdio: 'inherit' });
+
+try {
+	run(`git merge origin/main -m "${MERGE_MSG}"`, { inherit: true });
+} catch {
+	const conflicts = unmergedFiles();
+	if (conflicts.length === 1 && conflicts[0] === 'package.json') {
+		mergePackageJson();
+		run(`git commit -m "${MERGE_MSG}"`, { inherit: true });
+	} else {
+		console.error('Unhandled merge conflict(s):', conflicts.join(', ') || '(none)');
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Sync landing branch** workflow failed on [run 28413929575](https://github.com/shreyashankar/docwriter/actions/runs/28413929575) when merging `main` into `landing`:

```
CONFLICT (content): Merge conflict in package.json
```

`main` added `test:e2e` scripts while `landing` kept Cloudflare/Vercel landing scripts (`cf:login`, `build:landing`, etc.).

## Fix

1. **Immediate:** Resolved the conflict on `landing` directly (union of both script sets) and pushed.
2. **Durable:** Added `scripts/merge-main-into-landing.mjs` and updated `sync-landing.yml` to use it. When `package.json` is the only merge conflict, the script unions scripts/deps from both branches (landing-only entries preserved, shared deps take `main`'s versions).

The same helper is already on `landing` for the Vercel deploy workflow.

## Verification

- `node scripts/merge-main-into-landing.mjs` on `landing` reports "Already up to date."
- Vercel deploy workflow merge step succeeded after the landing push (deploy later failed on missing `VERCEL_TOKEN`, unrelated).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

