### PR TITLE
Fix sync-landing merge script add/add conflict

### DIFF
--- a/.github/workflows/sync-landing.yml
+++ b/.github/workflows/sync-landing.yml
@@ -28,5 +28,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout landing
+          git checkout origin/main -- scripts/merge-main-into-landing.mjs
           node scripts/merge-main-into-landing.mjs
           git push origin landing

--- a/scripts/merge-main-into-landing.mjs
+++ b/scripts/merge-main-into-landing.mjs
@@ -3,11 +3,18 @@
  * Merge origin/main into the current (landing) branch for CI.
  * Resolves recurring package.json conflicts by unioning landing-only
  * scripts/deps with main's updates, then regenerates package-lock.json.
+ * CI-owned files on main always win (merge script + sync workflow).
  */
 import { execSync } from 'node:child_process';
 import { unlinkSync, writeFileSync } from 'node:fs';
 
 const MERGE_MSG = 'chore: merge main into landing';
+
+/** Files maintained on main; landing should not fork these. */
+const MAIN_OWNED = new Set([
+	'scripts/merge-main-into-landing.mjs',
+	'.github/workflows/sync-landing.yml'
+]);
 
 function run(cmd, { inherit = false } = {}) {
 	return execSync(cmd, {
@@ -35,11 +42,21 @@ function mergePackageJson() {
 	writeFileSync('package.json', `${JSON.stringify(merged, null, '\t')}\n`);
 }
 
-function isPackageConflictOnly(conflicts) {
+function isAutoResolvable(conflicts) {
 	return (
 		conflicts.length > 0 &&
-		conflicts.every((f) => f === 'package.json' || f === 'package-lock.json')
+		conflicts.every(
+			(f) => f === 'package.json' || f === 'package-lock.json' || MAIN_OWNED.has(f)
+		)
 	);
+}
+
+function resolveMainOwned(conflicts) {
+	for (const file of conflicts) {
+		if (!MAIN_OWNED.has(file)) continue;
+		run(`git checkout --theirs -- ${file}`);
+		run(`git add ${file}`);
+	}
 }
 
 execSync('git fetch origin main landing', { stdio: 'inherit' });
@@ -48,20 +65,25 @@ try {
 	run(`git merge origin/main -m "${MERGE_MSG}"`, { inherit: true });
 } catch {
 	const conflicts = unmergedFiles();
-	if (!isPackageConflictOnly(conflicts)) {
+	if (!isAutoResolvable(conflicts)) {
 		console.error('Unhandled merge conflict(s):', conflicts.join(', ') || '(none)');
 		process.exit(1);
 	}
 
-	mergePackageJson();
-	try {
-		unlinkSync('package-lock.json');
-	} catch {
-		/* already absent */
+	resolveMainOwned(conflicts);
+
+	if (conflicts.some((f) => f === 'package.json' || f === 'package-lock.json')) {
+		mergePackageJson();
+		try {
+			unlinkSync('package-lock.json');
+		} catch {
+			/* already absent */
+		}
+		run('git add package.json');
+		run('git rm -f --cached package-lock.json 2>/dev/null || true');
+		run('npm install', { inherit: true });
+		run('git add package.json package-lock.json');
 	}
-	run('git add package.json');
-	run('git rm -f --cached package-lock.json 2>/dev/null || true');
-	run('npm install', { inherit: true });
-	run('git add package.json package-lock.json');
+
 	run(`git commit -m "${MERGE_MSG}"`, { inherit: true });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #52 merged, `sync-landing` failed with:

```
CONFLICT (add/add): Merge conflict in scripts/merge-main-into-landing.mjs
Unhandled merge conflict(s): scripts/merge-main-into-landing.mjs
```

Both `main` and `landing` had independently added different versions of the merge script.

## Fix

1. **Immediate:** Merged `main` into `landing` and took `main`'s script (pushed `6dfcf69`).
2. **Durable:** 
   - Workflow now runs `git checkout origin/main -- scripts/merge-main-into-landing.mjs` before invoking it, so a stale landing copy never runs
   - Script auto-resolves conflicts on CI-owned files (the script itself + `sync-landing.yml`) in favor of `main`

## Changes

2 files, +35 / −12 lines.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

