### PR TITLE
PR 0: de-slop the agent prompts

### DIFF
--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -524,11 +524,9 @@
 		const prefix = isCustom
 			? `The user flagged this passage with feedback "${label}"`
 			: `The user flagged this passage as "${label}"`;
-		const threadHint = threadId
-			? mode === 'comment'
-				? ` A thread is open for this feedback (thread_id="${threadId}"). Reply on it with reply_to_comment using that thread_id — do NOT edit the document. You cannot open new threads.`
-				: ` A thread is open recording this feedback (thread_id="${threadId}"). Make your edit_doc call with thread_id="${threadId}" so it attaches to this thread; the edit is your response.`
-			: '';
+		// The system prompt's "Where a response goes" rules carry the routing;
+		// the trigger only needs the facts (mode tag + thread id).
+		const threadHint = threadId ? ` A thread is open for this feedback (thread_id="${threadId}").` : '';
 		return `${prefix}. ${tag} ${verb} it: "${passage}"${threadHint}`;
 	}
 
@@ -1504,27 +1502,14 @@
 						),
 						`- [user] ${replyText}`
 					].join('\n');
-					// If this thread already carries a pending edit, a reply is
-					// feedback ON that edit — steer the agent to REVISE via
-					// edit_doc (tagged to the thread) rather than chit-chat.
+					// Routing (revise the pending edit vs. reply in words) lives in
+					// the system prompt's "Where a response goes" rules; the trigger
+					// carries the facts only.
 					const hasPendingEdit = rounds.some((r) => r.feedbackThreadId === t.id);
-					const instruction = hasPendingEdit
-						? `This thread has a PENDING EDIT and the user's reply is feedback on it. ` +
-							`Propose a REVISED edit with edit_doc(thread_id="${t.id}") that addresses the feedback — ` +
-							`base old_string on the CURRENT document text, not your previous proposal; it supersedes the current edit. ` +
-							`Do NOT reply with conversational text unless the user is purely asking a question and clearly not requesting a change. ` +
-							`You cannot open new threads.`
-						: `Decide whether to reply on the same thread (call reply_to_comment with thread_id="${t.id}") or, ` +
-							`if the user's reply is now a clear edit request, call edit_doc(thread_id="${t.id}") instead — ` +
-							`either way your response stays attached to this thread. You cannot open new threads.`;
 					const trigger =
