### PR TITLE
Fix sync-landing dirty worktree blocking merge

### DIFF
--- a/.github/workflows/sync-landing.yml
+++ b/.github/workflows/sync-landing.yml
@@ -28,6 +28,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout landing
-          git checkout origin/main -- scripts/merge-main-into-landing.mjs
-          node scripts/merge-main-into-landing.mjs
+          git show origin/main:scripts/merge-main-into-landing.mjs > /tmp/merge-main-into-landing.mjs
+          node /tmp/merge-main-into-landing.mjs
           git push origin landing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #53, sync-landing failed with:

```
error: Your local changes to the following files would be overwritten by merge:
  scripts/merge-main-into-landing.mjs
Merge with strategy ort failed.
Unhandled merge conflict(s): (none)
```

PR #53 checked out `main`'s merge script onto the `landing` worktree before running `git merge`, leaving uncommitted changes that blocked the merge.

## Fix

Write the script to `/tmp` and run it from there — the landing worktree stays clean.

```bash
git show origin/main:scripts/merge-main-into-landing.mjs > /tmp/merge-main-into-landing.mjs
node /tmp/merge-main-into-landing.mjs
```

Verified locally: merge completes successfully with this approach.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee1e32a-d66f-47c4-9012-0a107e141544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

