### PR TITLE
AI-provenance toggle: color agent-written text in the editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,15 @@ first `synced` event — on localhost this is sub-20ms.
   Reject / Retry, plus per-tab badges on the `TabBar` — there is no separate
   review column.
 - **Proposed rules / hooks** surface as dismissable toasts (`ToastStack`).
+- **AI provenance toggle** (`AiProvenanceToggle`, in the editor's sticky
+  top-right chrome next to `PreviewButton`): colors agent-written text,
+  iA-Writer-authorship style. Accepting a round stamps the `ai` Yjs
+  text-format attribute onto the text the agent actually introduced — a
+  word-level diff (`diffWordLevel` in `ydoc-codec.ts`), so surviving user
+  prose stays unmarked. The client renders the attribute as the
+  `AiProvenanceMark` Tiptap mark (`span[data-ai-text]`); the toggle is pure
+  CSS view state (`showAiProvenance` store, localStorage). Typing into an
+  AI span strips the mark from the typed text ("make it your own").
 
 ## Agent SDK integration
 
@@ -198,9 +207,19 @@ the mascot card).
   to MUTATE a tab MUST go through
   `hocuspocus.openDirectConnection(...)` (see `getHocuspocus` in
   `mcp-doc-tools.ts`) — never mutate a replayed throwaway doc.
+- **`Y.XmlText.toString()` is not plain text.** Once a text node carries a
+  format attribute (the `ai` provenance attribute), `toString()` serializes
+  formatted ranges as XML tags (`a <ai>b</ai>`). All text extraction in
+  `ydoc-codec.ts` goes through `toDelta()` — never call `toString()` on a
+  fragment's text. Related: `Y.Text.insert` WITHOUT attributes inherits the
+  formatting of the preceding character; build formatted paragraphs with
+  `applyDelta` (attribute-less ops insert genuinely unformatted).
 - **Serialization is plain text, not markdown.** `serializeFragment` /
   `serializeYDoc` in `ydoc-codec.ts` emit the document text verbatim
-  (plus typography normalization) — nothing escapes markdown specials.
+  (plus typography normalization) — nothing escapes markdown specials, and
+  the `ai` provenance attribute is stripped, so `document.md`, `read_doc`,
+  prompt diffs and stale checks all see plain text (provenance lives only
+  in the CRDT log).
   The editor schema is intentionally minimal (Document / Paragraph /
   Text / HardBreak); don't add StarterKit, Link, or Tiptap's history
   extension — undo is the custom `Y.UndoManager` wired through

--- a/src/lib/components/AiProvenanceToggle.svelte
+++ b/src/lib/components/AiProvenanceToggle.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { Sparkles } from 'lucide-svelte';
+	import { showAiProvenance } from '$lib/stores';
+
+	/**
+	 * Top-right sticky toggle for the AI-provenance view (next to the
+	 * preview buttons). When on, agent-written text — tracked as the `ai`
+	 * format attribute stamped at accept time — is colored in the editor,
+	 * iA-Writer-authorship style: your words render normal, the AI's words
+	 * render in the provenance color. Pure view state; toggling never
+	 * touches the document.
+	 */
+</script>
+
+<button
+	class="ai-provenance-btn"
+	class:active={$showAiProvenance}
+	onclick={() => showAiProvenance.update((v) => !v)}
+	title={$showAiProvenance
+		? 'Hide AI authorship highlighting'
+		: 'Show AI authorship: color text the AI wrote'}
+	aria-label="Toggle AI authorship highlighting"
+	aria-pressed={$showAiProvenance}
+	type="button"
+>
+	<Sparkles size={12} />
+	<span>AI text</span>
+</button>
+
+<style>
+	/* Mirrors PreviewButton's .preview-btn so the top-right chrome cluster
+	 * reads as one control group. */
+	.ai-provenance-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 5px;
+		height: 26px;
+		padding: 0 10px 0 8px;
+		font: inherit;
+		font-size: 12px;
+		font-weight: 500;
+		white-space: nowrap;
+		color: var(--text-faint);
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-light);
+		border-radius: 8px;
+		cursor: pointer;
+		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+		transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+	}
+	.ai-provenance-btn:hover {
+		color: var(--text);
+		background: var(--bg-hover);
+		border-color: var(--border);
+	}
+	.ai-provenance-btn.active {
+		color: var(--ai-provenance, var(--accent));
+		background: var(--accent-bg);
+		border-color: var(--accent-light);
+	}
+</style>

--- a/src/lib/components/PreviewButton.svelte
+++ b/src/lib/components/PreviewButton.svelte
@@ -94,14 +94,10 @@
 {/if}
 
 <style>