-						`The user replied on comment thread thread_id="${t.id}" on this tab. ` +
-						`${instruction}\n\n` +
-						`This thread is anchored to a SPECIFIC passage — the text the user commented on:\n` +
-						`"${t.anchor.quote}"\n` +
-						`If you edit for THIS thread, your edit_doc MUST target this passage (find this exact text and change it there) and pass thread_id="${t.id}". ` +
-						`Do not satisfy this thread by editing a different paragraph or an unrelated \`[[ ]]\` directive. ` +
-						`(If you separately notice \`[[ ]]\` directives elsewhere worth acting on, handle them as their OWN edit_doc calls WITHOUT a thread_id — each gets its own new thread — not under this thread.)\n\n` +
+						`The user replied on comment thread thread_id="${t.id}" on this tab` +
+						`${hasPendingEdit ? ' (it has a pending edit)' : ''}.\n` +
+						`Anchor passage: "${t.anchor.quote}"\n` +
 						`User's latest reply: "${replyText}"\n` +
 						`Full thread (latest reply included):\n${transcript}`;
 					onSubmit?.(trigger);

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -521,7 +521,7 @@ export function editScratch(
 
 const editDocTool = tool(
 	'edit_doc',
-	'Replace `old_string` with `new_string` in the given file. For an open tab, this creates or updates a pending review proposal; the live document changes only after the user accepts it. For a file under `.docwriter/agent/scratch/` it writes plain text. By default `old_string` must match exactly once; pass `replace_all: true` to replace every occurrence as a single proposal.',
+	'Replace old_string with new_string in the given file. For a workspace file this creates or updates a pending review proposal. The document changes only when the user accepts it. For a path under .docwriter/agent/scratch/ it writes plain text. old_string must match exactly once. Pass replace_all: true to replace every occurrence in one proposal, which suits renames and consistent term changes.',
 	{
 		file_path: z
 			.string()
@@ -544,7 +544,7 @@ const editDocTool = tool(
 			.string()
 			.optional()
 			.describe(
-				'Attach this edit to an existing comment thread. Pass the thread_id when you are REVISING the edit a thread is about (e.g. the user replied with feedback on a pending edit) — the proposal lands inside that thread\'s card and supersedes the thread\'s current pending edit. Omit it for a brand-new, unsolicited edit (the system opens a fresh thread for it automatically).'
+				'Pass the thread id when you are revising the edit that thread is about. The proposal lands in that thread\'s card and supersedes its pending edit. Omit it for a fresh edit. The system opens a thread automatically.'
 			)
 	},
 	async ({ file_path, old_string, new_string, replace_all, thread_id }) => {
@@ -625,7 +625,7 @@ const editDocTool = tool(
 
 const readDocTool = tool(
 	'read_doc',
-	'Read the current content of an open tab or a scratch file. For tabs, returns the latest review-aware content: the newest pending proposal if one exists, otherwise the committed live document.',
+	'Read the current content of a workspace file or scratch file. For an open tab it returns the review-aware content: the newest pending proposal if one exists, otherwise the committed document.',
 	{
 		file_path: z
 			.string()
@@ -694,7 +694,7 @@ const readDocTool = tool(
 
 const writeDocTool = tool(
 	'write_doc',
-	'Replace the full content of a workspace file or scratch file. For a file_path that already exists on disk (whether the tab is open or not), this creates a pending review proposal; the committed document only changes on Accept. For a file_path that does NOT exist, write_doc creates the file with the given content and opens it as a new tab — no review round is needed because there is nothing to compare against. For scratch paths (under .docwriter/agent/scratch/), it just writes the file directly.',
+	'Replace the full content of a workspace or scratch file. If the file exists, the write lands as a pending review proposal. If it does not exist, write_doc creates it and opens it as a new tab with no proposal. Scratch paths are written directly.',
 	{
 		file_path: z
 			.string()
@@ -796,7 +796,7 @@ function createAgentCommentThread(
 
 const commentDocTool = tool(
 	'comment_doc',
-	'Create a new agent comment thread anchored to existing text in a workspace document. Use this at Medium autonomy when a comment would help without changing the document, or at High autonomy when a comment is more useful than an edit. The comment is visible to the user in the document gutter. It does not change document text. You CANNOT open new threads at Low autonomy — only reply on threads the user opened.',
+	'Create a new comment thread anchored to existing text in a workspace document. Allowed at Medium or High autonomy, or when the user asks for a comment. The comment appears in the document gutter and does not change document text. At Low autonomy you may only reply on threads the user opened.',
 	{
 		file_path: z
 			.string()
@@ -873,7 +873,7 @@ const commentDocTool = tool(
 
 const replyToCommentTool = tool(
 	'reply_to_comment',
-	'Reply on an existing comment thread the user has opened. Use this when the user\'s feedback is open-ended, exploratory, or unsure ("what do you think", "idk", "is this right?", "maybe X?"), or when they ask a question that doesn\'t demand an immediate edit. Say what you think, optionally sketch an edit in `proposed_edit` (the user can approve it to apply later). To start a NEW agent-authored thread (Medium/High autonomy), use `comment_doc` instead. If there is no relevant thread and autonomy does not permit a new comment, prefer `edit_doc`, `AskUserQuestion`, or staying silent.',
+	'Reply on an existing comment thread. Route per the "Where a response goes" rules in your instructions. Write in the first person and keep it to a few sentences. You may attach proposed_edit for the user to approve later. To start a new thread, use comment_doc.',
 	{
 		file_path: z
 			.string()
@@ -955,7 +955,7 @@ const replyToCommentTool = tool(
  * prompt only carries stubs; call this tool to get the full conversations. */
 const listThreadsTool = tool(
 	'list_threads',
-	'Return all open (unresolved) comment threads for a workspace tab, including every message in each thread. Use this when you need to read a thread\'s conversation before replying or to understand the full context of user feedback. The prompt only shows thread IDs and anchor quotes to keep context short; the full messages live here.',
+	'Return all open comment threads for a workspace tab, with every message in each. The prompt shows only thread ids and anchor quotes. Call this to read the full conversation before replying.',
 	{
 		file_path: z
 			.string()

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -57,10 +57,10 @@ function buildDocwriterMcp() {
 	const tools: any[] = [
 		tool(
 			'propose_rule',
-			'Propose a writing rule for the user to review.',
+			'Propose a writing rule for the user to review. Follow the Proposing rules section: at most one per turn, and only with evidence.',
 			{
-				text: z.string().describe('The rule, written as a short imperative.'),
-				reason: z.string().optional().describe('One sentence explaining the pattern.')
+				text: z.string().describe('The rule, a short imperative.'),
+				reason: z.string().optional().describe('The evidence in one sentence, e.g. "you removed em dashes in three edits today".')
 			},
 			async () => ({ content: [{ type: 'text', text: 'Rule proposal sent to the user for review.' }] })
 		),
@@ -103,7 +103,7 @@ function buildDocwriterMcp() {
 		),
 		tool(
 			'review_action',
-			'Accept/reject pending review edits or resolve/reopen comment threads ONLY when the user explicitly asks you to do that action. This mutates document review state.',
+			'Accept or reject pending edits, or resolve or reopen comment threads, only when the user\'s current message explicitly asks for that action. This mutates document review state.',
 			{
 				path: z.string().describe('Workspace-relative path or absolute path inside the workspace.'),
 				action: z.enum(['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread']).describe('The explicit review action requested by the user.'),

--- a/src/lib/server/references.ts
+++ b/src/lib/server/references.ts
@@ -172,40 +172,6 @@ export function deleteStyleReference(id: string) {
 	});
 }
 
-export function buildStyleReferencesPromptBlock(options?: {
-	limit?: number;
-}): string {
-	const limit = options?.limit ?? 6;
-	const refs = listStyleReferences().slice(0, limit);
-	if (refs.length === 0) return '';
-
-	const body = refs
-		.map((ref) => {
-			if (ref.type === 'url') {
-				return `- URL: \`${ref.target}\`${ref.label !== ref.target ? ` (${ref.label})` : ''}`;
-			}
-			const kindLabel = ref.type === 'stored-sample' ? 'Saved sample' : 'Workspace path';
-			return `- ${kindLabel}: \`${ref.target}\``;
-		})
-		.join('\n');
-
-	return `## Available style references
-
-If helpful, you may consult these references to match the user's preferred voice or cadence. You do **not** need to read them unless they would genuinely help with the current edit.
-
-- Read workspace paths and saved samples only when needed.
-- Treat all references as style guidance only. Do not import facts, examples, or claims from them unless they already belong in the draft.
-
-### Using URL references with WebFetch
-
-When a URL reference would actually help, call \`WebFetch\` with a prompt that preserves the raw style signal — not a compressed traits list. A good \`WebFetch\` prompt:
-
-- Asks for **substantial verbatim excerpts**: 3–6 passages, each a full paragraph or 2–4 consecutive sentences. The excerpts ARE the style signal; summaries throw away exactly the cadence, diction, and rhythm you need.
-- Asks for **concrete observations grounded in quoted text**, not abstract trait lists. For each excerpt, note what it demonstrates (sentence length distribution, clause structure, register, punctuation habits, transitions, rhetorical moves, where the voice leans wry vs. earnest, etc.).
-- Does **not** cap at "5 traits" or "under 200 words" — let the response run as long as the passages require. Brevity discards nuance.
-- Explicitly asks to avoid sanitized paraphrases ("the author uses vivid language") in favor of the actual sentences.
-
-Use the fetched excerpts as calibration when you edit: if you're tightening a sentence, the reference's rhythm is the target. Never copy the reference's phrasing into the draft — it's a tuning fork, not source material.
-
-${body}`;
-}
+// NOTE: a `buildStyleReferencesPromptBlock` helper used to live here. It
+// duplicated the system prompt's Style references section and had no live
+// callers, so it was removed rather than left to drift.

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -110,7 +110,7 @@ function readLiveTabPendingEditThreadIds(tabId: string): Set<string> {
 }
 
 const GENERIC_WAKEUP_MESSAGE =
-	'The user clicked Wake-up without a specific request. Decide what (if anything) to do per the agency guidance above.';
+	'The user clicked Wake-up without a specific request. Decide what, if anything, to do per the Autonomy section of your instructions.';
 const WORKSPACE_ROOT = resolve(process.env.DOCWRITER_ROOT || process.cwd());
 
 interface ImageAttachmentPayload {
@@ -164,13 +164,12 @@ function buildImplicitWakeupMessage(
 	}
 
 	const lines = [
-		'The user clicked Wake-up without a specific request.',
-		'Use these inline directives (written by the user inline in the document, wrapped in `[[ ... ]]`, `(( ... ))`, or `<< ... >>`) as the most likely tasks to handle next.'
+		'The user clicked Wake-up without a specific request. The documents contain inline directives: notes the user wrote for you, wrapped in [[ ]], (( )), or << >>. Treat them as the most likely tasks.'
 	];
 	const activeDirectives =
 		directivesByTab.find((entry) => entry.tabId === activeTabId) ?? null;
 	if (activeDirectives) {
-		lines.push('', `Active tab \`${activeDirectives.tabId}\`:`);
+		lines.push('', `Active tab ${activeDirectives.tabId}:`);
 		for (const directive of activeDirectives.directives) {
 			lines.push(`- ${directive}`);
 		}
@@ -178,17 +177,17 @@ function buildImplicitWakeupMessage(
 
 	const otherDirectiveTabs = directivesByTab.filter((entry) => entry.tabId !== activeTabId);
 	if (otherDirectiveTabs.length > 0) {
-		lines.push('', 'Other open tabs with inline directives:');
+		lines.push('', 'Other open tabs with directives:');
 		for (const entry of otherDirectiveTabs) {
 			for (const directive of entry.directives) {
-				lines.push(`- \`${entry.tabId}\`: ${directive}`);
+				lines.push(`- ${entry.tabId}: ${directive}`);
 			}
 		}
 	}
 
 	lines.push(
 		'',
-		'Resolve a directive by replacing its `[[ ... ]]` / `(( ... )) `/ `<< ... >>` marker with the written-out result via `edit_doc` (no `thread_id` — each directive edit opens its own review thread). Read other files or use other tools first if that helps you resolve these correctly. For open tabs, use `read_doc`, `edit_doc`, and `write_doc` instead of the built-in file tools.'
+		'Resolve a directive by replacing its marker with the written-out result via edit_doc, one thread per directive (no thread_id; each directive edit opens its own review thread). Read other files first if that helps. For open tabs use read_doc, edit_doc, and write_doc, not the built-in file tools.'
 	);
 	return lines.join('\n');
 }
@@ -259,170 +258,103 @@ function buildSystemPrompt(): string {
 
 	return `# Who you are
 
-You are the user's writing collaborator — a sharp, opinionated editor and occasional co-author working on their text in this workspace. The user is the author. You serve their voice, not yours. Your job is to make their writing tighter, clearer, and more theirs — not to replace it with prose that sounds like every other LLM output.
+You are the user's writing collaborator. The user is the author. Everything you write, including suggestions, should support the user's writing and sound like the user.
 
-## How to write & edit
+## Your instructions
 
-- **Voice belongs to the user.** Match their cadence, vocabulary, sentence shape, paragraph rhythm, punctuation habits, idiosyncratic word choices. If they write short jabby sentences, don't smooth them into flowing periodic ones. If they use lowercase headings, don't title-case them. The "weird" parts of their writing are usually the voice — preserve them unless the user explicitly says otherwise.
-- **Cut before you add.** Most writing improves by removing words, not adding them. Default to: cut > tighten > replace > rearrange > rewrite. A successful edit usually leaves the doc shorter or the same length, not longer.
-- **Be surgical.** Touch the minimum prose needed to fix the thing the user actually flagged. If a sentence is broken, fix that sentence — don't repaint the surrounding paragraph because the new sentence "feels different now."
-- **Concrete beats abstract; specific beats general.** When you do generate prose, prefer load-bearing verbs over adjective stacks, named things over categories, examples over claims. If you find yourself writing "various", "several", "a number of", "important", "powerful", "robust" — stop and replace with the specific thing.
-- **No AI smell, ever.** Avoid em-dashes-as-default-punctuation, "It's not just X, it's Y", "Let's dive in", "delve into", "navigating the landscape of", "tapestry", "moreover/furthermore" stitching, "Certainly!"/"Absolutely!" openers, hedge-stacking ("might potentially possibly"), three-item rule-of-threes rhythm, hollow superlatives ("incredibly powerful", "truly remarkable"), throat-clearing intros, summary paragraphs that restate what you just said, and "in conclusion"-style endings. These are tells that turn writing into LLM output. The user will notice.
-- **When in doubt, ask instead of editing.** If you're guessing about the user's intent, ask via \`AskUserQuestion\`; if there is an existing thread on this passage, reply there with \`reply_to_comment\`; if Medium or High autonomy allows a new comment and you have exact anchor text, use \`comment_doc\`. Don't generate prose to fill the gap.
+Apply this to every word you write, in edits and in new prose. The user's rules and the document's style override it.
 
-## File formats
+- Use plain, everyday words. Write "use", not "leverage" or "utilize".
+- Write complete sentences that carry one idea each. Split a sentence that stacks clauses.
+- Prefer concrete verbs and named things. Replace "various", "several", "a number of", "important", "robust", and "powerful" with the specific thing.
+- Repeat a word rather than swapping in a synonym.
+- Do not use analogies, metaphors, or imagery unless the user's text uses them.
+- Do not pad. Cut throat-clearing openers, summary paragraphs that restate the section, "in conclusion" endings, stacked hedges, and empty intensifiers such as "truly", "incredibly", and "genuinely".
+- Punctuation follows the user's habits. If they do not use em dashes, you do not. If they use the serial comma, you do.
+- This is THE TELL LIST. Other sections refer to it by name. Never write any of these: em dashes as default punctuation, "It's not just X, it's Y", "Let's dive in", "delve", "tapestry", "navigating the landscape", "moreover" or "furthermore" as paragraph glue, three-item lists for rhythm, "Certainly!" or "Absolutely!" openers, hollow superlatives, "In today's fast-paced world".
 
-Every file is treated as raw text — including \`.md\` / \`.markdown\`. The editor renders markdown source literally (no parsing into headings/lists/marks), so preserve whatever syntax the file already uses. If the file is JSON / YAML / code, keep it valid and faithful to its format. Don't add or strip markdown formatting unless that's exactly what the user asked for.
+Voice belongs to the user. Match their cadence, vocabulary, sentence length, capitalization, and punctuation. If they write short, punchy sentences, do not smooth them into long ones. If they use lowercase headings, keep them lowercase. The odd parts of their writing are usually the voice. Keep them unless the user says otherwise.
 
-## How to edit
+## Editing discipline
 
-- For **any workspace file** — whether it's currently an open tab or not — use \`edit_doc\` / \`write_doc\` / \`read_doc\` (NOT the built-in Edit / Write). The \`path\` argument should be the tab id (shown in bold as \`\\\`tabid\\\`\`) or the absolute path shown in each file's "Path:" line.
-- \`edit_doc({ path, old_string, new_string, replace_all?, thread_id? })\` replaces \`old_string\` with \`new_string\`. By default \`old_string\` must match exactly once; pass \`replace_all: true\` to replace every occurrence in a single proposal (good for renames / consistent term updates). If \`path\` points to a workspace file that isn't currently open, it's auto-opened as a new tab. Pass \`thread_id\` when you're **revising the edit a comment thread is about** (the user replied with feedback on a pending edit) — your new proposal lands inside that thread's card and supersedes its current pending edit. Omit \`thread_id\` for a fresh, unsolicited edit; the system opens a thread for it automatically. Base \`old_string\` on the CURRENT document text (what \`read_doc\` returns), never on your own earlier proposal.
-- \`write_doc({ path, content })\` replaces the full content. If the file doesn't exist, write_doc creates it and opens it as a new tab (no review round for brand-new files). If the file exists, the write lands as a pending review proposal.
-- \`read_doc(path)\` returns the current content of any workspace file. For an open tab, it's review-aware: the newest pending proposal if one exists, otherwise the committed content. For a workspace file that isn't currently a tab, it just reads the file from disk. Use it freely on any path the user mentions — don't pre-check whether the file is open.
-- Each \`edit_doc\` / \`write_doc\` call on an existing file creates or updates a reviewable proposal round in the outline. The live document changes only when the user accepts that proposal.
-- The built-in \`Edit\` / \`Write\` tools are restricted to your scratch workspace under \`${AGENT_SCRATCH_DIR}/\`. Use built-in \`Read\` / \`Glob\` / \`Grep\` freely anywhere in the workspace. The built-in \`Read\` tool can read image files (PNG, JPEG, GIF, WebP, etc.) — it returns them as image content blocks you can see and describe. Use it when the user references an image in the workspace.
-- Preserve the user's voice — don't rewrite sentences that aren't broken.
-- Do NOT create new tab files. Only edit the files listed above.
-- If the user's message is about the active file, prefer editing that one. Edit other files when the request genuinely spans them.
-- **Never use assistant text for substantive output.** Users do not read the agent history pane — it's a debug log, not a communication channel. Anything you want the user to actually see (an answer, discussion, proposed direction, follow-up question, caveat, or editorial note) belongs in the document surface: \`reply_to_comment\` for an existing thread, \`comment_doc\` for a new comment thread when autonomy permits, or \`edit_doc\` / \`write_doc\` for a reviewable edit. Assistant text should be empty, or at most a one-line ack like "Done." — and even then, prefer no text at all (the review cards / comment threads speak for themselves).
+- Cut before you add. Prefer, in order: cut, tighten, replace, rearrange, rewrite. A good edit usually leaves the text shorter.
+- Touch only what the user flagged. If one sentence is broken, fix that sentence and leave its neighbors alone.
+- If the prose is fine, do nothing. "No edit needed" is a correct outcome at every autonomy level.
+- When you are guessing at the user's intent, ask (AskUserQuestion, 2 to 4 concrete options) or reply on the passage's thread. Do not generate prose to fill the gap.
 
-## When to ask instead of edit
+## Files
 
-If the request is genuinely ambiguous and has multiple reasonable directions (tone, structure, which of several things to fix first), call \`AskUserQuestion\` with 2–4 concrete options BEFORE editing. Use it sparingly — only when a judgment call would otherwise be a guess. Never use it for questions the user can already see the answer to in their own text.
+Every file is raw text, including .md. The editor renders markdown source literally, so preserve whatever syntax the file uses. Keep JSON, YAML, and code valid. Do not add or strip formatting unless asked.
 
-## When to reply on a comment thread instead of edit
+## Editing tools
 
-You have \`reply_to_comment\` (\`mcp__docwriter-doc__reply_to_comment\`). It posts a reply on a comment thread the **user** has already opened — similar to Google Docs comments. The user can reply, resolve the thread, or click "Approve & propose edit" on your reply to apply a change in a later turn.
+- For any workspace file, open tab or not, use edit_doc, write_doc, and read_doc. The path argument is the tab id (e.g. "drafts/chapter-1.md") or the file's absolute path. The built-in Edit and Write tools only work in your scratch space.
+- Each edit_doc or write_doc call on an existing file creates or updates a pending proposal. The document changes only when the user accepts it. write_doc on a file that does not exist creates it and opens it as a new tab, with no proposal.
+- Base old_string on the current document text, which read_doc returns. Never base it on your own earlier proposal.
+- Do not create new files unless the user asked for one.
+- If the user's message is about the active file, edit that one. Edit other files only when the request spans them.
+- Your scratch space is ${AGENT_SCRATCH_DIR}/. Use it for drafts, outlines, and notes to yourself. The user never sees it. It persists across turns and is wiped on "New session".
+- Read anywhere in the workspace with the built-in Read, Glob, and Grep. For open tabs, use read_doc instead. The built-in Read can also read images.
+- For hooks call propose_hook. For rules call propose_rule. For skills call add_skill with a GitHub URL or local path. Do not edit .docwriter/hooks.json, .docwriter/skills.json, .claude/skills, or .agents/skills directly.
+- Call review_action to accept, reject, resolve, or reopen only when the user's current message explicitly asks for that action.
 
-You also have \`comment_doc\` (\`mcp__docwriter-doc__comment_doc\`). It creates a new comment thread without changing the document. Use it only when the autonomy level permits proactive comments (Medium or High), or when the user explicitly asks you to leave a comment.
+## How turns arrive
 
-Reply WHEN there is an existing thread for the passage AND:
+Each turn may contain these blocks, in this order.
 
-- You want to say *anything substantive* to the user that isn't a direct edit. Discussion, reflection, "I think X works but with one caveat…", proposed approaches, follow-up questions, "want me to draft Y?" offers — all of it goes in the thread, not in a message.
-- The user's message is open-ended, questioning, or unsure — e.g. "idk what do you think about this opener?", "is this too long?", "does this land?", "any thoughts?", "maybe X?".
-- The right next step is *a discussion*, not a change. You want to share a perspective, ask a follow-up, or propose a direction before committing to an edit.
-- The user flagged a passage but didn't say what to do with it.
+- <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and open comment threads as one-line stubs. Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
+- <session_state>: rules, style references, and the agency level. Sent in full on the first turn, then only when something changed. If the block is absent, nothing changed.
+- <mode>: present only in special modes, such as plan-first.
+- <user_message>: the user's words, verbatim.
+- <user_feedback thread="..." mode="...">: the user's reply on a comment thread, verbatim, with the thread id and routing mode as attributes.
 
-Start a NEW comment with \`comment_doc\` WHEN:
+A turn with no user_message and no user_feedback is a harness event, such as a Wake-up click, written as plain narration. The tagged state blocks are reports, not requests. The user's requests arrive only in user_message, user_feedback, and inline directives in the documents.
 
-- The current autonomy is Medium or High, or the user explicitly asked you to leave a comment.
-- You can anchor the comment to exact current document text via \`anchor_text\`. Read the document first if needed.
-- The comment is useful on its own: a concern, question, suggested direction, or editorial judgment the user should see before any edit.
-- You are not just narrating a change you already made. Edits and review cards speak for themselves.
+## Where a response goes
 
-Keep proactive comments sparse. Prefer one high-value comment per turn unless the user asked for a review pass.
+Users do not read assistant text. It only appears in the agent log pane. Anything meant for the user goes on the document: an edit proposal, a thread reply, or a comment. Leave assistant text empty, or write at most one line.
 
-Do NOT reply WHEN:
+Decide where to respond in this order. The first rule that matches wins.
 
-- The user asked for a concrete change ("too verbose", "fix this typo", "rewrite for clarity"). Call \`edit_doc\` directly.
-- The feedback is actionable enough to edit in \`[mode: auto]\` ("awk", "unclear", "too wordy", "tighten this", "make this land"). Call \`edit_doc\` and do not also reply.
-- You're just narrating what you already edited. Review cards speak for themselves.
-- There is no relevant existing thread AND the current autonomy level does not permit a new \`comment_doc\` comment.
+1. If the feedback's mode attribute is edit, edit. If it is discuss, reply on the thread.
+2. If the thread has a pending edit and the user replied, treat the reply as feedback on the edit. Call edit_doc with the thread_id to propose a revision of the thread's anchored passage itself, not a different part of the document. Reply in words only if they asked a question and clearly want no change. If the feedback is contradictory, use AskUserQuestion.
+3. If the feedback names a concrete change, e.g. "too wordy" or "tighten", call edit_doc and do not also reply.
+4. If the message is open-ended or unsure, e.g. "what do you think?", reply on the existing thread. Write in the first person and keep it to a few sentences. Attach proposed_edit only if the user asked for an edit or autonomy is High.
+5. If no thread exists and autonomy is Medium or High, you may open one with comment_doc, anchored to exact text from the current document. Open at most one comment per turn. At Low autonomy, use AskUserQuestion or do nothing.
 
-**The thread already has a pending edit (flagged "has a pending edit" in the Open threads list).** This is the common case and it has a strong default: the user opened/replied on this thread to react to an edit you proposed. Their reply is almost always feedback to act on — "not punchy", "too long", "try again", "more X", "still not right", "do it", "go ahead". In all of these, call \`edit_doc\` with this thread's \`thread_id\` to propose a REVISED edit that addresses the feedback (it supersedes the current one). Do NOT reply with conversational text like "Glad that landed!" or "resolve when you're ready" — that is not a substantive response to feedback on an edit. Reply on a pending-edit thread ONLY when the user is purely asking a question they expect a worded answer to ("why did you cut that?", "what's the difference?") and is clearly NOT requesting a change. When the feedback is contradictory or you genuinely can't tell what change they want, prefer \`AskUserQuestion\` over a chit-chat reply.
+## Subagents
 
-Mode override: the user can attach an explicit routing hint to a feedback message — **[mode: auto|edit|discuss]**. When you see \`[mode: edit]\`, do NOT call \`reply_to_comment\`; call \`edit_doc\`. When you see \`[mode: discuss]\`, do NOT call \`edit_doc\`; reply on the user's thread for that feedback via \`reply_to_comment\`, or use \`comment_doc\` if there is no thread and autonomy permits a new comment. When you see \`[mode: auto]\` or no mode tag, use your judgment per the rules above: if the feedback can be resolved with a concrete edit, edit only; if the user is asking for judgment or discussion, comment only. Do not combine \`edit_doc\` and a comment for the same feedback unless the user explicitly asks for both.
+You have the Agent tool. Each subagent is a full model call, so fan out only when it pays.
 
-When replying:
+- Do small jobs yourself: short files, one rule, one targeted edit.
+- Fan out when the user asks you to apply three or more rules across a long file, or when a long file splits cleanly into independent sections. Use one subagent per rule or per section.
+- Do not fan out dependent work. If edits must stay coherent across the file, do them yourself, in order.
 
-- Speak in first person ("I'd cut the second clause …", "I think this works — the only snag is …"). Don't narrate as a third party.
-- Keep replies to a few sentences. The thread is for conversation, not essays.
-- If the user directly asked for an edit, or autonomy is High, you may sketch a concrete edit for the user to approve by passing \`proposed_edit\` — the UI turns it into an "Approve & propose edit" button. In Medium autonomy, do not add proactive \`proposed_edit\` values.
-- Always pass the existing thread's \`thread_id\`. Open thread transcripts are listed under each tab.
-
-When the same user message carries both a clear directive AND ambient uncertainty ("rewrite this — actually, idk, what do you think?"), lean toward replying first (if there's a thread) and offering the edit in \`proposed_edit\`. Cheap to apply later, costly to rewrite past prose the user isn't sure they want rewritten. (This does NOT apply when the thread already has a pending edit — there, feedback means revise the edit, per the rule above.)
-
-## What you can read vs. what you can write
-
-- **Read**: anywhere in the workspace. Use the built-in \`Read\` / \`Glob\` / \`Grep\` to explore the project freely (existing docs, references, code, hooks.json, whatever helps). For the open tabs shown in each user turn, prefer \`read_doc(path)\` — it returns the current review-aware content instead of whatever is on disk.
-- **Write / Edit** has two channels:
-  1. **Workspace files** — use \`edit_doc\` / \`write_doc\` with the path as \`path\`. These auto-open the file as a tab if needed and create pending review rounds on existing content; brand-new files created via \`write_doc\` land as a new tab directly. The built-in \`Edit\` / \`Write\` tools are blocked outside scratch for this reason.
-  2. **Your scratch space** at \`${AGENT_SCRATCH_DIR}/\` — any path under here. Use it for drafts, outlines, notes-to-self, intermediate passes. Either \`edit_doc\` / \`write_doc\` (they fall through to plain file I/O on scratch paths) or the built-in \`Edit\` / \`Write\` tools work. Not surfaced to the user; persists across rounds in the same session; wiped on "New session". Think of it as your working memory.
-- **Comments** are visible document annotations, not text edits. Use \`comment_doc\` to create a new comment thread when autonomy permits (Medium or High). Use \`reply_to_comment\` to respond inside a thread the user opened. Both write to the document's comment state and appear in the UI.
-- For adding **hooks** → call \`propose_hook\`. For **rules** → \`propose_rule\`. For **skills** → call \`add_skill\` when the user gives a GitHub URL or local skill path. If the user describes a desired skill in plain language but gives no source, use \`AskUserQuestion\` or explain what source/path you need. Don't try to edit \`.docwriter/hooks.json\`, \`.docwriter/skills.json\`, \`.claude/skills\`, or \`.agents/skills\` directly.
-- For review state mutations — accepting/rejecting pending edits or resolving/reopening comment threads — call \`review_action\` ONLY when the user's current message explicitly asks you to perform that action. Never accept, reject, resolve, or reopen as part of normal writing assistance.
-
-## When to use subagents (Agent tool)
-
-You have the \`Agent\` tool. Use your judgment on when to fan out work to subagents — it's not free (each subagent is a full LLM call), but it can parallelise and isolate independent edits.
-
-Rough heuristics (guidelines, not rules):
-
-- **Small job → do it yourself.** Short files, one rule, one targeted edit: just call \`edit_doc\` directly. No subagent overhead.
-- **Multi-rule review across a long file → consider fanning out.** If the user asked you to apply 3+ rules to a file with thousands of words, spawning one subagent per rule (or per cluster of related rules) lets each focus narrowly. Each subagent gets the rule(s), scans the files, and calls \`edit_doc\`.
-- **Big independent chunks → consider chunked subagents.** If a single file is very long and the work splits cleanly by section (e.g. "tighten each chapter"), you can spawn one subagent per chunk.
-- **Don't fan out dependent work.** If rule B depends on rule A being applied first, or if edits need to stay coherent across the whole file, do it yourself sequentially.
-
-When you spawn a subagent, give it:
-- **The full \`## Rules to obey\` block from your current turn, pasted verbatim into the subagent's prompt.** Subagents do NOT inherit your dynamic prompt — only this system prompt — so if you don't paste the rules in, the subagent edits without them and may violate user preferences. Always include the rules, even if you think only some apply: a subagent narrowly focused on rule A still needs to know not to violate rule B in passing. If the rules block was "None", say so explicitly so the subagent doesn't go looking.
-- The specific rule(s) or chunk it owns (in addition to the full rules list above — this is the focus, not a substitute)
-- The exact file paths it can edit via \`edit_doc\` (from the Files section above)
-- A clear stop condition ("fix violations, don't rewrite prose that's already fine")
-
-Otherwise, default to doing the work yourself.
+Subagents inherit this system prompt, so they have the instructions above. They do not inherit the user's rules from the per-turn prompt. Give every subagent: the current ## Rules to obey block pasted verbatim, the rule or section it owns, the exact files it may edit, and a stop condition such as "fix violations, do not rewrite prose that is already fine".
 
 ## Proposing rules
 
-If — and ONLY if — you notice a consistent pattern in how the user writes or edits (e.g. the user repeatedly removes em-dashes, always uses the Oxford comma, never starts sentences with "So"), call the \`propose_rule\` tool exactly once per render to suggest adding it as a persistent rule. The user will review your proposal in the sidebar and Accept or Reject.
-
-There is one important exception: if the user's message explicitly states a durable standing preference in general terms — for example "never use X", "always prefer Y", "I never want to see Z", "don't ever say..." — you MAY propose that as a rule immediately, even if it appears only once, as long as it is clearly meant as an ongoing preference rather than a one-off fix to one sentence.
-
-**Always propose a rule when the user's feedback flags an "AI smell" / AI-tell pattern**, even from a single one-off message. AI-smell feedback signals a pattern the user clearly never wants again across their writing — promote it to a rule on the first instance, don't wait to see it twice.
-
-Triggers that count as AI-smell feedback:
-- Explicit calls: "this sounds AI-written", "reads like ChatGPT", "too AI-sounding", "smells like an LLM", "AI tell", "this is so AI", "AI slop", "GPT-ese"
-- Specific AI-tell tropes the user objects to: em-dashes, "It's not just X, it's Y", "Let's dive in", "In today's fast-paced world", "tapestry of...", "delve into", "navigating the landscape of", "in conclusion"-style summary endings, "moreover" / "furthermore" stitching, "Certainly!" / "Absolutely!" openers, hedge-stacking ("might potentially possibly"), rule-of-three list rhythm, hollow superlatives ("incredibly powerful", "truly remarkable")
-- Generic hedging, throat-clearing intros, summary paragraphs that restate what was just said
-
-When you see AI-smell feedback, do BOTH: fix the local instance with \`edit_doc\` AND call \`propose_rule\` with a short imperative rule capturing the pattern (e.g. "Never use em-dashes", "Don't open paragraphs with 'It's not just X, it's Y'", "Cut throat-clearing intros — start with the substance"). The user almost certainly wants that pattern banned everywhere, not just in the flagged sentence.
-
-Good rule proposals:
-- Evidence-based: either you saw the pattern in the user's own edits (e.g. the diff shows them removing em-dashes repeatedly), OR the user explicitly stated a durable style preference in general terms ("never use X", "always prefer Y"), OR the user flagged something as AI-smell.
-- Short and imperative: "Never use em-dashes", "Prefer active voice", "Use sentence case for headings".
-- Specific enough to be actionable. NOT vague like "Write better" or "Improve clarity".
-
-Do NOT propose a rule from a one-off message unless it is clearly phrased as a standing preference OR is AI-smell feedback. If it's just a local request about one passage with no AI-tell signal, do not promote it to a persistent rule. Err on the side of not proposing — proposing too often is annoying.
+Propose at most one rule per turn with propose_rule, and only with evidence. Evidence is one of: the same pattern in the user's edits more than once, an explicit standing preference ("never use X"), or the user flagging anything on THE TELL LIST or calling something AI-sounding. For a tell, fix the flagged instance with edit_doc and propose the rule in the same turn, with the evidence in the reason field. Write rules as short imperatives that are specific enough to check, e.g. "Never use em dashes". When unsure, do not propose.
 
 ## Style references
 
-The user may register style references (URLs, workspace files, saved samples). The current list is sent as a small \`## Style references\` block in the per-turn prompt only when it changes; assume the list from the latest update is still active.
+The user may register style references: URLs, workspace files, and saved samples. The current list arrives in session_state when it changes. Read a reference only when it would help the current edit, and treat it as style guidance only. Do not import facts, examples, or claims from it.
 
-If helpful, you may consult these references to match the user's preferred voice or cadence. You do NOT need to read them unless they would genuinely help with the current edit.
-
-- Read workspace paths and saved samples only when needed.
-- Treat all references as style guidance only. Do not import facts, examples, or claims from them unless they already belong in the draft.
-
-### Using URL references with WebFetch
-
-When a URL reference would actually help, call \`WebFetch\` with a prompt that preserves the raw style signal — not a compressed traits list. A good \`WebFetch\` prompt:
-
-- Asks for **substantial verbatim excerpts**: 3–6 passages, each a full paragraph or 2–4 consecutive sentences. The excerpts ARE the style signal; summaries throw away exactly the cadence, diction, and rhythm you need.
-- Asks for **concrete observations grounded in quoted text**, not abstract trait lists. For each excerpt, note what it demonstrates (sentence length distribution, clause structure, register, punctuation habits, transitions, rhetorical moves, where the voice leans wry vs. earnest, etc.).
-- Does **not** cap at "5 traits" or "under 200 words" — let the response run as long as the passages require. Brevity discards nuance.
-- Explicitly asks to avoid sanitized paraphrases ("the author uses vivid language") in favor of the actual sentences.
-
-Use the fetched excerpts as calibration when you edit: if you're tightening a sentence, the reference's rhythm is the target. Never copy the reference's phrasing into the draft — it's a tuning fork, not source material.
+When you fetch a URL reference, ask WebFetch for 3 to 6 verbatim passages, each a full paragraph or a few consecutive sentences, with a note on what each passage shows about sentence length, clause structure, register, and punctuation. Do not ask for a summary or a trait list. The passages themselves are the signal. Use them to judge the rhythm of your own edit, and never copy their phrasing into the draft.
 
 ## Rules to obey
 
 ${rulesBlock}
 
-Treat each rule as a hard constraint on every edit. If a rule conflicts with the user's explicit request in the current turn, the request wins for that turn but do not generalize the override.
+Each rule is a hard constraint on every edit. If a rule conflicts with the user's explicit request this turn, the request wins for this turn only. Rule changes arrive in session_state as + and - lines. If none appear, this list is current.
 
-Per-turn prompts may include a \`## Rules update\` block when rules have been added or removed since the last turn. A new rule appears as \`+ <rule text>\`; a removed rule as \`- <rule text>\`. If no update block appears, the rule set above is current.
+## Autonomy
 
-## How to decide whether to edit or comment
+The agency level arrives in session_state when it changes.
 
-Your agency level governs how proactive you are — whether you may edit, may open a comment, or should wait. The current setting is communicated as a \`## Agency\` line in the per-turn prompt only when it changes; otherwise, the prior setting still applies. The three levels:
-
-- **conservative / Low** — Default to NO edits and NO proactive comments. The user is often just writing their own text; most of the time the right move is to stop without touching any file. Make an edit only if ONE is clearly true: (1) a file contains an inline directive — \`[[ note ]]\`, \`(( note ))\`, or \`<< note >>\` — follow it and delete the directive text, (2) a diff on a tab shows the user added something that needs a specific fix (typo, broken sentence, missing content they explicitly asked for), or (3) the user's explicit message asks for an edit. You may reply on an existing comment thread when the user asked for discussion there, but do NOT open new threads with \`comment_doc\`. Do NOT polish, reword, or "improve" prose that is already fine. When in doubt, do nothing.
-- **balanced / Medium** — Same edit permissions as Low, plus proactive comments. You may create new comment threads with \`comment_doc\` when a comment would genuinely help, reply on existing threads, and ask focused questions. Do NOT make unsolicited document edits, and do NOT include a \`proposed_edit\` unless the user asked for one. Keep comments sparse — one high-value comment per turn unless the user asked for a review pass. If there's no useful comment to leave and no direct request, stay silent.
-- **aggressive / High** — Proactive comments AND proactive reviewable edits. Look for meaningful improvements — tighten wordy passages, clarify ambiguous sentences, strengthen weak verbs, improve flow between paragraphs — and default to proposing one useful edit or comment each round; only skip when every file is already clearly good and no directive asks for work. For a given passage, choose whichever is more useful: a \`comment_doc\` thread for discussion, or an \`edit_doc\` / \`write_doc\` proposal for a concrete change. Still respect the user's voice — tighten, don't rewrite from scratch.
-
-## Reading file content
-
-No tab content is inlined in the per-turn prompt — only diffs since your last edit. Call \`read_doc(path)\` to fetch any tab's current content. It's free: the server holds the Y.Doc in-process, no network round-trip. Read whatever you actually need (often just the active tab or the one the user's message is about); don't preemptively fetch every tab.`;
+- Low: no edits, no new comments. Act only on an inline directive, a diff that needs a specific fix, or an explicit request. When in doubt, do nothing.
+- Medium: you have Low's edit permissions, and you may also open a comment thread when one would help. Open at most one per turn.
+- High: propose an edit or comment when you can name the specific defect: an unclear antecedent, a repeated point, a buried verb, a broken transition. Name the defect in the proposal. If you cannot name a defect, do not edit. Tighten, but do not rewrite.`;
 }
 
 /** Build the per-render user prompt. Only the DYNAMIC content goes here —
@@ -453,17 +385,12 @@ function renderCommentThreadsBlock(
 	const open = threads.filter((t) => !t.resolved);
 	if (open.length === 0) return '';
 	const pending = new Set(pendingEditThreadIds);
-	const lines: string[] = [
-		'',
-		`Open threads (${open.length}) — each is a passage the user commented on. The comment is usually a REQUEST to revise that exact passage. To act on one, call \`edit_doc(thread_id="…")\` and edit the quoted text itself — NOT a different part of the document, and not an unrelated \`[[ ]]\` directive. Call \`list_threads("<tabId>")\` for the full conversation before acting.`
-	];
+	const lines: string[] = ['Open threads (route per "Where a response goes"):'];
 	for (const thread of open) {
 		const quote = thread.anchor.quote.replace(/\n+/g, ' ').slice(0, 120);
 		const ellipsis = thread.anchor.quote.length > 120 ? '…' : '';
-		const editNote = pending.has(thread.id)
-			? ' — **has a pending edit.** A reply here is feedback on that edit: call `edit_doc` with `thread_id` set to this id to propose a REVISED edit of the quoted passage (it supersedes the current one). Do not reply with chit-chat unless the user is only asking a question.'
-			: '';
-		lines.push(`- \`${thread.id}\` — user commented on this passage: "${quote}${ellipsis}"${editNote}`);
+		const pendingNote = pending.has(thread.id) ? ' (pending edit)' : '';
+		lines.push(`- ${thread.id}${pendingNote} anchored to: "${quote}${ellipsis}"`);
 	}
 	return '\n' + lines.join('\n');
 }
@@ -497,15 +424,17 @@ function buildRulesDelta(
 	const removed = prior.filter((t) => !currentSet.has(t));
 	if (added.length === 0 && removed.length === 0) return null;
 
-	const lines: string[] = ['## Rules update', ''];
+	const lines: string[] = [];
 	if (priorJson === null) {
-		// First render of the session — show full current list as "added".
+		// First render of the session — show the full current list.
 		if (currentRuleTexts.length === 0) {
-			lines.push('No active rules.');
+			lines.push('Rules: none active.');
 		} else {
-			for (const t of currentRuleTexts) lines.push(`+ ${t}`);
+			lines.push('Rules:');
+			currentRuleTexts.forEach((t, i) => lines.push(`${i + 1}. ${t}`));
 		}
 	} else {
+		lines.push('Rule changes:');
 		for (const t of added) lines.push(`+ ${t}`);
 		for (const t of removed) lines.push(`- ${t}`);
 	}
@@ -517,13 +446,13 @@ function buildRulesDelta(
 function buildRefsBlock(): string | null {
 	const refs = listStyleReferences().slice(0, 6);
 	if (refs.length === 0) return null;
-	const lines = ['## Style references', ''];
+	const lines = ['Style references:'];
 	for (const ref of refs) {
 		if (ref.type === 'url') {
-			lines.push(`- URL: \`${ref.target}\`${ref.label !== ref.target ? ` (${ref.label})` : ''}`);
+			lines.push(`- URL: ${ref.target}${ref.label !== ref.target ? ` (${ref.label})` : ''}`);
 		} else {
 			const kind = ref.type === 'stored-sample' ? 'Saved sample' : 'Workspace path';
-			lines.push(`- ${kind}: \`${ref.target}\``);
+			lines.push(`- ${kind}: ${ref.target}`);
 		}
 	}
 	return lines.join('\n');
@@ -532,7 +461,8 @@ function buildRefsBlock(): string | null {
 function buildMultiTabPrompt(
 	activeTabId: string | null,
 	tabs: TabPromptInfo[],
-	userMessage: string
+	userMessage: string,
+	opts: { isUserMessage?: boolean } = {}
 ): string {
 	const meta = readMeta();
 	const currentRuleTexts = meta.rules.map((r) => r.text);
@@ -548,44 +478,60 @@ function buildMultiTabPrompt(
 	const currentRefsJson = snapshotRefs();
 
 	const tabSections = tabs.length === 0
-		? 'No files are open as tabs. Use `Read` / `Glob` / `Grep` to explore the workspace; use `edit_doc({ path, ... })` to edit, or `write_doc({ path, ... })` to create a file (the path argument is the workspace-relative path).'
-		: tabs
+		? 'No files are open as tabs. Use Read / Glob / Grep to explore the workspace; use edit_doc({ path, ... }) to edit, or write_doc({ path, ... }) to create a file (the path argument is the workspace-relative path).'
+		: 'Open tabs: ' +
+			tabs.map((t) => t.tabId + (t.tabId === activeTabId ? ' (active)' : '')).join(', ') +
+			'\n\n' +
+			tabs
 				.map(({ tabId, currentMd, lastSeenMd, commentThreads, pendingEditThreadIds }) => {
-					const isActive = tabId === activeTabId;
 					const hasLastSeen = lastSeenMd !== null;
 					const hasDiff = hasLastSeen && lastSeenMd !== currentMd;
-					const activeNote = isActive ? ' [active]' : '';
-					const header = `### \`${tabId}\`${activeNote}\n\nPath: \`${tabId}\``;
 					const threadBlock = renderCommentThreadsBlock(commentThreads, pendingEditThreadIds);
 
 					if (!hasLastSeen) {
-						return `${header}\n\nNew — call \`read_doc("${tabId}")\` to read it.${threadBlock}`;
+						return `${tabId}\nNew this session. Call read_doc("${tabId}") to read it.${threadBlock}`;
 					}
 					if (hasDiff) {
-						return `${header}\n\nChanges:\n\`\`\`diff\n${unifiedLineDiff(lastSeenMd as string, currentMd)}\n\`\`\`${threadBlock}`;
+						return `${tabId}\nChanged since your last turn:\n\`\`\`diff\n${unifiedLineDiff(lastSeenMd as string, currentMd)}\n\`\`\`${threadBlock}`;
 					}
-					return `${header}\n\nUnchanged.${threadBlock}`;
+					return `${tabId}\nUnchanged.${threadBlock}`;
 				})
 				.join('\n\n');
 
-	// Assemble the dynamic prompt: only the delta blocks + the user's message.
-	// Static guidance (refs usage, rules meta, agency definitions, read_doc
-	// reminder) lives in the system prompt and isn't re-sent here.
-	const sections: string[] = [`## Files\n\n${tabSections}`];
+	// Assemble the dynamic prompt per the turn protocol the system prompt
+	// defines in "How turns arrive": tagged state blocks first, the user's
+	// words last. session_state is omitted entirely when nothing changed.
+	const sections: string[] = [`<workspace_state>\n${tabSections}\n</workspace_state>`];
 
+	const sessionParts: string[] = [];
+	const rulesDelta = buildRulesDelta(currentRuleTexts, priorRulesJson);
+	if (rulesDelta) sessionParts.push(rulesDelta);
 	if (currentRefsJson !== priorRefsJson) {
 		const refsBlock = buildRefsBlock();
-		if (refsBlock) sections.push(refsBlock);
+		if (refsBlock) sessionParts.push(refsBlock);
 	}
-
-	const rulesDelta = buildRulesDelta(currentRuleTexts, priorRulesJson);
-	if (rulesDelta) sections.push(rulesDelta);
-
 	if (currentAgency !== priorAgency) {
-		sections.push(`Agency: ${currentAgency}`);
+		sessionParts.push(`Agency: ${currentAgency}`);
+	}
+	if (sessionParts.length > 0) {
+		sections.push(`<session_state>\n${sessionParts.join('\n\n')}\n</session_state>`);
 	}
 
-	sections.push(`## Request\n\n${userMessage}`);
+	if (opts.isUserMessage === false) {
+		// Harness event (wakeup, directive retry): plain narration, no user tag.
+		sections.push(userMessage);
+	} else {
+		// The feedback path still transports thread id + mode inside the
+		// message string (composed in TiptapEditor); surface them as
+		// attributes so the model sees an explicit frame.
+		const threadId = userMessage.match(/thread_id="([^"]+)"/)?.[1] ?? null;
+		const mode = userMessage.match(/\[mode: (auto|edit|discuss)\]/)?.[1] ?? null;
+		sections.push(
+			threadId
+				? `<user_feedback thread="${threadId}"${mode ? ` mode="${mode}"` : ''}>\n${userMessage}\n</user_feedback>`
+				: `<user_message>\n${userMessage}\n</user_message>`
+		);
+	}
 
 	// Persist the new snapshots for next turn's diff. Failures are swallowed —
 	// at worst the next turn sends a redundant full block.
@@ -779,16 +725,16 @@ export const POST: RequestHandler = async ({ request }) => {
 		const planModeInstruction = planMode
 			? [
 					'',
-					'## Plan-first mode (active)',
-					'',
-					'The user has explicitly asked for a plan BEFORE any edits. Do NOT call `edit_doc`, `write_doc`, or any mutation tool — they are unavailable this round.',
-					'Read what you need with `read_doc` / `Read` / `Glob` / `Grep`, think through the change, then call the `ExitPlanMode` tool with your plan in the `plan` argument.',
-					'The plan should be concise, markdown-formatted, and concrete — list the files you\'d touch and what you\'d change in each. After you call `ExitPlanMode` the run ends; the user will approve or reject the plan.'
+					'<mode>',
+					'Plan-first mode is active. The user asked for a plan before any edits. Do not call edit_doc, write_doc, or any other mutation tool this round. Read what you need with read_doc, Read, Glob, and Grep, then call ExitPlanMode with your plan in the plan argument.',
+					'For each change, the plan states: the diagnosis (why the current text reads wrong, concretely), the intended change in one or two sentences, and the files it touches. Keep the plan short and concrete. After ExitPlanMode the run ends and the user approves or rejects it.',
+					'</mode>'
 				].join('\n')
 			: '';
 		const prompt = warmup
-			? `You are a writing assistant. The user has a set of files open as tabs. Acknowledge you're ready in 1-2 sentences. Don't edit anything.`
-			: buildMultiTabPrompt(active, tabsForPrompt, message) + planModeInstruction;
+			? `You are the user's writing collaborator. The user has files open as tabs. Say you are ready in one or two sentences. Do not edit anything.`
+			: buildMultiTabPrompt(active, tabsForPrompt, message, { isUserMessage: !!userMessage }) +
+				planModeInstruction;
 		const baseSystemPromptBlock = warmup ? undefined : buildSystemPrompt();
 		const skillsPromptBlock =
 			!warmup && (providerId === 'openai' || providerId === 'cursor')
@@ -1031,11 +977,12 @@ export const POST: RequestHandler = async ({ request }) => {
 								pendingEditThreadIds: [...readLiveTabPendingEditThreadIds(id)]
 							})),
 							[
-								'You just ended without proposing an edit, but the active tab still contains inline directives.',
-								'Handle one active-tab directive now if it is feasible.',
-								'You may still read other files or use other tools first if needed.',
-								'Do not end this retry without either calling `edit_doc` or `write_doc`, or sending a brief explanation of why the directive cannot be completed yet.'
-							].join('\n')
+								'You ended without proposing an edit, but the active tab still contains inline directives.',
+								'Handle one now if you can. You may read other files first if that helps.',
+								'If a directive cannot be completed yet, say why in a comment anchored to the directive text (comment_doc).',
+								'Do not end this retry with neither an edit nor a comment.'
+							].join('\n'),
+							{ isUserMessage: false }
 						);
 						send('directive_retry', {});
 						await runQueryRound(retryPrompt);

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -278,7 +278,7 @@ Voice belongs to the user. Match their cadence, vocabulary, sentence length, cap
 ## Editing discipline
 
 - Cut before you add. Prefer, in order: cut, tighten, replace, rearrange, rewrite. A good edit usually leaves the text shorter.
-- Edit only the span that prompted the edit. If the user flagged one sentence, fix that sentence and leave its neighbors alone. A request about the whole document puts the whole document in scope, and a proactive edit at High autonomy stays inside the span of the defect you named.
+- Edit only the thing you are fixing. If one sentence is broken, fix that sentence and leave its neighbors alone.
 - If the prose is fine, do nothing. "No edit needed" is a correct outcome at every autonomy level.
 - When you are guessing at the user's intent, ask (AskUserQuestion, 2 to 4 concrete options) or reply on the passage's thread. Do not generate prose to fill the gap.
 

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -278,7 +278,7 @@ Voice belongs to the user. Match their cadence, vocabulary, sentence length, cap
 ## Editing discipline
 
 - Cut before you add. Prefer, in order: cut, tighten, replace, rearrange, rewrite. A good edit usually leaves the text shorter.
-- Match the edit's scope to its trigger. A flagged sentence means fix that sentence and leave its neighbors alone. A document-wide request means the whole document. A defect you named at High autonomy means that defect's span, nothing more.
+- Edit only the span that prompted the edit. If the user flagged one sentence, fix that sentence and leave its neighbors alone. A request about the whole document puts the whole document in scope, and a proactive edit at High autonomy stays inside the span of the defect you named.
 - If the prose is fine, do nothing. "No edit needed" is a correct outcome at every autonomy level.
 - When you are guessing at the user's intent, ask (AskUserQuestion, 2 to 4 concrete options) or reply on the passage's thread. Do not generate prose to fill the gap.
 

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -278,7 +278,7 @@ Voice belongs to the user. Match their cadence, vocabulary, sentence length, cap
 ## Editing discipline
 
 - Cut before you add. Prefer, in order: cut, tighten, replace, rearrange, rewrite. A good edit usually leaves the text shorter.
-- Touch only what the user flagged. If one sentence is broken, fix that sentence and leave its neighbors alone.
+- Match the edit's scope to its trigger. A flagged sentence means fix that sentence and leave its neighbors alone. A document-wide request means the whole document. A defect you named at High autonomy means that defect's span, nothing more.
 - If the prose is fine, do nothing. "No edit needed" is a correct outcome at every autonomy level.
 - When you are guessing at the user's intent, ask (AskUserQuestion, 2 to 4 concrete options) or reply on the passage's thread. Do not generate prose to fill the gap.
 


### PR DESCRIPTION
## What this is

PR 0 from the V3 plan: rewrite every prompt surface the Agent SDK sees so the prompts stop demonstrating the register they ban and stop restating themselves. No tool mechanics, schemas, or transport change. Net: 151 insertions, 253 deletions.

## System prompt (`buildSystemPrompt`)

Measured ~5,960 tokens before, ~2,350 after, with zero em dashes (the old prompt used 55 while banning them as an AI tell).

- Adds a positive writing standard (plain words, complete sentences, one idea per sentence, no analogies, no padding) so the defense is no longer a blacklist alone. Distilled from the plain-writing skill so it applies deterministically on every provider.
- One tell list, referenced by name, instead of two full copies.
- The comment-routing rules, previously stated six times across the system prompt, thread stubs, and tool descriptions, are now one ordered decision list. The anchored-passage guard from the client trigger strings moved into rule 2.
- New "How turns arrive" section defines the turn protocol: `<workspace_state>`, `<session_state>`, `<mode>`, `<user_message>`, `<user_feedback thread mode>`, delta semantics, and harness-event turns.
- High autonomy inverted: no more "default to proposing one useful edit each round" plus "improve flow". Now: name the specific defect or do not edit.
- propose_rule guidance made self-consistent: at most one per turn, always with evidence.

## Per-turn prompt (`buildMultiTabPrompt`)

Harness state now arrives in tagged blocks and the user's words in their own tag, following the convention of other harnesses (system-reminder / environment_context / tagged attachments). Delta behavior is unchanged: diffs since last look, session block only when something changed. Thread stubs identify (`thr_x (pending edit) anchored to: "..."`) instead of instructing.

## Special prompts

- Plan mode now requires each plan item to open with the diagnosis.
- Directive retry's escape hatch is a comment anchored to the directive, not assistant text (which the same prompt says nobody reads).
- Warmup says "writing collaborator", matching the system prompt.

## Also

- Six tool descriptions trimmed in `mcp-doc-tools.ts`, two in `claude.ts`.
- `TiptapEditor.svelte` feedback triggers carry facts (thread id, anchor, reply, transcript) instead of routing lectures.
- Deleted the dead `buildStyleReferencesPromptBlock` in `references.ts` (no callers, drifting duplicate of the system prompt section).

## Validation

- `npm run check`: 0 errors, 0 warnings.
- Before/after sample-edit comparison (ten edits, two cold drafts, low vs medium effort) is the planned follow-up before this merges, per the V3 plan's PR 0 verification step.

## Not in this PR

The `effort: 'low'` hardcode, the client-to-server thread-id API field, and the voice-layer/pack work (PR 13).