### PR TITLE
Fix sync-landing CI without moving landing code to main

### DIFF
--- a/.github/workflows/sync-landing.yml
+++ b/.github/workflows/sync-landing.yml
@@ -19,11 +19,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
       - name: Merge main into landing
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main landing
           git checkout landing
-          git merge origin/main -m "chore: merge main into landing"
+          node scripts/merge-main-into-landing.mjs
           git push origin landing

--- a/scripts/merge-main-into-landing.mjs
+++ b/scripts/merge-main-into-landing.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Merge origin/main into the current (landing) branch for CI.
+ * Resolves recurring package.json conflicts by unioning landing-only
+ * scripts/deps with main's updates, then regenerates package-lock.json.
+ */
+import { execSync } from 'node:child_process';
+import { unlinkSync, writeFileSync } from 'node:fs';
+
+const MERGE_MSG = 'chore: merge main into landing';
+
+function run(cmd, { inherit = false } = {}) {
+	return execSync(cmd, {
+		encoding: 'utf8',
+		stdio: inherit ? 'inherit' : 'pipe'
+	});
+}
+
+function unmergedFiles() {
+	return run('git diff --name-only --diff-filter=U')
+		.trim()
+		.split('\n')
+		.filter(Boolean);
+}
+
+function mergePackageJson() {
+	const landing = JSON.parse(run('git show :2:package.json'));
+	const main = JSON.parse(run('git show :3:package.json'));
+	const merged = {
+		...main,
+		scripts: { ...main.scripts, ...landing.scripts },
+		devDependencies: { ...landing.devDependencies, ...main.devDependencies },
+		dependencies: { ...landing.dependencies, ...main.dependencies }
+	};
+	writeFileSync('package.json', `${JSON.stringify(merged, null, '\t')}\n`);
+}
+
+function isPackageConflictOnly(conflicts) {
+	return (
+		conflicts.length > 0 &&
+		conflicts.every((f) => f === 'package.json' || f === 'package-lock.json')
+	);
+}
+
+execSync('git fetch origin main landing', { stdio: 'inherit' });
+
+try {
+	run(`git merge origin/main -m "${MERGE_MSG}"`, { inherit: true });
+} catch {
+	const conflicts = unmergedFiles();
+	if (!isPackageConflictOnly(conflicts)) {
+		console.error('Unhandled merge conflict(s):', conflicts.join(', ') || '(none)');
+		process.exit(1);
+	}
+
+	mergePackageJson();
+	try {
+		unlinkSync('package-lock.json');
+	} catch {
+		/* already absent */
+	}
+	run('git add package.json');
+	run('git rm -f --cached package-lock.json 2>/dev/null || true');
+	run('npm install', { inherit: true });
+	run('git add package.json package-lock.json');
+	run(`git commit -m "${MERGE_MSG}"`, { inherit: true });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

PR #50 was the wrong approach — `main` intentionally keeps landing code on the `landing` branch (`707403d`). That PR should be closed.

This replaces it with a **2-file, +72 line** fix:

1. Merged `main` into `landing` directly (pushed as `cbb06c9`) to fix the immediate CI failure
2. Updates `sync-landing.yml` so future merges handle `package.json` **and** `package-lock.json` conflicts by unioning package fields and running `npm install`

## Changes

- `scripts/merge-main-into-landing.mjs` — union landing/main package.json; regenerate lockfile
- `.github/workflows/sync-landing.yml` — use the script + Node setup for `npm install`

No landing routes, Clerk, or lockfile churn on `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