-	/* Pinned top-right of the editor host, just to the left of where
-	 * the FindBar lives so they don't collide when find is open. The
-	 * FindBar wins the corner when both are visible. */
+	/* Laid out inside the editor's top-right chrome cluster
+	 * (.editor-topright-chrome in TiptapEditor), which owns the absolute
+	 * pin-to-corner positioning for the whole button row. */
 	.preview-control {
-		position: absolute;
-		top: 12px;
-		right: 16px;
-		z-index: 11;
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;

--- a/src/lib/editor-extensions.ts
+++ b/src/lib/editor-extensions.ts
@@ -9,9 +9,11 @@ import {
 	absolutePositionToRelativePosition,
 	relativePositionToAbsolutePosition
 } from '@tiptap/y-tiptap';
-import type { Extensions } from '@tiptap/core';
+import { Mark, type Extensions } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import * as Y from 'yjs';
 import {
+	AI_ATTR,
 	FRAGMENT_NAME,
 	REVIEW_ARRAY_NAME,
 	COMMENTS_MAP_NAME,
@@ -33,6 +35,85 @@ export {
 	relativePositionToAbsolutePosition
 };
 
+/** AI-provenance mark. Maps 1:1 to the Yjs text-format attribute `AI_ATTR`
+ * that the server's accept path stamps onto agent-introduced text (see
+ * `applyEditToFragment` / `replaceYDocTextWithAiProvenance` in ydoc-codec).
+ * The mark MUST be registered on every editor bound to a tab Y.Doc: y-tiptap
+ * resolves delta attributes via `schema.mark(name, …)` inside a try/catch
+ * that silently DROPS the whole paragraph node on failure — an unregistered
+ * mark makes agent-touched paragraphs vanish from the editor.
+ *
+ * Rendering is a bare `span[data-ai-text]`; whether it is colored is decided
+ * by CSS gated on the provenance toggle's container class, so flipping the
+ * toggle never touches the document.
+ *
+ * Authorship semantics ("as you type, you make it your own", per iA Writer):
+ * text the USER types must never come out AI-marked, even when typed inside
+ * or against an AI span. `inclusive: false` stops the mark from extending at
+ * span edges, and the appended-transaction plugin below strips it from any
+ * locally-inserted text (typing mid-span inherits marks in ProseMirror;
+ * so does typing at a paragraph start whose first char is AI-marked, where
+ * PM falls back to nodeAfter's marks). Remote transactions — agent edits,
+ * accept deltas, Yjs undo/redo — carry ySyncPluginKey meta and are left
+ * alone, so genuine AI provenance survives sync and undo. */
+export const AiProvenanceMark = Mark.create({
+	name: AI_ATTR,
+	inclusive: false,
+	parseHTML() {
+		return [{ tag: 'span[data-ai-text]' }];
+	},
+	renderHTML() {
+		return ['span', { 'data-ai-text': 'true' }, 0];
+	},
+	addProseMirrorPlugins() {
+		const type = this.type;
+		return [
+			new Plugin({
+				key: new PluginKey('aiProvenanceStrip'),
+				appendTransaction(transactions, _oldState, newState) {
+					// Collect ranges inserted by LOCAL transactions, mapping
+					// previously-collected ranges through every later step so
+					// they stay valid against newState.doc.
+					const ranges: Array<{ from: number; to: number }> = [];
+					for (const tr of transactions) {
+						if (!tr.docChanged) continue;
+						const isLocal = tr.getMeta(ySyncPluginKey) === undefined;
+						for (const step of tr.steps) {
+							const map = step.getMap();
+							for (const r of ranges) {
+								r.from = map.map(r.from);
+								r.to = map.map(r.to);
+							}
+							if (isLocal) {
+								map.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+									if (newEnd > newStart) ranges.push({ from: newStart, to: newEnd });
+								});
+							}
+						}
+					}
+					let tr: typeof newState.tr | null = null;
+					const docSize = newState.doc.content.size;
+					for (const range of ranges) {
+						const from = Math.max(0, Math.min(range.from, docSize));
+						const to = Math.max(from, Math.min(range.to, docSize));
+						if (from === to) continue;
+						if (!newState.doc.rangeHasMark(from, to, type)) continue;
+						tr = tr ?? newState.tr;
+						tr.removeMark(from, to, type);
+					}
+					// Clear a lingering stored mark so the very next keystroke
+					// doesn't re-insert AI-marked text just to strip it again.
+					if (newState.storedMarks?.some((m) => m.type === type)) {
+						tr = tr ?? newState.tr;
+						tr.setStoredMarks(newState.storedMarks.filter((m) => m.type !== type));
+					}
+					return tr;
+				}
+			})
+		];
+	}
+});
+
 /** Plain-text extension set: minimal schema (doc, paragraph, text, hard-break).
  * Every file — including `.md` / `.markdown` / `.mdx` — is rendered as source
  * text. `# Heading` shows as `# Heading`, `**bold**` as `**bold**`. No parser
@@ -46,6 +127,7 @@ export function plainBaseExtensions(options?: { placeholder?: string }): Extensi
 		Paragraph,
 		Text,
 		HardBreak,
+		AiProvenanceMark,
 		Placeholder.configure({ placeholder: options?.placeholder ?? 'Start writing...' })
 	];
 }

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1681,7 +1681,7 @@
 		transition: color 160ms ease;
 	}
 	.tiptap-host.show-ai-provenance :global(.tiptap-content span[data-ai-text]) {
-		color: var(--ai-provenance, var(--tool-accent, #7c3aed));
+		color: var(--ai-provenance, var(--tool-accent));
 	}
 	.tiptap-wrapper {
 		position: relative;

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -28,6 +28,7 @@
 	import { handleEditorPaste, handleEditorDrop } from './media-paste';
 	import FindBar from '$lib/components/FindBar.svelte';
 	import PreviewButton from '$lib/components/PreviewButton.svelte';
+	import AiProvenanceToggle from '$lib/components/AiProvenanceToggle.svelte';
 	import CommentGutter from '$lib/components/CommentGutter.svelte';
 	import { Crosshair } from 'lucide-svelte';
 	// `ySyncPluginKey` MUST come from the same package whose ySyncPlugin the
@@ -51,7 +52,8 @@
 		openCommentThreadId,
 		agentSettings,
 		expandedReviewRoundId,
-		pinnedDiffRounds
+		pinnedDiffRounds,
+		showAiProvenance
 	} from '$lib/stores';
 	import type { Action, CommentThread, FeedbackMode } from '$lib/types';
 	import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
@@ -1406,16 +1408,19 @@
 
 <svelte:window onkeydown={handleFeedbackWindowKeydown} />
 
-<div class="tiptap-host" class:find-open={findState.open}>
-	<!-- Top-right floating chrome: preview button + find bar. Both live
-	     outside the scroll container so they pin regardless of scroll.
-	     When find is open, the preview button shifts down so the two
-	     don't overlap (FindBar wins the corner). -->
-	<PreviewButton
-		activeTabPath={tabId}
-		onOpenSplit={onOpenSplitPreview}
-		splitOpen={splitPreviewOpen}
-	/>
+<div class="tiptap-host" class:find-open={findState.open} class:show-ai-provenance={$showAiProvenance}>
+	<!-- Top-right floating chrome: AI-provenance toggle + preview button +
+	     find bar. All live outside the scroll container so they pin
+	     regardless of scroll. When find is open, the button cluster shifts
+	     down so the two don't overlap (FindBar wins the corner). -->
+	<div class="editor-topright-chrome">
+		<AiProvenanceToggle />
+		<PreviewButton
+			activeTabPath={tabId}
+			onOpenSplit={onOpenSplitPreview}
+			splitOpen={splitPreviewOpen}
+		/>
+	</div>
 	{#if findState.open}
 		<FindBar
 			findState={findState}
@@ -1650,10 +1655,33 @@
 		min-width: 0;
 		min-height: 0;
 	}
-	/* When the FindBar is open, drop the PreviewButton below it so the
+	/* Top-right button cluster (AI-provenance toggle + preview controls).
+	 * One absolutely-positioned flex row so the buttons stack leftward from
+	 * the corner regardless of which ones are visible. */
+	.editor-topright-chrome {
+		position: absolute;
+		top: 12px;
+		right: 16px;
+		z-index: 11;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+	/* When the FindBar is open, drop the button cluster below it so the
 	 * two don't collide in the corner. */
-	.tiptap-host.find-open :global(.preview-control) {
+	.tiptap-host.find-open .editor-topright-chrome {
 		top: 50px;
+	}
+
+	/* AI-provenance view: agent-written text carries the `ai` mark
+	 * (span[data-ai-text], see AiProvenanceMark). It renders as normal prose
+	 * until the toggle turns the view on — then it takes the theme's
+	 * provenance color, iA-Writer-authorship style. */
+	.tiptap-host :global(.tiptap-content span[data-ai-text]) {
+		transition: color 160ms ease;
+	}
+	.tiptap-host.show-ai-provenance :global(.tiptap-content span[data-ai-text]) {
+		color: var(--ai-provenance, var(--tool-accent, #7c3aed));
 	}
 	.tiptap-wrapper {
 		position: relative;

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -23,7 +23,7 @@ import {
 	getFragment,
 	readReviewRounds,
 	serializeYDoc,
-	replaceYDocText,
+	replaceYDocTextWithAiProvenance,
 	applyEditToFragment
 } from '$lib/shared/ydoc-codec';
 import { applyPendingReviewRound } from '$lib/review-rounds';
@@ -246,7 +246,9 @@ export async function acceptTabRounds(
 		// Mutate the live fragment one op at a time, touching only the
 		// paragraphs each op covers. Concurrent user typing in any other
 		// paragraph merges through Yjs CRDT untouched. `write` ops are
-		// wholesale by contract; they keep using replaceYDocText.
+		// wholesale by contract. Every op here is agent-authored, so both
+		// paths tag introduced text with the `ai` provenance attribute
+		// (diff-scoped: carried-over user prose stays human-authored).
 		ydoc.transact(() => {
 			const fragment = getFragment(ydoc);
 			for (const round of accepted) {
@@ -257,12 +259,12 @@ export async function acceptTabRounds(
 					// hit by rounds persisted before the operation field
 					// existed.
 					if (typeof round.afterMd === 'string') {
-						replaceYDocText(ydoc, round.afterMd);
+						replaceYDocTextWithAiProvenance(ydoc, round.afterMd);
 					}
 					continue;
 				}
 				if (op.type === 'write') {
-					replaceYDocText(ydoc, op.content);
+					replaceYDocTextWithAiProvenance(ydoc, op.content);
 					continue;
 				}
 				// op.type === 'edit'

--- a/src/lib/shared/ydoc-codec.ts
+++ b/src/lib/shared/ydoc-codec.ts
@@ -10,6 +10,7 @@
  * `REVIEW_ARRAY_NAME`, `AGENT_ORIGIN`) so the client and server never drift.
  */
 import * as Y from 'yjs';
+import DiffMatchPatch from 'diff-match-patch';
 import type { CommentThread, PendingReviewRound } from '$lib/types';
 
 /**
@@ -48,6 +49,18 @@ export const AGENT_ORIGIN = 'agent';
 export const USER_ORIGIN = 'user';
 export const SYSTEM_ORIGIN = 'system';
 
+/** Yjs text-format attribute (and Tiptap mark name) that flags a run of text
+ * as AI-authored. Set by the accept path when an agent round lands; the
+ * client renders it as `span[data-ai-text]` and the provenance toggle colors
+ * it. Absence of the attribute means human-authored — pre-existing docs need
+ * no migration. Provenance lives only in the CRDT (SQLite `yjs_updates`);
+ * `serializeFragment` strips it, so `document.md`, `read_doc`, prompt diffs
+ * and stale checks all keep seeing plain text. */
+export const AI_ATTR = 'ai';
+
+/** One contiguous span of paragraph text with a single provenance flag. */
+export type ProvenanceRun = { text: string; ai: boolean };
+
 export function getFragment(ydoc: Y.Doc): Y.XmlFragment {
 	return ydoc.getXmlFragment(FRAGMENT_NAME);
 }
@@ -83,23 +96,196 @@ export function serializeFragment(fragment: Y.XmlFragment): string {
 }
 
 function textOf(node: unknown): string {
-	if (node instanceof Y.XmlText) return node.toString();
+	return runsOf(node)
+		.map((r) => r.text)
+		.join('');
+}
+
+/** Flatten a node to provenance runs. Mirrors `textOf`'s walk exactly:
+ * `<hardBreak/>` becomes a '\n' run, nested elements recurse. NOTE:
+ * `Y.XmlText.toString()` cannot be used for text extraction once formatting
+ * attributes exist — it serializes formatted ranges as XML tags
+ * (`a <ai>b</ai>`), so all text extraction goes through `toDelta()`. */
+function runsOf(node: unknown): ProvenanceRun[] {
+	if (node instanceof Y.XmlText) {
+		const runs: ProvenanceRun[] = [];
+		for (const d of node.toDelta() as Array<{
+			insert?: unknown;
+			attributes?: Record<string, unknown>;
+		}>) {
+			if (typeof d.insert === 'string' && d.insert.length > 0) {
+				runs.push({ text: d.insert, ai: Boolean(d.attributes?.[AI_ATTR]) });
+			}
+		}
+		return runs;
+	}
 	if (node instanceof Y.XmlElement || node instanceof Y.XmlFragment) {
-		const parts: string[] = [];
+		const runs: ProvenanceRun[] = [];
 		(node as Y.XmlElement).forEach((child: unknown) => {
 			if (
 				child instanceof Y.XmlElement &&
 				typeof (child as Y.XmlElement).nodeName === 'string' &&
 				(child as Y.XmlElement).nodeName === 'hardBreak'
 			) {
-				parts.push('\n');
+				runs.push({ text: '\n', ai: false });
 				return;
 			}
-			parts.push(textOf(child));
+			runs.push(...runsOf(child));
 		});
-		return parts.join('');
+		return runs;
 	}
-	return '';
+	return [];
+}
+
+/** Per-paragraph runs with typography normalized run-by-run. Every
+ * normalizeTypography replacement is context-free, so normalizing each run
+ * individually equals normalizing the concatenation — offsets computed
+ * against the joined text stay valid against the runs. */
+function paragraphRunsNormalized(child: unknown): ProvenanceRun[] {
+	const out: ProvenanceRun[] = [];
+	for (const r of runsOf(child)) {
+		const text = normalizeTypography(r.text);
+		if (text.length > 0) out.push({ text, ai: r.ai });
+	}
+	return out;
+}
+
+/** Join per-paragraph run lists with '\n' separator runs, mirroring how
+ * `serializeFragment` joins paragraph texts. */
+function joinParagraphRuns(paraRuns: ProvenanceRun[][]): ProvenanceRun[] {
+	const out: ProvenanceRun[] = [];
+	paraRuns.forEach((runs, i) => {
+		if (i > 0) out.push({ text: '\n', ai: false });
+		out.push(...runs);
+	});
+	return out;
+}
+
+/** Slice a run list by character offsets (like String.slice on the joined
+ * text), preserving each character's provenance flag. */
+function sliceRuns(runs: ProvenanceRun[], from: number, to: number): ProvenanceRun[] {
+	const out: ProvenanceRun[] = [];
+	let cursor = 0;
+	for (const run of runs) {
+		const runStart = cursor;
+		const runEnd = cursor + run.text.length;
+		cursor = runEnd;
+		if (runEnd <= from) continue;
+		if (runStart >= to) break;
+		const text = run.text.slice(Math.max(0, from - runStart), Math.min(run.text.length, to - runStart));
+		if (text.length > 0) out.push({ text, ai: run.ai });
+	}
+	return out;
+}
+
+const dmp = new DiffMatchPatch.diff_match_patch();
+
+/** Word-level diff. A raw character diff produces mid-word provenance
+ * boundaries — "cat" → "ferret" shares the trailing "t", so "ferre" would be
+ * AI and "t" human, and the editor would color half a word. Instead we
+ * tokenize both texts into words + whitespace runs, encode each distinct
+ * token as one sentinel char (diff-match-patch's lines-to-chars technique at
+ * word granularity), diff in token space, and run `diff_cleanupSemantic`
+ * THERE — so a lone surviving token sandwiched between rewrites merges into
+ * one phrase-level chunk, while genuinely surviving words stay unmarked.
+ * Decoding restores the real text; every boundary lands on a token edge.
+ * Falls back to a plain character diff in the (pathological) case of more
+ * distinct tokens than sentinel code points. */
+function diffWordLevel(oldText: string, newText: string): Array<[number, string]> {
+	const tokenRe = /\S+|\s+/g;
+	const tokenToChar = new Map<string, string>();
+	const charToToken = new Map<string, string>();
+	// Sentinel code points: skip the surrogate range so decoding can walk
+	// the encoded string one UTF-16 unit at a time.
+	let nextCode = 1;
+	const encode = (text: string): string | null => {
+		let out = '';
+		for (const token of text.match(tokenRe) ?? []) {
+			let c = tokenToChar.get(token);
+			if (c === undefined) {
+				if (nextCode === 0xd800) nextCode = 0xe000;
+				if (nextCode >= 0xfff0) return null;
+				c = String.fromCharCode(nextCode++);
+				tokenToChar.set(token, c);
+				charToToken.set(c, token);
+			}
+			out += c;
+		}
+		return out;
+	};
+	const encodedOld = encode(oldText);
+	const encodedNew = encodedOld === null ? null : encode(newText);
+	if (encodedOld === null || encodedNew === null) {
+		const charDiffs = dmp.diff_main(oldText, newText);
+		dmp.diff_cleanupSemantic(charDiffs);
+		return charDiffs as Array<[number, string]>;
+	}
+	const diffs = dmp.diff_main(encodedOld, encodedNew, false);
+	dmp.diff_cleanupSemantic(diffs);
+	return diffs.map(([op, chars]) => {
+		let text = '';
+		for (let i = 0; i < chars.length; i += 1) text += charToToken.get(chars[i]) ?? '';
+		return [op, text] as [number, string];
+	});
+}
+
+/** Transform `oldRuns` into `newText`, marking inserted text as AI-authored
+ * and carrying the provenance of surviving text through unchanged. Uses the
+ * word-level diff above, so an agent rewrite of half a sentence marks that
+ * half as AI — never sub-word fragments, never the untouched remainder. */
+function diffRunsToText(oldRuns: ProvenanceRun[], newText: string): ProvenanceRun[] {
+	const oldText = oldRuns.map((r) => r.text).join('');
+	if (oldText === newText) return oldRuns;
+	if (!newText) return [];
+	if (!oldText) return [{ text: newText, ai: true }];
+	const diffs = diffWordLevel(oldText, newText);
+	const out: ProvenanceRun[] = [];
+	let cursor = 0;
+	for (const [op, text] of diffs) {
+		if (op === 0) {
+			out.push(...sliceRuns(oldRuns, cursor, cursor + text.length));
+			cursor += text.length;
+		} else if (op === -1) {
+			cursor += text.length;
+		} else {
+			out.push({ text, ai: true });
+		}
+	}
+	return out;
+}
+
+/** Build `<paragraph>` elements from runs, splitting on '\n' like
+ * `buildParagraphElements`. Formatted text is written via `applyDelta`:
+ * unlike `Y.Text.insert` without attributes — which INHERITS the formatting
+ * of the character before the insertion point — `applyDelta` inserts
+ * attribute-less ops as genuinely unformatted. */
+function buildParagraphsFromRuns(runs: ProvenanceRun[]): Y.XmlElement[] {
+	const paras: ProvenanceRun[][] = [[]];
+	for (const run of runs) {
+		const parts = run.text.split('\n');
+		parts.forEach((part, i) => {
+			if (i > 0) paras.push([]);
+			if (part.length > 0) {
+				const current = paras[paras.length - 1];
+				const last = current[current.length - 1];
+				if (last && last.ai === run.ai) last.text += part;
+				else current.push({ text: part, ai: run.ai });
+			}
+		});
+	}
+	return paras.map((paraRuns) => {
+		const p = new Y.XmlElement('paragraph');
+		if (paraRuns.length > 0) {
+			const t = new Y.XmlText();
+			t.applyDelta(
+				paraRuns.map((r) =>
+					r.ai ? { insert: r.text, attributes: { [AI_ATTR]: true } } : { insert: r.text }
+				)
+			);
+			p.insert(0, [t]);
+		}
+		return p;
+	});
 }
 
 function buildParagraphElements(content: string): Y.XmlElement[] {
@@ -119,6 +305,13 @@ function buildParagraphElements(content: string): Y.XmlElement[] {
  * only deleting + reinserting the paragraphs the edit covers, concurrent
  * typing in any other paragraph merges through Yjs CRDT untouched.
  *
+ * Provenance: edit-ops are agent-authored by construction (they only exist
+ * inside PendingReviewRounds), so the text this splice INTRODUCES is tagged
+ * with the `ai` format attribute — at phrase granularity via
+ * `diffRunsToText`, not "the whole new_string". Text that survives the edit
+ * (including the untouched head/tail of the affected paragraphs) keeps
+ * whatever provenance it already had.
+ *
  * Caller must be inside a `ydoc.transact(..., origin)`. */
 export function applyEditToFragment(
 	fragment: Y.XmlFragment,
@@ -128,27 +321,29 @@ export function applyEditToFragment(
 ): boolean {
 	if (!oldString) return false;
 
-	// Snapshot paragraph texts so we can compute affected range. Mirrors
-	// serializeFragment's per-child textOf walk.
-	const paraTexts: string[] = [];
-	fragment.forEach((child) => paraTexts.push(textOf(child)));
+	// Snapshot paragraph runs (normalized) so we can compute the affected
+	// range AND carry existing provenance through the rebuild. The joined
+	// texts mirror serializeFragment's output exactly.
+	const paraRuns: ProvenanceRun[][] = [];
+	fragment.forEach((child) => paraRuns.push(paragraphRunsNormalized(child)));
+	const paraTexts = paraRuns.map((runs) => runs.map((r) => r.text).join(''));
 
 	if (replaceAll) {
 		// Sweeping rename: replace every occurrence in one pass. Concurrent
 		// typing protection is weaker here (we touch the whole fragment),
 		// but replace_all is a sweeping rename by intent — the caller is
 		// asking for it.
-		const fullText = normalizeTypography(paraTexts.join('\n'));
+		const fullText = paraTexts.join('\n');
 		if (fullText.indexOf(oldString) < 0) return false;
 		const replaced = fullText.split(oldString).join(normalizeTypography(newString));
 		if (replaced === fullText) return false;
-		const newParas = buildParagraphElements(replaced);
+		const newRuns = diffRunsToText(joinParagraphRuns(paraRuns), replaced);
 		fragment.delete(0, fragment.length);
-		fragment.insert(0, newParas);
+		fragment.insert(0, buildParagraphsFromRuns(newRuns));
 		return true;
 	}
 
-	const fullText = normalizeTypography(paraTexts.join('\n'));
+	const fullText = paraTexts.join('\n');
 	const startOffset = fullText.indexOf(oldString);
 	if (startOffset < 0) return false;
 	const endOffset = startOffset + oldString.length;
@@ -160,31 +355,39 @@ export function applyEditToFragment(
 	let cursor = 0;
 	let firstAffected = -1;
 	let lastAffected = -1;
-	let startInFirst = 0;
-	let endInLast = 0;
+	let regionStart = 0;
 	for (let i = 0; i < paraTexts.length; i += 1) {
 		const paraStart = cursor;
 		const paraEnd = cursor + paraTexts[i].length;
 		if (firstAffected < 0 && startOffset >= paraStart && startOffset <= paraEnd) {
 			firstAffected = i;
-			startInFirst = startOffset - paraStart;
+			regionStart = paraStart;
 		}
 		if (firstAffected >= 0 && endOffset >= paraStart && endOffset <= paraEnd) {
 			lastAffected = i;
-			endInLast = endOffset - paraStart;
 			break;
 		}
 		cursor = paraEnd + 1; // +1 for the '\n' separator between paragraphs
 	}
 	if (firstAffected < 0 || lastAffected < 0) return false;
 
-	const before = paraTexts[firstAffected].slice(0, startInFirst);
-	const after = paraTexts[lastAffected].slice(endInLast);
-	const splicedText = before + normalizeTypography(newString) + after;
-	const newParas = buildParagraphElements(splicedText);
+	// Splice in run space: head and tail of the affected region pass through
+	// with their existing provenance; only oldString → newString is diffed.
+	const regionRuns = joinParagraphRuns(paraRuns.slice(firstAffected, lastAffected + 1));
+	const regionLength = regionRuns.reduce((n, r) => n + r.text.length, 0);
+	const startInRegion = startOffset - regionStart;
+	const endInRegion = startInRegion + oldString.length;
+	const newRuns = [
+		...sliceRuns(regionRuns, 0, startInRegion),
+		...diffRunsToText(
+			sliceRuns(regionRuns, startInRegion, endInRegion),
+			normalizeTypography(newString)
+		),
+		...sliceRuns(regionRuns, endInRegion, regionLength)
+	];
 	const count = lastAffected - firstAffected + 1;
 	fragment.delete(firstAffected, count);
-	fragment.insert(firstAffected, newParas);
+	fragment.insert(firstAffected, buildParagraphsFromRuns(newRuns));
 	return true;
 }
 
@@ -204,4 +407,20 @@ export function replaceYDocText(ydoc: Y.Doc, content: string): void {
 	const fragment = getFragment(ydoc);
 	if (fragment.length > 0) fragment.delete(0, fragment.length);
 	if (content) fragment.insert(0, buildParagraphElements(normalizeTypography(content)));
+}
+
+/** Like `replaceYDocText`, but for AGENT-authored content (accepting a
+ * `write` op or a legacy afterMd round): diffs the new content against the
+ * current fragment and tags only the text the agent actually introduced with
+ * the `ai` provenance attribute. A wholesale rewrite that carries most of the
+ * user's prose through unchanged keeps that prose human-authored; a brand-new
+ * file (empty fragment) comes out entirely AI-authored. Callers must wrap
+ * this in `ydoc.transact(..., origin)`. */
+export function replaceYDocTextWithAiProvenance(ydoc: Y.Doc, content: string): void {
+	const fragment = getFragment(ydoc);
+	const paraRuns: ProvenanceRun[][] = [];
+	fragment.forEach((child) => paraRuns.push(paragraphRunsNormalized(child)));
+	const newRuns = diffRunsToText(joinParagraphRuns(paraRuns), normalizeTypography(content ?? ''));
+	if (fragment.length > 0) fragment.delete(0, fragment.length);
+	if (content) fragment.insert(0, buildParagraphsFromRuns(newRuns));
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -536,6 +536,23 @@ if (typeof window !== 'undefined') {
 	showSidebar.subscribe((v) => window.localStorage.setItem(SHOW_SIDEBAR_KEY, String(v)));
 }
 
+/** AI-provenance view toggle: when true, text the agent wrote (tracked as
+ * the `ai` Yjs format attribute, applied at accept time) is colored in the
+ * editor so the user can see at a glance which prose is theirs and which is
+ * the AI's. Pure view state — flipping it never touches the document.
+ * Persisted to localStorage so it survives reloads. Default off. */
+const SHOW_AI_PROVENANCE_KEY = 'docwriter.showAiProvenance';
+function readShowAiProvenance(): boolean {
+	if (typeof window === 'undefined') return false;
+	return window.localStorage.getItem(SHOW_AI_PROVENANCE_KEY) === 'true';
+}
+export const showAiProvenance = writable<boolean>(readShowAiProvenance());
+if (typeof window !== 'undefined') {
+	showAiProvenance.subscribe((v) =>
+		window.localStorage.setItem(SHOW_AI_PROVENANCE_KEY, String(v))
+	);
+}
+
 /** Whether the floating agent dock is expanded into a panel (showing the
  * history log + dock controls) or collapsed to a pill in the bottom-right.
  * Persisted so it survives reloads. Default collapsed. */

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -50,6 +50,7 @@ export const themes: Theme[] = [
 			'--color-user-edit': '#d97706',
 			'--color-agent-edit': '#059669',
 			'--color-pinned': '#7c3aed',
+			'--ai-provenance': '#7c3aed',
 			'--win-bg': '#d1fae5',
 			'--win-border': '#10b981',
 		}
@@ -91,6 +92,7 @@ export const themes: Theme[] = [
 			'--color-user-edit': '#fbbf24',
 			'--color-agent-edit': '#6ee7b7',
 			'--color-pinned': '#c4b5fd',
+			'--ai-provenance': '#c4b5fd',
 			'--win-bg': 'rgba(16, 185, 129, 0.18)',
 			'--win-border': '#10b981',
 		}
@@ -132,6 +134,7 @@ export const themes: Theme[] = [
 			'--color-user-edit': '#b58900',
 			'--color-agent-edit': '#859900',
 			'--color-pinned': '#6c71c4',
+			'--ai-provenance': '#6c71c4',
 			'--win-bg': '#e9f5e6',
 			'--win-border': '#859900',
 		}
@@ -173,6 +176,7 @@ export const themes: Theme[] = [
 			'--color-user-edit': '#b58900',
 			'--color-agent-edit': '#859900',
 			'--color-pinned': '#6c71c4',
+			'--ai-provenance': '#8b90d9',
 			'--win-bg': 'color-mix(in srgb, #859900 16%, transparent)',
 			'--win-border': '#859900',
 		}
@@ -214,6 +218,7 @@ export const themes: Theme[] = [
 			'--color-user-edit': '#e6db74',
 			'--color-agent-edit': '#a6e22e',
 			'--color-pinned': '#ae81ff',
+			'--ai-provenance': '#ae81ff',
 			'--win-bg': 'color-mix(in srgb, #a6e22e 22%, transparent)',
 			'--win-border': '#a6e22e',
 		}


### PR DESCRIPTION
iA-Writer-style authorship view: a sticky "AI text" toggle in the editor's top-right chrome (next to the preview buttons) that colors agent-written text, so you can take visual ownership of the doc as you write.

## How it works

**Authorship is tracked in the CRDT itself.** When a pending round is accepted, the accept path stamps an `ai` Yjs text-format attribute onto exactly the text the agent introduced (`applyEditToFragment` for edit ops, new `replaceYDocTextWithAiProvenance` for write ops / legacy rounds). Provenance rides normal Yjs sync + undo and persists in `yjs_updates`. Absence of the attribute = human, so existing docs need no migration.

**Word/phrase-level diffing, not character diffs.** A raw char diff colors half-words (`cat → ferret` shares the trailing `t`, so `ferre` would be marked and `t` not). `diffWordLevel` tokenizes into words + whitespace, encodes tokens as sentinel chars (diff-match-patch lines-to-chars technique at word granularity), diffs in token space with `diff_cleanupSemantic` applied *there* — lone surviving tokens between rewrites merge into phrase-level chunks, genuinely surviving words stay unmarked, and every mark boundary lands on a token edge. Existing marks in a rebuilt paragraph carry through run-by-run, so later edits don't erase earlier attribution.

**Client:** the attribute maps to a new `AiProvenanceMark` Tiptap mark (`span[data-ai-text]`), registered in the base schema (y-tiptap silently drops paragraphs whose marks aren't in the schema). A ProseMirror plugin strips the mark from locally-typed text — typing into an AI span makes it your own — while y-sync (agent edits, accepts, undo/redo) transactions are left alone.

**Toggle is pure view state:** `showAiProvenance` store persisted to localStorage; CSS gates the color. All colors resolve through the theme system — a new `--ai-provenance` variable per theme in `themes.ts` (violet family, distinct from the diff green/red), no hard-coded hex in components.

**Serialization stays plain text:** text extraction now goes through `toDelta()` because `Y.XmlText.toString()` serializes formatted ranges as XML tags (`a <ai>b</ai>`) — `document.md`, `read_doc`, prompt diffs, and stale checks are unaffected; provenance never leaks into markdown.

## Verification

- 29 codec-level assertions: phrase-scoped marking, multi-paragraph edits, replace-all renames, deletions, typography normalization, provenance surviving encode/decode round-trips and stacked edits
- End-to-end against the live dev server: `dev_fake_agent_edit`/`dev_fake_agent_write` → pending round → accept via `/api/document` → attributes on exactly the changed words, markdown flush clean
- Playwright in Chromium: toggle renders/colors/uncolors, persists across reload, typed text inside an AI span comes out unmarked, undo clean
- `npm run check`: 0 errors, 0 warnings

Known tradeoff: provenance lives only in the SQLite CRDT log — files edited outside DocWriter and reseeded read as human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9HjEwqDnMFSHyyA5wVBkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9HjEwqDnMFSHyyA5wVBkU)_