### PR TITLE
UX fixes, plan-first feedback mode, Google-Docs-style layout and comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ first `synced` event — on localhost this is sub-20ms.
 
 ## Layout
 
-- **Left (`OutlinePane`, 260px):** auto-generated TOC from headings only
+- **Left (`OutlinePane`, 200px default, resizable):** auto-generated TOC from headings only
   (`showOutline`), with the `FileTree` below it. This is the sole
   `OutlinePane` instance — it renders only the TOC. (There used to be a
   second `showReview` instance in a right-hand sidebar; that mode has been

--- a/src/lib/components/AgentDock.svelte
+++ b/src/lib/components/AgentDock.svelte
@@ -17,7 +17,7 @@
 	queuedSubmissionCount.subscribe((v) => (queuedCount = v));
 
 	let chatOpen = $state(false);
-	let chatPopoverEl: HTMLDivElement | null = $state(null);
+	let dockEl: HTMLDivElement | null = $state(null);
 	let chatMessageDraft = $state('');
 	let chatPlanModeDraft = $state(false);
 
@@ -33,8 +33,12 @@
 	$effect(() => {
 		if (!chatOpen) return;
 		function onDown(e: MouseEvent) {
+			// Check against the whole dock (button + popover), not just the
+			// popover: a mousedown on the Send button would close here and the
+			// button's click would immediately toggle it back open, making the
+			// button unable to ever close the popover.
 			const target = e.target as Node | null;
-			if (chatPopoverEl && target && !chatPopoverEl.contains(target)) chatOpen = false;
+			if (dockEl && target && !dockEl.contains(target)) chatOpen = false;
 		}
 		function onKey(e: KeyboardEvent) {
 			if (e.key === 'Escape') chatOpen = false;
@@ -48,7 +52,7 @@
 	});
 </script>
 
-<div class="agent-dock">
+<div class="agent-dock" bind:this={dockEl}>
 	<button
 		class="dock-message-btn header-pill-btn"
 		class:has-queue={queuedCount > 0}
@@ -68,11 +72,12 @@
 		{/if}
 	</button>
 	{#if chatOpen}
-		<div class="dock-chat-popover" bind:this={chatPopoverEl}>
+		<div class="dock-chat-popover">
 			<ChatPanel
 				bind:message={chatMessageDraft}
 				bind:planMode={chatPlanModeDraft}
 				onSend={sendMessage}
+				onClose={() => (chatOpen = false)}
 				rendering={rendering}
 				queuedCount={queuedCount}
 			/>

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -9,6 +9,8 @@
 
 	interface Props {
 		onSend: (message: string, opts: { planMode: boolean; images: ImageAttachment[] }) => void;
+		/** Renders an explicit ✕ in the header when provided. */
+		onClose?: () => void;
 		/** True while a render is in flight. Sends still work — they get
 		 * appended to the queue and run when the current render finishes. */
 		rendering?: boolean;
@@ -21,6 +23,7 @@
 	}
 	let {
 		onSend,
+		onClose,
 		rendering = false,
 		queuedCount = 0,
 		message = $bindable(''),
@@ -118,6 +121,11 @@
 				free-form request to the agent
 			{/if}
 		</span>
+		{#if onClose}
+			<button class="panel-close" aria-label="Close" title="Close" onclick={onClose}>
+				<X size={12} />
+			</button>
+		{/if}
 	</div>
 
 	<textarea
@@ -209,6 +217,29 @@
 	.panel-subtitle {
 		font-size: 11px;
 		color: var(--text-faint);
+		/* Keep the subtitle hugging the right edge (next to the ✕) instead
+		 * of being centered by the header's space-between. */
+		margin-left: auto;
+	}
+	.panel-close {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		margin-left: 4px;
+		border: none;
+		background: transparent;
+		color: var(--text-faint);
+		border-radius: 4px;
+		cursor: pointer;
+		padding: 0;
+		flex-shrink: 0;
+		align-self: center;
+	}
+	.panel-close:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
 	}
 	textarea {
 		width: 100%;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -529,21 +529,21 @@
 				<div class="card-messages">
 					{#each thread.messages as message (message.id)}
 						<div class="message" class:from-agent={message.author === 'agent'} class:from-user={message.author === 'user'}>
-							<span class="author">
-								<span
-									class="avatar small"
-									class:avatar-agent={message.author === 'agent'}
-									class:avatar-user={message.author !== 'agent'}
-								>
-									{#if message.author === 'agent'}
-										<Cat size={11} strokeWidth={1.8} />
-									{:else}
-										<User size={11} strokeWidth={1.8} />
-									{/if}
-								</span>
-								<span class="author-name">{message.author === 'agent' ? 'Agent' : 'You'}</span>
+							<span
+								class="avatar msg"
+								class:avatar-agent={message.author === 'agent'}
+								class:avatar-user={message.author !== 'agent'}
+							>
+								{#if message.author === 'agent'}
+									<Cat size={14} strokeWidth={1.8} />
+								{:else}
+									<User size={14} strokeWidth={1.8} />
+								{/if}
 							</span>
-							<span class="timestamp">{formatTimestamp(message.timestamp)}</span>
+							<span class="author-block">
+								<span class="author-name">{message.author === 'agent' ? 'Agent' : 'You'}</span>
+								<span class="timestamp">{formatTimestamp(message.timestamp)}</span>
+							</span>
 							<div class="message-body">{@html renderMarkdown(message.text)}</div>
 							{#if message.author === 'agent' && message.proposedEdit}
 								<button
@@ -763,7 +763,7 @@
 		z-index: 2;
 		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.13), 0 2px 6px rgba(0, 0, 0, 0.05);
 		border-color: color-mix(in srgb, var(--text) 14%, var(--border-light));
-		padding: 13px 14px;
+		padding: 16px;
 	}
 	/* Circular avatars carry the only color on the card (Google-Docs style):
 	 * the card itself stays a neutral white sheet. */
@@ -776,9 +776,11 @@
 		height: 22px;
 		border-radius: 50%;
 	}
-	.avatar.small {
-		width: 18px;
-		height: 18px;
+	/* Message-header avatar: bigger than the collapsed-row one so the
+	 * name + stacked timestamp line up beside it (Google-Docs-sized). */
+	.avatar.msg {
+		width: 26px;
+		height: 26px;
 	}
 	.avatar-agent {
 		background: color-mix(in srgb, var(--accent) 16%, transparent);
@@ -815,11 +817,11 @@
 		border-radius: 9px;
 	}
 	.card-messages {
-		max-height: 260px;
+		max-height: 300px;
 		overflow-y: auto;
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 14px;
 		/* Room at the top-right for the keep-shown toggle (pin-corner) so it
 		 * doesn't sit on the first message's timestamp. */
 		padding-right: 40px;
@@ -857,32 +859,40 @@
 		0%, 100% { opacity: 0.3; transform: translateY(0); }
 		50% { opacity: 0.9; transform: translateY(-2px); }
 	}
-	/* Per-message: author distinction comes from the avatar + name row
-	 * alone (Google-Docs-clean) — no left-accent rules, no nested box;
-	 * the body sits directly in the card. */
+	/* Per-message, Google-Docs anatomy: a roomy avatar, the name in real
+	 * (13px) dark type with the timestamp stacked in small gray UNDER it —
+	 * not competing on the same line — then the body full-width below.
+	 * Author distinction comes from the avatar + name alone; no accent
+	 * rules, no nested box. */
 	.message {
 		display: grid;
-		grid-template-columns: auto 1fr auto;
-		column-gap: 6px;
-	}
-	.author {
-		display: inline-flex;
+		grid-template-columns: auto 1fr;
+		column-gap: 9px;
 		align-items: center;
-		gap: 6px;
-		font-size: 11.5px;
+	}
+	.author-block {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		gap: 1px;
+		min-width: 0;
+	}
+	.author-name {
+		font-size: 13px;
 		font-weight: 600;
+		line-height: 1.2;
 		color: var(--text);
 	}
 	.timestamp {
-		font-size: 10.5px;
+		font-size: 11px;
+		line-height: 1.2;
 		color: var(--text-faint);
-		grid-column: 3;
 	}
 	.message-body {
-		grid-column: 1 / 4;
-		margin-top: 2px;
-		font-size: 12px;
-		line-height: 1.45;
+		grid-column: 1 / 3;
+		margin-top: 7px;
+		font-size: 13px;
+		line-height: 1.5;
 		color: var(--text);
 		word-break: break-word;
 	}
@@ -906,7 +916,7 @@
 		display: block;
 	}
 	.approve-btn {
-		grid-column: 1 / 4;
+		grid-column: 1 / 3;
 		justify-self: start;
 		display: inline-flex;
 		align-items: center;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -857,22 +857,13 @@
 		0%, 100% { opacity: 0.3; transform: translateY(0); }
 		50% { opacity: 0.9; transform: translateY(-2px); }
 	}
-	/* Per-message: clear author distinction via left-accent + author
-	 * color. No nested box; body sits directly in the card. User is
-	 * blue-ish (cool), agent is amber (warm) to match the thread's
-	 * comment color and the pill in the text. */
+	/* Per-message: author distinction comes from the avatar + name row
+	 * alone (Google-Docs-clean) — no left-accent rules, no nested box;
+	 * the body sits directly in the card. */
 	.message {
 		display: grid;
 		grid-template-columns: auto 1fr auto;
 		column-gap: 6px;
-		padding-left: 8px;
-		border-left: 2px solid var(--border-light);
-	}
-	.message.from-user {
-		border-left-color: color-mix(in srgb, #3b82f6 60%, transparent);
-	}
-	.message.from-agent {
-		border-left-color: color-mix(in srgb, #f59e0b 70%, transparent);
 	}
 	.author {
 		display: inline-flex;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -729,9 +729,9 @@
 		position: relative;
 		flex-shrink: 0;
 		/* Reads `--gutter-width` from +page.svelte. */
-		width: var(--gutter-width, 240px);
-		min-width: var(--gutter-width, 240px);
-		max-width: var(--gutter-width, 240px);
+		width: var(--gutter-width, 300px);
+		min-width: var(--gutter-width, 300px);
+		max-width: var(--gutter-width, 300px);
 		height: 100%;
 		/* Extra bottom room so the lowest card can sit clear of the fixed
 		 * agent dock (AgentDockShell publishes its height as the var). */

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -95,6 +95,26 @@
 		await item.onClick();
 	}
 
+	/** Keep an open panel/submenu inside the viewport: cap its height to the
+	 * space below its top edge and let the content scroll. Without this a
+	 * tall flyout (e.g. Writing references) runs past the bottom of the
+	 * window and its lower controls are unreachable. */
+	function clampToViewport(node: HTMLElement) {
+		const clamp = () => {
+			node.style.maxHeight = '';
+			const rect = node.getBoundingClientRect();
+			const available = window.innerHeight - rect.top - 12;
+			node.style.maxHeight = `${Math.max(120, Math.round(available))}px`;
+		};
+		clamp();
+		window.addEventListener('resize', clamp);
+		return {
+			destroy() {
+				window.removeEventListener('resize', clamp);
+			}
+		};
+	}
+
 	// Close on outside click / Escape.
 	$effect(() => {
 		if (openMenu === null) return;
@@ -167,7 +187,7 @@
 								<ChevronRight size={12} class="submenu-arrow" />
 
 								{#if openSubmenu === item.label}
-									<div class="submenu-panel" role="menu" tabindex="-1">
+									<div class="submenu-panel" role="menu" tabindex="-1" use:clampToViewport>
 										{#each item.items as sub, subIdx (subIdx)}
 											{#if sub.kind === 'divider'}
 												<div class="menu-divider" role="separator"></div>
@@ -211,6 +231,7 @@
 										class="submenu-panel panel-flyout"
 										role="menu"
 										tabindex="-1"
+										use:clampToViewport
 									>
 										{#if panelSnippet}{@render panelSnippet()}{/if}
 									</div>
@@ -330,6 +351,9 @@
 		border-radius: 6px;
 		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.10), 0 2px 4px rgba(0, 0, 0, 0.04);
 		padding: 4px;
+		/* clampToViewport caps max-height to the space below; overflow makes
+		 * the capped panel scroll instead of clipping its lower controls. */
+		overflow-y: auto;
 	}
 	/* Panel flyouts embed arbitrary content (e.g. RulesPanel) — let that
 	 * content own its own padding and sizing. Reset `white-space` because

--- a/src/lib/components/ReferencesPanel.svelte
+++ b/src/lib/components/ReferencesPanel.svelte
@@ -1,5 +1,18 @@
+<script lang="ts" module>
+	/** Drafts survive the popover unmounting. Clicking outside the menu
+	 * destroys this panel on mousedown, so without this a half-typed
+	 * sample or URL was silently lost. */
+	let savedDrafts = {
+		sampleName: '',
+		sampleContent: '',
+		sampleExpanded: false,
+		urlValue: '',
+		urlLabel: ''
+	};
+</script>
+
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { Link2, NotebookPen, Plus, Trash2 } from 'lucide-svelte';
 	import { pushHistory } from '$lib/stores';
 
@@ -24,12 +37,16 @@
 	let savingSample = $state(false);
 	let savingUrl = $state(false);
 
-	let sampleName = $state('');
-	let sampleContent = $state('');
-	let sampleExpanded = $state(false);
+	let sampleName = $state(savedDrafts.sampleName);
+	let sampleContent = $state(savedDrafts.sampleContent);
+	let sampleExpanded = $state(savedDrafts.sampleExpanded);
 
-	let urlValue = $state('');
-	let urlLabel = $state('');
+	let urlValue = $state(savedDrafts.urlValue);
+	let urlLabel = $state(savedDrafts.urlLabel);
+
+	onDestroy(() => {
+		savedDrafts = { sampleName, sampleContent, sampleExpanded, urlValue, urlLabel };
+	});
 
 	async function loadReferences() {
 		loading = true;

--- a/src/lib/components/RulesPanel.svelte
+++ b/src/lib/components/RulesPanel.svelte
@@ -1,4 +1,12 @@
+<script lang="ts" module>
+	/** Draft survives the popover unmounting. Clicking outside the menu
+	 * closes (and destroys) this panel on mousedown — before the input's
+	 * blur handler can fire — so without this a half-typed rule was lost. */
+	let savedDraft = '';
+</script>
+
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { X, Play } from 'lucide-svelte';
 	import { rules, pushHistory } from '$lib/stores';
 	import type { Rule } from '$lib/types';
@@ -9,9 +17,14 @@
 	let { onSubmit }: Props = $props();
 
 	let rulesList: Rule[] = $state([]);
-	rules.subscribe((v) => (rulesList = v));
+	const unsubscribeRules = rules.subscribe((v) => (rulesList = v));
 
-	let newRule = $state('');
+	let newRule = $state(savedDraft);
+
+	onDestroy(() => {
+		savedDraft = newRule;
+		unsubscribeRules();
+	});
 
 	async function saveRules(nextRules: Rule[]) {
 		rules.set(nextRules);

--- a/src/lib/components/RulesPillBar.svelte
+++ b/src/lib/components/RulesPillBar.svelte
@@ -131,7 +131,8 @@
 	function closePopover() {
 		popoverOpen = false;
 		popoverMode = 'manage';
-		newRule = '';
+		// Deliberately keep `newRule`: clicking out (backdrop / Escape)
+		// shouldn't discard a half-typed rule — it's restored on reopen.
 		cancelEdit();
 	}
 

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1392,8 +1392,8 @@
 		return wrapperEl?.scrollTop ?? 0;
 	}
 
-	export function focusEditor(): void {
-		editor?.commands.focus();
+	export function focusEditor(opts?: { scrollIntoView?: boolean }): void {
+		editor?.commands.focus(null, { scrollIntoView: opts?.scrollIntoView ?? true });
 	}
 
 	// Flash a sage-green halo on the freshly-accepted text range. Called

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -63,10 +63,7 @@
 	interface Props {
 		/** Workspace path for the tab this editor instance is bound to. */
 		tabId: string;
-		/** `planThreadId` (feedback popup's "Plan first") makes the render
-		 * post the agent's diagnosis as a reply on that thread BEFORE any
-		 * edit is allowed — the server gates edit_doc/write_doc on it. */
-		onSubmit?: (trigger?: string, opts?: { planThreadId?: string }) => void;
+		onSubmit?: (trigger?: string) => void;
 		/** One-shot scroll restore. Read once in onMount after the editor's
 		 * content has laid out, then ignored. The parent captures this from
 		 * `getScrollTop()` before tearing the editor down (Accept / Reject /
@@ -151,18 +148,13 @@
 	});
 	let feedbackInputEl: HTMLDivElement | null = $state(null);
 	let feedbackInput = $state('');
-	/** Routing mode for the current feedback submission. `auto` lets the
-	 * agent decide comment vs. edit; `edit` forces an edit_doc call;
-	 * `discuss` forces a reply_to_comment call on the user-opened thread.
-	 * Resets to `auto` whenever the
-	 * popup closes so each feedback session starts fresh. */
+	/** Routing mode for the current feedback submission. `edit` = direct
+	 * edit_doc proposal; `plan` = the agent first replies on the feedback
+	 * thread with WHY the passage was flagged (same reflection contract as
+	 * chat's plan-first mode), then proposes the edit on the same thread.
+	 * Resets to `edit` whenever the popup closes so each feedback session
+	 * starts fresh. */
 	let feedbackMode = $state<FeedbackMode>('edit');
-	/** "Plan first" for the current feedback submission (Edit mode only).
-	 * When checked, the agent must reflect on WHY the passage was flagged —
-	 * posted as a reply on the feedback thread — before it may propose the
-	 * edit. Mirrors ChatPanel's plan-first checkbox, but the plan lands in
-	 * situ as a comment instead of a modal plan proposal. */
-	let feedbackPlanFirst = $state(false);
 
 	// Comment thread + review state, each mirrored from its store via `$store`
 	// auto-subscription so there's exactly ONE reactive value per concept and
@@ -492,7 +484,6 @@
 		feedbackSelectionRange = null;
 		shouldFocusFeedbackInput = false;
 		feedbackMode = 'edit';
-		feedbackPlanFirst = false;
 		updateDiff();
 		if (preserveSelection && refocusEditor) {
 			requestAnimationFrame(() => editor?.commands.focus());
@@ -514,49 +505,42 @@
 		closeFeedbackPopup();
 	}
 
-	/** Format the trigger string for a feedback submission. The `[mode: …]`
-	 * tag is parsed by the agent prompt to force commenting vs. editing
-	 * (or leave it to auto-routing). The verb ("Rewrite", "Discuss",
-	 * "Consider") also nudges the agent even if it missed the tag.
-	 * When a thread was pre-opened for the feedback (Auto/Discuss modes),
-	 * include its id so the agent replies on that thread rather than
-	 * opening a duplicate one. */
+	/** Format the trigger string for a feedback submission. The pre-opened
+	 * thread id is included so the agent works on that thread rather than
+	 * opening a duplicate one. In `plan` mode the trigger additionally
+	 * requires a reply_to_comment reflection on the thread BEFORE the edit
+	 * (same contract as chat's plan-first mode, landing in situ). */
 	function buildFeedbackTrigger(
 		label: string,
 		passage: string,
 		isCustom: boolean,
-		threadId: string | null,
-		planFirst = false
+		threadId: string | null
 	): string {
-		const mode = feedbackMode;
-		// The agent prompt understands `[mode: edit]` (edit only) and
-		// `[mode: discuss]` (reply only); "comment" maps to discuss.
-		const agentMode = mode === 'comment' ? 'discuss' : 'edit';
-		const verb = mode === 'comment' ? 'Discuss' : 'Rewrite';
-		const tag = `[mode: ${agentMode}]`;
+		// Both modes end in an edit; `[mode: edit]` keeps the system prompt's
+		// routing rules pointed at edit_doc.
+		const tag = `[mode: edit]`;
 		const prefix = isCustom
 			? `The user flagged this passage with feedback "${label}"`
 			: `The user flagged this passage as "${label}"`;
 		// The system prompt's "Where a response goes" rules carry the routing;
 		// the trigger only needs the facts (mode tag + thread id).
 		const threadHint = threadId ? ` A thread is open for this feedback (thread_id="${threadId}").` : '';
-		// Same contract as chat's plan-first mode, but the plan lands on the
-		// thread: diagnosis first (why the user likely flagged it, concretely,
-		// tied to the passage), intended change in one or two sentences, THEN
-		// the edit. The server enforces the ordering by denying edit_doc /
-		// write_doc until the reply_to_comment for this thread has been made.
+		// Plan-first: same reflection contract as chat's plan-first mode, but
+		// the plan lands in situ — the agent MUST post it as a reply on the
+		// feedback thread before proposing the edit, so the reasoning shows
+		// as a comment above the pending-edit card.
 		const planHint =
-			planFirst && threadId
-				? ` Plan first: before proposing any edit, reply on thread_id="${threadId}" via reply_to_comment with a short reflection — the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Only after that reply, propose the edit via edit_doc with thread_id="${threadId}" so it attaches to the same thread.`
+			feedbackMode === 'plan' && threadId
+				? ` Plan first: before proposing any edit, you MUST reply on thread_id="${threadId}" via reply_to_comment with a short reflection — the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Only after posting that reply, propose the edit via edit_doc with thread_id="${threadId}" so it attaches to the same thread.`
 				: '';
-		return `${prefix}. ${tag} ${verb} it: "${passage}"${threadHint}${planHint}`;
+		return `${prefix}. ${tag} Rewrite it: "${passage}"${threadHint}${planHint}`;
 	}
 
 	/** Open a comment thread with the user's feedback as the first message,
 	 * so the feedback persists on the passage and the agent prompt's
 	 * transcript starts from the user's voice. Returns the new thread id, or
-	 * null on failure. Fires for BOTH modes now (edit = record, comment =
-	 * conversation).
+	 * null on failure. Fires for BOTH modes (direct edit = record, plan
+	 * first = where the agent's reflection reply lands).
 	 *
 	 * `relPositions` carries the user's actual selection encoded as Yjs
 	 * RelativePositions — when present, the server stores them on the
@@ -569,9 +553,9 @@
 		passage: string,
 		relPositions: { relStart: string; relEnd: string } | null
 	): Promise<string | null> {
-		// Every feedback now opens a thread so it persists on the passage —
-		// in edit mode as a record, in comment mode as the conversation the
-		// agent replies on.
+		// Every feedback opens a thread so it persists on the passage — as a
+		// record in direct-edit mode, and as the conversation the agent's
+		// plan reflection replies on in plan-first mode.
 		try {
 			const res = await fetch('/api/comments', {
 				method: 'POST',
@@ -611,27 +595,23 @@
 		if (!feedbackPopup) return;
 		const text = feedbackPopup.text;
 		const modeSnapshot = feedbackMode;
-		// Plan-first only applies to Edit mode — a Comment response IS the
-		// reflection, there's no edit to gate behind it.
-		const planSnapshot = feedbackPlanFirst && modeSnapshot === 'edit';
 		const relSnapshot = snapshotFeedbackRelPositions();
 		trackActionUsage(action.label);
 		if (!action.pinned) {
 			recentActions.update((prev) => [action, ...prev.filter((x) => x.id !== action.id)].slice(0, 6));
 		}
 		closeFeedbackPopup();
-		// Restore the mode for the pre-open call — closeFeedbackPopup reset
-		// it to `auto`, but we want to honor what the user picked.
+		// Restore the mode for the trigger build — closeFeedbackPopup reset
+		// it to `edit`, but we want to honor what the user picked.
 		feedbackMode = modeSnapshot;
 		const threadId = await maybeOpenThreadForFeedback(action.label, text, relSnapshot);
 		if (threadId) {
 			newAwaitingThreadId = threadId;
 			tick().then(() => { newAwaitingThreadId = null; });
 		}
-		const planFirst = planSnapshot && !!threadId;
-		const trigger = buildFeedbackTrigger(action.label, text, false, threadId, planFirst);
+		const trigger = buildFeedbackTrigger(action.label, text, false, threadId);
 		feedbackMode = 'edit';
-		if (onSubmit) onSubmit(trigger, planFirst && threadId ? { planThreadId: threadId } : undefined);
+		if (onSubmit) onSubmit(trigger);
 	}
 
 	async function sendCustomFeedback() {
@@ -652,7 +632,6 @@
 		};
 		trackActionUsage(customAction.label);
 		recentActions.update((prev) => [customAction, ...prev.filter((x) => x.label !== customAction.label)].slice(0, 6));
-		const planSnapshot = feedbackPlanFirst && modeSnapshot === 'edit';
 		closeFeedbackPopup();
 		feedbackMode = modeSnapshot;
 		const threadId = await maybeOpenThreadForFeedback(fb, text, relSnapshot);
@@ -660,10 +639,9 @@
 			newAwaitingThreadId = threadId;
 			tick().then(() => { newAwaitingThreadId = null; });
 		}
-		const planFirst = planSnapshot && !!threadId;
-		const trigger = buildFeedbackTrigger(fb, text, true, threadId, planFirst);
+		const trigger = buildFeedbackTrigger(fb, text, true, threadId);
 		feedbackMode = 'edit';
-		if (onSubmit) onSubmit(trigger, planFirst && threadId ? { planThreadId: threadId } : undefined);
+		if (onSubmit) onSubmit(trigger);
 	}
 
 	function syncPlainLineRows() {
@@ -1628,30 +1606,16 @@
 					class="mode-chip"
 					class:mode-chip-active={feedbackMode === 'edit'}
 					onclick={() => (feedbackMode = 'edit')}
-					title="Opens a thread with your feedback and has the agent propose an edit to the passage."
+					title="The agent proposes an edit to the passage right away."
 					type="button"
-				>Edit</button>
+				>Direct edit</button>
 				<button
 					class="mode-chip"
-					class:mode-chip-active={feedbackMode === 'comment'}
-					onclick={() => (feedbackMode = 'comment')}
-					title="Opens a thread with your feedback; the agent replies in the thread and does not edit."
+					class:mode-chip-active={feedbackMode === 'plan'}
+					onclick={() => (feedbackMode = 'plan')}
+					title="The agent first replies on the thread with why this passage reads wrong and what it intends to change, then proposes the edit."
 					type="button"
-				>Comment</button>
-				<label
-					class="feedback-plan-toggle"
-					class:disabled={feedbackMode === 'comment'}
-					title={feedbackMode === 'comment'
-						? 'Comment mode already replies on the thread — plan-first applies to Edit mode.'
-						: 'The agent first replies on the thread with why this passage reads wrong and what it intends to change, and only then proposes the edit.'}
-				>
-					<input
-						type="checkbox"
-						bind:checked={feedbackPlanFirst}
-						disabled={feedbackMode === 'comment'}
-					/>
-					<span>Plan first</span>
-				</label>
+				>Plan first</button>
 			</div>
 			<div class="quick-actions">
 				{#each pinnedActions as action}
@@ -2477,34 +2441,6 @@
 		color: var(--text);
 		background: var(--bg);
 		box-shadow: 0 0 0 1px var(--border-light);
-	}
-	/* Mirrors ChatPanel's plan-first toggle, popup-sized. */
-	.feedback-plan-toggle {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		margin-left: 6px;
-		padding-right: 6px;
-		font-size: 11px;
-		font-weight: 500;
-		color: var(--text-faint);
-		cursor: pointer;
-		user-select: none;
-		white-space: nowrap;
-	}
-	.feedback-plan-toggle input {
-		margin: 0;
-		cursor: pointer;
-	}
-	.feedback-plan-toggle:hover:not(.disabled) {
-		color: var(--text-secondary);
-	}
-	.feedback-plan-toggle.disabled {
-		opacity: 0.5;
-		cursor: default;
-	}
-	.feedback-plan-toggle.disabled input {
-		cursor: default;
 	}
 	/* Footer keyboard hint — reminds you the popover is dismissable with
 	 * Esc (and submittable with Enter) so it never feels like a trap. */

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -63,7 +63,10 @@
 	interface Props {
 		/** Workspace path for the tab this editor instance is bound to. */
 		tabId: string;
-		onSubmit?: (trigger?: string) => void;
+		/** `planThreadId` (feedback popup's "Plan first") makes the render
+		 * post the agent's diagnosis as a reply on that thread BEFORE any
+		 * edit is allowed — the server gates edit_doc/write_doc on it. */
+		onSubmit?: (trigger?: string, opts?: { planThreadId?: string }) => void;
 		/** One-shot scroll restore. Read once in onMount after the editor's
 		 * content has laid out, then ignored. The parent captures this from
 		 * `getScrollTop()` before tearing the editor down (Accept / Reject /
@@ -154,6 +157,12 @@
 	 * Resets to `auto` whenever the
 	 * popup closes so each feedback session starts fresh. */
 	let feedbackMode = $state<FeedbackMode>('edit');
+	/** "Plan first" for the current feedback submission (Edit mode only).
+	 * When checked, the agent must reflect on WHY the passage was flagged —
+	 * posted as a reply on the feedback thread — before it may propose the
+	 * edit. Mirrors ChatPanel's plan-first checkbox, but the plan lands in
+	 * situ as a comment instead of a modal plan proposal. */
+	let feedbackPlanFirst = $state(false);
 
 	// Comment thread + review state, each mirrored from its store via `$store`
 	// auto-subscription so there's exactly ONE reactive value per concept and
@@ -483,6 +492,7 @@
 		feedbackSelectionRange = null;
 		shouldFocusFeedbackInput = false;
 		feedbackMode = 'edit';
+		feedbackPlanFirst = false;
 		updateDiff();
 		if (preserveSelection && refocusEditor) {
 			requestAnimationFrame(() => editor?.commands.focus());
@@ -515,7 +525,8 @@
 		label: string,
 		passage: string,
 		isCustom: boolean,
-		threadId: string | null
+		threadId: string | null,
+		planFirst = false
 	): string {
 		const mode = feedbackMode;
 		// The agent prompt understands `[mode: edit]` (edit only) and
@@ -529,7 +540,16 @@
 		// The system prompt's "Where a response goes" rules carry the routing;
 		// the trigger only needs the facts (mode tag + thread id).
 		const threadHint = threadId ? ` A thread is open for this feedback (thread_id="${threadId}").` : '';
-		return `${prefix}. ${tag} ${verb} it: "${passage}"${threadHint}`;
+		// Same contract as chat's plan-first mode, but the plan lands on the
+		// thread: diagnosis first (why the user likely flagged it, concretely,
+		// tied to the passage), intended change in one or two sentences, THEN
+		// the edit. The server enforces the ordering by denying edit_doc /
+		// write_doc until the reply_to_comment for this thread has been made.
+		const planHint =
+			planFirst && threadId
+				? ` Plan first: before proposing any edit, reply on thread_id="${threadId}" via reply_to_comment with a short reflection — the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Only after that reply, propose the edit via edit_doc with thread_id="${threadId}" so it attaches to the same thread.`
+				: '';
+		return `${prefix}. ${tag} ${verb} it: "${passage}"${threadHint}${planHint}`;
 	}
 
 	/** Open a comment thread with the user's feedback as the first message,
@@ -591,6 +611,9 @@
 		if (!feedbackPopup) return;
 		const text = feedbackPopup.text;
 		const modeSnapshot = feedbackMode;
+		// Plan-first only applies to Edit mode — a Comment response IS the
+		// reflection, there's no edit to gate behind it.
+		const planSnapshot = feedbackPlanFirst && modeSnapshot === 'edit';
 		const relSnapshot = snapshotFeedbackRelPositions();
 		trackActionUsage(action.label);
 		if (!action.pinned) {
@@ -605,9 +628,10 @@
 			newAwaitingThreadId = threadId;
 			tick().then(() => { newAwaitingThreadId = null; });
 		}
-		const trigger = buildFeedbackTrigger(action.label, text, false, threadId);
+		const planFirst = planSnapshot && !!threadId;
+		const trigger = buildFeedbackTrigger(action.label, text, false, threadId, planFirst);
 		feedbackMode = 'edit';
-		if (onSubmit) onSubmit(trigger);
+		if (onSubmit) onSubmit(trigger, planFirst && threadId ? { planThreadId: threadId } : undefined);
 	}
 
 	async function sendCustomFeedback() {
@@ -628,6 +652,7 @@
 		};
 		trackActionUsage(customAction.label);
 		recentActions.update((prev) => [customAction, ...prev.filter((x) => x.label !== customAction.label)].slice(0, 6));
+		const planSnapshot = feedbackPlanFirst && modeSnapshot === 'edit';
 		closeFeedbackPopup();
 		feedbackMode = modeSnapshot;
 		const threadId = await maybeOpenThreadForFeedback(fb, text, relSnapshot);
@@ -635,9 +660,10 @@
 			newAwaitingThreadId = threadId;
 			tick().then(() => { newAwaitingThreadId = null; });
 		}
-		const trigger = buildFeedbackTrigger(fb, text, true, threadId);
+		const planFirst = planSnapshot && !!threadId;
+		const trigger = buildFeedbackTrigger(fb, text, true, threadId, planFirst);
 		feedbackMode = 'edit';
-		if (onSubmit) onSubmit(trigger);
+		if (onSubmit) onSubmit(trigger, planFirst && threadId ? { planThreadId: threadId } : undefined);
 	}
 
 	function syncPlainLineRows() {
@@ -1612,6 +1638,20 @@
 					title="Opens a thread with your feedback; the agent replies in the thread and does not edit."
 					type="button"
 				>Comment</button>
+				<label
+					class="feedback-plan-toggle"
+					class:disabled={feedbackMode === 'comment'}
+					title={feedbackMode === 'comment'
+						? 'Comment mode already replies on the thread — plan-first applies to Edit mode.'
+						: 'The agent first replies on the thread with why this passage reads wrong and what it intends to change, and only then proposes the edit.'}
+				>
+					<input
+						type="checkbox"
+						bind:checked={feedbackPlanFirst}
+						disabled={feedbackMode === 'comment'}
+					/>
+					<span>Plan first</span>
+				</label>
 			</div>
 			<div class="quick-actions">
 				{#each pinnedActions as action}
@@ -2437,6 +2477,34 @@
 		color: var(--text);
 		background: var(--bg);
 		box-shadow: 0 0 0 1px var(--border-light);
+	}
+	/* Mirrors ChatPanel's plan-first toggle, popup-sized. */
+	.feedback-plan-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		margin-left: 6px;
+		padding-right: 6px;
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text-faint);
+		cursor: pointer;
+		user-select: none;
+		white-space: nowrap;
+	}
+	.feedback-plan-toggle input {
+		margin: 0;
+		cursor: pointer;
+	}
+	.feedback-plan-toggle:hover:not(.disabled) {
+		color: var(--text-secondary);
+	}
+	.feedback-plan-toggle.disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.feedback-plan-toggle.disabled input {
+		cursor: default;
 	}
 	/* Footer keyboard hint — reminds you the popover is dismissable with
 	 * Esc (and submittable with Enter) so it never feels like a trap. */

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -44,6 +44,7 @@
 		submitCountdown,
 		editorFontScale,
 		editorSoftWrap,
+		editorLineNumbers,
 		pinnedActions,
 		recentActions,
 		trackActionUsage,
@@ -116,6 +117,7 @@
 	// a live subscriber that keeps firing against a destroyed editor.
 	let fontScale = $derived($editorFontScale);
 	let softWrap = $derived($editorSoftWrap);
+	let lineNumbersOn = $derived($editorLineNumbers);
 	/** Per-paragraph row entries for the line gutter. Each row carries a
 	 * label and an absolute `top` offset (px) from the editor content's
 	 * top. Absolute positioning lets the gutter follow paragraphs through
@@ -168,8 +170,8 @@
 	let newAwaitingThreadId = $state<string | null>(null);
 	let rounds: MaterializedPendingReviewRound[] = $derived($pendingReviewRounds);
 	let baseline = $derived($reviewBaseline);
-	/** The gutter (and its 200px column) shows when there's anything to
-	 * review — unresolved comment threads OR pending edit rounds. */
+	/** The gutter (and its --gutter-width column) shows when there's anything
+	 * to review — unresolved comment threads OR pending edit rounds. */
 	let hasGutterContent = $derived(
 		threadsForTab.some((t) => !t.resolved) || rounds.length > 0
 	);
@@ -646,6 +648,10 @@
 
 	function syncPlainLineRows() {
 		if (!editor) return;
+		// Numbers hidden (the default): skip the per-paragraph rect measuring
+		// entirely — the gutter isn't rendered. The $effect on lineNumbersOn
+		// re-syncs when the user toggles them back on.
+		if (!lineNumbersOn) return;
 		const contentEl = editor.view.dom as HTMLElement | null;
 		if (!contentEl) return;
 		const lineHeight = parseFloat(getComputedStyle(contentEl).lineHeight || '0');
@@ -1373,6 +1379,7 @@
 		if (!editor) return;
 		softWrap;
 		fontScale;
+		lineNumbersOn;
 		schedulePlainLineSync();
 	});
 
@@ -1453,15 +1460,17 @@
 		class="plain-editor-shell"
 		class:soft-wrap-enabled={softWrap}
 	>
-		<div
-			class="plain-line-gutter"
-			aria-hidden="true"
-			style:min-height="{plainGutterMinHeight}px"
-		>
-			{#each plainLineRows as row}
-				<div class="plain-line-number" style:top="{row.top}px">{row.label}</div>
-			{/each}
-		</div>
+		{#if lineNumbersOn}
+			<div
+				class="plain-line-gutter"
+				aria-hidden="true"
+				style:min-height="{plainGutterMinHeight}px"
+			>
+				{#each plainLineRows as row}
+					<div class="plain-line-number" style:top="{row.top}px">{row.label}</div>
+				{/each}
+			</div>
+		{/if}
 		<div class="tiptap-editor plain-mode" class:soft-wrap-enabled={softWrap} bind:this={element}></div>
 		{#if hasGutterContent}
 			<CommentGutter
@@ -1702,8 +1711,9 @@
 		 * it. The dock sits bottom-right over this wrapper. */
 		/* Symmetric L/R padding, constant whether or not comments exist — the
 		 * gutter column is always reserved in the grid, so the page never
-		 * shifts when a thread/card appears. */
-		padding: 0 32px calc(48px + var(--dock-reserved-bottom, 0px)) 32px;
+		 * shifts when a thread/card appears. Tight (16px) so the width goes
+		 * to the page + comment margin instead of dead canvas. */
+		padding: 0 16px calc(48px + var(--dock-reserved-bottom, 0px)) 16px;
 		/* Shared app canvas (defined on .app) — the document is a white sheet
 		 * floating on it; the line-number + comment gutters live on the canvas
 		 * in the margins rather than blending into the page. */
@@ -1736,11 +1746,23 @@
 	 * `.comment-gutter` in CommentGutter.svelte. */
 	.plain-editor-shell {
 		display: grid;
-		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
+		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 300px);
 		gap: var(--editor-grid-gap, 18px);
 		width: 100%;
 		justify-content: center;
 		align-items: start;
+	}
+	/* Explicit column assignment: the line gutter is conditionally rendered
+	 * (line-numbers toggle), so auto-placement would otherwise shift the
+	 * page into column 1 when it's absent. */
+	.plain-editor-shell > .plain-line-gutter {
+		grid-column: 1;
+	}
+	.plain-editor-shell > .tiptap-editor.plain-mode {
+		grid-column: 2;
+	}
+	.plain-editor-shell > :global(.comment-gutter) {
+		grid-column: 3;
 	}
 	.plain-line-gutter {
 		position: relative;

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -533,7 +533,7 @@
 		// as a comment above the pending-edit card.
 		const planHint =
 			feedbackMode === 'plan' && threadId
-				? ` Plan first: before proposing any edit, you MUST reply on thread_id="${threadId}" via reply_to_comment with a short reflection — the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Only after posting that reply, propose the edit via edit_doc with thread_id="${threadId}" so it attaches to the same thread.`
+				? ` Plan first: before proposing any edit, you MUST reply on thread_id="${threadId}" via reply_to_comment with your reflection. Explain, in complete sentences, why the user likely flagged this passage, what in the current text reads wrong, and what you intend to change. Write it as plain explanatory prose that carries your reasoning, the way you would explain it out loud. Do not compress it into label-led fragments or bullet points. Only after posting that reply, propose the edit via edit_doc with thread_id="${threadId}" so it attaches to the same thread.`
 				: '';
 		return `${prefix}. ${tag} Rewrite it: "${passage}"${threadHint}${planHint}`;
 	}

--- a/src/lib/server/db-writes.ts
+++ b/src/lib/server/db-writes.ts
@@ -167,6 +167,18 @@ export function dbSetEditorSoftWrap(enabled: boolean) {
 	}
 }
 
+export function dbSetEditorLineNumbers(enabled: boolean) {
+	try {
+		const db = getDb();
+		db.prepare('INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)').run(
+			'editorLineNumbers',
+			String(enabled)
+		);
+	} catch (err) {
+		logDbError('setEditorLineNumbers', err);
+	}
+}
+
 export function dbSetTheme(theme: string) {
 	try {
 		const db = getDb();

--- a/src/lib/server/runtime-state.ts
+++ b/src/lib/server/runtime-state.ts
@@ -7,6 +7,7 @@ import {
 	dbSetSessionOwner,
 	dbSetSessionId,
 	dbSetEditorSoftWrap,
+	dbSetEditorLineNumbers,
 	dbSetTheme,
 	dbUpsertTabs,
 	kvGet
@@ -40,6 +41,9 @@ export type { AgentSettings, Rule };
 // directives) don't silently clip off the right edge of the editor with no
 // visible scroll affordance. Users can still flip it off via Settings.
 const DEFAULT_EDITOR_SOFT_WRAP = true;
+/** Line numbers default OFF — the gutter column collapses so the paper +
+ * comment margin get the space (Google-Docs-style). */
+const DEFAULT_EDITOR_LINE_NUMBERS = false;
 
 export interface TabsState {
 	/** Tab IDs in display order. Tab ID = filename without the .md extension. */
@@ -171,6 +175,16 @@ export function getEditorSoftWrap(): boolean {
 
 export function setEditorSoftWrap(enabled: boolean) {
 	dbSetEditorSoftWrap(enabled);
+}
+
+export function getEditorLineNumbers(): boolean {
+	const raw = kvGet('editorLineNumbers');
+	if (raw === null) return DEFAULT_EDITOR_LINE_NUMBERS;
+	return raw === 'true';
+}
+
+export function setEditorLineNumbers(enabled: boolean) {
+	dbSetEditorLineNumbers(enabled);
 }
 
 export function getTheme(): string {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -123,6 +123,11 @@ export const editorFontScale = writable<number>(1.0);
  * long lines don't silently clip off the right edge of the editor; the
  * server mirrors this default in `runtime-state.ts`. */
 export const editorSoftWrap = writable<boolean>(true);
+/** User preference: show line numbers in the editor's left gutter. Default
+ * OFF — the gutter column collapses and the reclaimed width goes to the
+ * page + comment margin (Google-Docs-style). The server mirrors this
+ * default in `runtime-state.ts`. */
+export const editorLineNumbers = writable<boolean>(false);
 
 // ── Actions toolbar ───────────────────────────────────────────────────
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -179,9 +179,12 @@ export interface CommentThread {
 /** Routing hint carried from the feedback popup to the agent prompt. Both
  * modes open a comment thread on the passage (the feedback always persists
  * as a thread); the mode decides how the agent responds:
- *  - `edit`: propose an `edit_doc` change (no `reply_to_comment`).
- *  - `comment`: reply on the thread via `reply_to_comment` — no edit. */
-export type FeedbackMode = 'edit' | 'comment';
+ *  - `edit`: directly propose an `edit_doc` change.
+ *  - `plan`: first reply on the thread via `reply_to_comment` with the
+ *    diagnosis (why the passage was flagged, concretely) and the intended
+ *    change, THEN propose the edit — the reflection shows as a comment
+ *    above the pending-edit card. */
+export type FeedbackMode = 'edit' | 'plan';
 
 export type HistoryEntry =
 	| {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3038,7 +3038,8 @@
 		 * canvas margins are tight — that reclaimed width belongs to the
 		 * cards. */
 		--paper-width: 900px;
-		--gutter-width: 300px;
+		--comment-width: 300px;
+		--gutter-width: var(--comment-width);
 		--line-gutter-width: 52px;
 		--editor-grid-gap: 18px;
 		background: var(--canvas);
@@ -3172,12 +3173,18 @@
 		--line-number-pad-right: 6px;
 		--editor-grid-gap: 10px;
 	}
-	/* Line numbers hidden (the default): collapse the number column so the
-	 * page + comment margin get the width. Second selector outranks the
-	 * split-preview override above. */
-	.source-workspace.line-numbers-off,
+	/* Line numbers hidden (the default): collapse the number column and give
+	 * its width to the COMMENT margin, not the paper — the page geometry is
+	 * identical with numbers on or off (total column extras stay equal:
+	 * 52 + 300 = 0 + 352). Second rule outranks the split-preview override
+	 * above and mirrors its narrower (34px) number column. */
+	.source-workspace.line-numbers-off {
+		--line-gutter-width: 0px;
+		--gutter-width: calc(var(--comment-width) + 52px);
+	}
 	.source-preview-layout.split-preview-open .source-workspace.line-numbers-off {
 		--line-gutter-width: 0px;
+		--gutter-width: calc(var(--comment-width) + 34px);
 	}
 	.source-preview-layout.split-preview-open > :global(.resizer) {
 		z-index: 30;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -147,7 +147,7 @@
 		flushAutosave: () => Promise<boolean>;
 		cancelIdleTimer: () => void;
 		getScrollTop: () => number;
-		focusEditor: () => void;
+		focusEditor: (opts?: { scrollIntoView?: boolean }) => void;
 		flashAcceptedRange: (text: string) => void;
 	};
 
@@ -1492,7 +1492,11 @@
 			const data = (await res.json().catch(() => ({}))) as ReviewActionResponse;
 			if (res.ok && data?.ok && Array.isArray(data.rounds) && typeof data.yjsUpdate === 'string') {
 				applyUpdateToTab(tabId, data.yjsUpdate);
-				editorRef?.focusEditor();
+				// Focus so undo (Cmd+Z) works immediately, but don't scroll the
+				// caret into view — the caret is often far from the accepted
+				// edit and the default scroll yanked the user away from the
+				// card they just clicked.
+				editorRef?.focusEditor({ scrollIntoView: false });
 			}
 			return { res, data };
 		} finally {
@@ -1522,7 +1526,7 @@
 			if (res.ok && data?.ok && typeof data.yjsUpdate === 'string') {
 				applyUpdateToTab(tabId, data.yjsUpdate);
 				if (resolved) clearPeekIfMatches(undefined);
-				editorRef?.focusEditor();
+				editorRef?.focusEditor({ scrollIntoView: false });
 			}
 		} catch (e) {
 			console.error('Failed to set thread resolution:', e);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -158,7 +158,7 @@
 	// await. Prevents two concurrent calls from the same event loop tick (e.g.
 	// a button click firing just as the idle timer callback is about to run).
 	let submitInFlight = false;
-	let queuedSubmissions: Array<{ trigger?: string; planMode?: boolean; planThreadId?: string }> = [];
+	let queuedSubmissions: Array<{ trigger?: string; planMode?: boolean }> = [];
 
 	let currentAbort: AbortController | null = null;
 	/** Which tabs currently have a pending review (drives the tab dot badges
@@ -901,16 +901,9 @@
 		return isAcceptedEditsMessage(trigger) || isImplicitWakeupTrigger(trigger);
 	}
 
-	async function submit(
-		trigger?: string,
-		opts?: { planMode?: boolean; images?: ImageAttachment[]; planThreadId?: string }
-	) {
+	async function submit(trigger?: string, opts?: { planMode?: boolean; images?: ImageAttachment[] }) {
 		const planMode = opts?.planMode ?? false;
 		const images = opts?.images ?? [];
-		// Feedback popup's "Plan first": the server withholds edit_doc /
-		// write_doc until the agent has replied on this thread with its
-		// diagnosis, so the reflection lands as a comment before any edit.
-		const planThreadId = opts?.planThreadId;
 		if (rendering || submitInFlight) {
 			// An implicit "review the docs" wakeup carries no specific intent,
 			// so while the agent is already busy it's always redundant — the
@@ -924,7 +917,7 @@
 			// accepted your edits"), so we keep one queued — but collapse
 			// duplicates when there's already something behind it.
 			if (isSkippableWhenQueued(trigger) && queuedSubmissions.length > 0) return;
-			queuedSubmissions = [...queuedSubmissions, { trigger, planMode, planThreadId }];
+			queuedSubmissions = [...queuedSubmissions, { trigger, planMode }];
 			queuedSubmissionCount.set(queuedSubmissions.length);
 			return;
 		}
@@ -1003,7 +996,6 @@
 					userMessage: trigger,
 					model,
 					planMode,
-					planThreadId,
 					tab: tabId,
 					images: images.length > 0 ? images : undefined,
 					provider
@@ -1423,10 +1415,7 @@
 					queuedSubmissionCount.set(queuedSubmissions.length);
 				}
 				if (!isSkippableWhenQueued(next.trigger) || queuedSubmissions.length === 0) {
-					setTimeout(
-						() => void submit(next.trigger, { planMode: next.planMode, planThreadId: next.planThreadId }),
-						0
-					);
+					setTimeout(() => void submit(next.trigger, { planMode: next.planMode }), 0);
 				}
 			} else {
 				queuedSubmissionCount.set(0);
@@ -2923,7 +2912,7 @@
 							<TiptapEditor
 								tabId={activeTabFilePath}
 								bind:this={editorRef}
-								onSubmit={(trigger, opts) => submit(trigger, opts)}
+								onSubmit={(trigger) => submit(trigger)}
 								initialScrollTop={pendingScrollRestore}
 								onAcceptInlineEdit={(roundId) => {
 									const rounds = currentRounds();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,6 +109,7 @@
 		submitCountdown,
 		editorFontScale,
 		editorSoftWrap,
+		editorLineNumbers,
 		historyVerbosity,
 		showFilesPane,
 		showSidebar,
@@ -2005,6 +2006,9 @@
 	let softWrap = $state(false);
 	editorSoftWrap.subscribe((v) => (softWrap = v));
 
+	let lineNumbersOn = $state(false);
+	editorLineNumbers.subscribe((v) => (lineNumbersOn = v));
+
 	// Preset font sizes exposed in the View → Font size submenu. The inline
 	// keyboard path (Ctrl+/Ctrl-) still bumps by 0.1.
 	const FONT_PRESETS: Array<{ label: string; scale: number }> = [
@@ -2052,6 +2056,12 @@
 					checked: softWrap,
 					onClick: () => editorSoftWrap.update((v) => !v)
 				},
+				{
+					kind: 'action',
+					label: 'Line numbers',
+					checked: lineNumbersOn,
+					onClick: () => editorLineNumbers.update((v) => !v)
+				},
 				{ kind: 'panel', label: 'Writing references', panelKey: 'references' },
 				{ kind: 'panel', label: 'Skills', panelKey: 'skills' },
 				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' },
@@ -2097,9 +2107,10 @@
 		}
 	]);
 
-	// Pane widths (resizable)
-	let leftWidth = $state(240);
-	const MIN_PANE_WIDTH = 180;
+	// Pane widths (resizable). Sidebar starts narrow (Google-Docs-like) so
+	// the canvas + comment margin get the width; still user-resizable.
+	let leftWidth = $state(200);
+	const MIN_PANE_WIDTH = 160;
 	const MAX_PANE_WIDTH = 560;
 	function resizeLeft(delta: number) {
 		leftWidth = Math.max(MIN_PANE_WIDTH, Math.min(MAX_PANE_WIDTH, leftWidth + delta));
@@ -2167,6 +2178,9 @@
 			if (typeof data.editorSoftWrap === 'boolean') {
 				editorSoftWrap.set(data.editorSoftWrap);
 			}
+			if (typeof data.editorLineNumbers === 'boolean') {
+				editorLineNumbers.set(data.editorLineNumbers);
+			}
 			if (typeof data.theme === 'string') {
 				selectedTheme.set(data.theme);
 			}
@@ -2191,6 +2205,8 @@
 			actionUsageCounts.subscribe((v) => (counts = v))();
 			let wrapLongLines = false;
 			editorSoftWrap.subscribe((v) => (wrapLongLines = v))();
+			let lineNumbers = false;
+			editorLineNumbers.subscribe((v) => (lineNumbers = v))();
 			let theme = 'light';
 			selectedTheme.subscribe((v) => (theme = v))();
 			try {
@@ -2201,6 +2217,7 @@
 						recentActions: recent,
 						actionUsageCounts: counts,
 						editorSoftWrap: wrapLongLines,
+						editorLineNumbers: lineNumbers,
 						theme
 					})
 				});
@@ -2263,6 +2280,7 @@
 		recentActions.subscribe(() => schedulePersistSession());
 		actionUsageCounts.subscribe(() => schedulePersistSession());
 		editorSoftWrap.subscribe(() => schedulePersistSession());
+		editorLineNumbers.subscribe(() => schedulePersistSession());
 		selectedTheme.subscribe(() => schedulePersistSession());
 
 		// Subscribe to the file-watcher event bus (used by `docwriter --watch`).
@@ -2883,7 +2901,7 @@
 		{/if}
 		<main class="center-pane">
 			<div class="source-preview-layout" class:split-preview-open={splitPreviewOpen} bind:this={splitLayoutEl}>
-				<section class="source-workspace" aria-label="Source editor">
+				<section class="source-workspace" class:line-numbers-off={!lineNumbersOn} aria-label="Source editor">
 					<!-- Align the tab strip over the page column (same geometry as
 					     `.plain-editor-shell`) so the active tab sits on the page. -->
 					<div class="tab-align">
@@ -3015,9 +3033,12 @@
 		 * Google-Docs gray in Light); fall back to a derived recess. */
 		--canvas: var(--canvas-bg, color-mix(in srgb, var(--text) 6%, var(--bg)));
 		/* Page + comment-gutter widths — single source of truth; the editor
-		 * grid and the tab-align grid both read these. */
+		 * grid and the tab-align grid both read these. The comment margin is
+		 * wide (Google-Docs-like) because line numbers default off and the
+		 * canvas margins are tight — that reclaimed width belongs to the
+		 * cards. */
 		--paper-width: 900px;
-		--gutter-width: 240px;
+		--gutter-width: 300px;
 		--line-gutter-width: 52px;
 		--editor-grid-gap: 18px;
 		background: var(--canvas);
@@ -3151,6 +3172,13 @@
 		--line-number-pad-right: 6px;
 		--editor-grid-gap: 10px;
 	}
+	/* Line numbers hidden (the default): collapse the number column so the
+	 * page + comment margin get the width. Second selector outranks the
+	 * split-preview override above. */
+	.source-workspace.line-numbers-off,
+	.source-preview-layout.split-preview-open .source-workspace.line-numbers-off {
+		--line-gutter-width: 0px;
+	}
 	.source-preview-layout.split-preview-open > :global(.resizer) {
 		z-index: 30;
 	}
@@ -3182,10 +3210,12 @@
 	 * so the tab strip lands directly over the page column below it. */
 	.tab-align {
 		display: grid;
-		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 240px);
+		grid-template-columns: var(--line-gutter-width, 52px) minmax(0, var(--paper-width, 720px)) var(--gutter-width, 300px);
 		gap: var(--editor-grid-gap, 18px);
 		justify-content: center;
-		padding: 10px 32px 0;
+		/* Tight canvas margins (matches .tiptap-wrapper) — the space lives
+		 * in the comment gutter, not dead margins. */
+		padding: 10px 16px 0;
 		flex-shrink: 0;
 	}
 	.tab-slot {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -158,7 +158,7 @@
 	// await. Prevents two concurrent calls from the same event loop tick (e.g.
 	// a button click firing just as the idle timer callback is about to run).
 	let submitInFlight = false;
-	let queuedSubmissions: Array<{ trigger?: string; planMode?: boolean }> = [];
+	let queuedSubmissions: Array<{ trigger?: string; planMode?: boolean; planThreadId?: string }> = [];
 
 	let currentAbort: AbortController | null = null;
 	/** Which tabs currently have a pending review (drives the tab dot badges
@@ -901,9 +901,16 @@
 		return isAcceptedEditsMessage(trigger) || isImplicitWakeupTrigger(trigger);
 	}
 
-	async function submit(trigger?: string, opts?: { planMode?: boolean; images?: ImageAttachment[] }) {
+	async function submit(
+		trigger?: string,
+		opts?: { planMode?: boolean; images?: ImageAttachment[]; planThreadId?: string }
+	) {
 		const planMode = opts?.planMode ?? false;
 		const images = opts?.images ?? [];
+		// Feedback popup's "Plan first": the server withholds edit_doc /
+		// write_doc until the agent has replied on this thread with its
+		// diagnosis, so the reflection lands as a comment before any edit.
+		const planThreadId = opts?.planThreadId;
 		if (rendering || submitInFlight) {
 			// An implicit "review the docs" wakeup carries no specific intent,
 			// so while the agent is already busy it's always redundant — the
@@ -917,7 +924,7 @@
 			// accepted your edits"), so we keep one queued — but collapse
 			// duplicates when there's already something behind it.
 			if (isSkippableWhenQueued(trigger) && queuedSubmissions.length > 0) return;
-			queuedSubmissions = [...queuedSubmissions, { trigger, planMode }];
+			queuedSubmissions = [...queuedSubmissions, { trigger, planMode, planThreadId }];
 			queuedSubmissionCount.set(queuedSubmissions.length);
 			return;
 		}
@@ -996,6 +1003,7 @@
 					userMessage: trigger,
 					model,
 					planMode,
+					planThreadId,
 					tab: tabId,
 					images: images.length > 0 ? images : undefined,
 					provider
@@ -1415,7 +1423,10 @@
 					queuedSubmissionCount.set(queuedSubmissions.length);
 				}
 				if (!isSkippableWhenQueued(next.trigger) || queuedSubmissions.length === 0) {
-					setTimeout(() => void submit(next.trigger, { planMode: next.planMode }), 0);
+					setTimeout(
+						() => void submit(next.trigger, { planMode: next.planMode, planThreadId: next.planThreadId }),
+						0
+					);
 				}
 			} else {
 				queuedSubmissionCount.set(0);
@@ -2912,7 +2923,7 @@
 							<TiptapEditor
 								tabId={activeTabFilePath}
 								bind:this={editorRef}
-								onSubmit={(trigger) => submit(trigger)}
+								onSubmit={(trigger, opts) => submit(trigger, opts)}
 								initialScrollTop={pendingScrollRestore}
 								onAcceptInlineEdit={(roundId) => {
 									const rounds = currentRounds();

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -1,4 +1,5 @@
 import { error, json } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 import type { RequestHandler } from './$types';
 import * as Y from 'yjs';
 import type { Document } from '@hocuspocus/server';
@@ -124,13 +125,19 @@ export const POST: RequestHandler = async ({ request }) => {
 		const messageText = typeof body.message === 'string' ? body.message.trim() : '';
 		if (!threadId) throw error(400, 'threadId is required');
 		if (!messageText) throw error(400, 'message is required');
+		// Dev-only test seam (mirrors dev_fake_agent_edit): allow faking an
+		// agent-authored reply so the plan-first thread rendering can be
+		// exercised locally without a live agent. Real agent replies go
+		// through the reply_to_comment MCP tool, never this route.
+		const author: CommentMessage['author'] =
+			dev && body.author === 'agent' ? 'agent' : 'user';
 		const outcome = await mutateTabYDoc(tabId, (doc) => {
 			const commentsMap = getCommentsMap(doc);
 			const existing = commentsMap.get(threadId);
 			if (!existing) return { ok: false, error: 'Thread not found', status: 404 };
 			const reply: CommentMessage = {
 				id: 'msg_' + cryptoRandomId(),
-				author: 'user',
+				author,
 				text: messageText,
 				timestamp: Date.now()
 			};

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -262,10 +262,11 @@ You are the user's writing collaborator. The user is the author. Everything you 
 
 ## Your instructions
 
-Apply this to every word you write, in edits and in new prose. The user's rules and the document's style override it.
+Apply this to every word you write: edits, new prose, and your replies on comment threads. The user's rules and the document's style override it.
 
 - Use plain, everyday words. Write "use", not "leverage" or "utilize".
-- Write complete sentences that carry one idea each. Split a sentence that stacks clauses.
+- Write complete sentences, and prefer long, explanatory sentences over short, punchy ones. Write the way people explain things out loud, in longer sentences with commas and one or two related clauses that carry the reasoning along. A sentence should end because the thought is complete, not because a short sentence would sound stronger. Plain means explanatory, not terse.
+- Communicate clearly and boring. State the literal thing with no embellishment and no performance. Never write a staccato run of short sentences for emphasis, and never lead with a colon-headed label fragment such as "The problem: fixed." Explain in prose.
 - Prefer concrete verbs and named things. Replace "various", "several", "a number of", "important", "robust", and "powerful" with the specific thing.
 - Repeat a word rather than swapping in a synonym.
 - Do not use analogies, metaphors, or imagery unless the user's text uses them.
@@ -319,7 +320,7 @@ Decide where to respond in this order. The first rule that matches wins.
 1. If the feedback's mode attribute is edit, edit. If it is discuss, reply on the thread.
 2. If the thread has a pending edit and the user replied, treat the reply as feedback on the edit. Call edit_doc with the thread_id to propose a revision of the thread's anchored passage itself, not a different part of the document. Reply in words only if they asked a question and clearly want no change. If the feedback is contradictory, use AskUserQuestion.
 3. If the feedback names a concrete change, e.g. "too wordy" or "tighten", call edit_doc and do not also reply.
-4. If the message is open-ended or unsure, e.g. "what do you think?", reply on the existing thread. Write in the first person and keep it to a few sentences. Attach proposed_edit only if the user asked for an edit or autonomy is High.
+4. If the message is open-ended or unsure, e.g. "what do you think?", reply on the existing thread. Write in the first person, in complete explanatory sentences that carry your reasoning. A few sentences is the right length, but they must be full sentences, not fragments or label-led lines. Attach proposed_edit only if the user asked for an edit or autonomy is High.
 5. If no thread exists and autonomy is Medium or High, you may open one with comment_doc, anchored to exact text from the current document. Open at most one comment per turn. At Low autonomy, use AskUserQuestion or do nothing.
 
 ## Subagents

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -665,15 +665,20 @@ function buildHooks(
 export const POST: RequestHandler = async ({ request }) => {
 	try {
 		const body = await request.json();
-		const { userMessage, model, warmup, tab, planMode, images, provider: providerIdRaw } = body as {
+		const { userMessage, model, warmup, tab, planMode, planThreadId: planThreadIdRaw, images, provider: providerIdRaw } = body as {
 			userMessage?: string;
 			model?: string;
 			warmup?: boolean;
 			tab?: string;
 			planMode?: boolean;
+			/** Feedback popup's "Plan first": the agent must reply on this
+			 * thread with its diagnosis before edit_doc/write_doc unlock. */
+			planThreadId?: string;
 			images?: ImageAttachmentPayload[];
 			provider?: string;
 		};
+		const planThreadId =
+			typeof planThreadIdRaw === 'string' && planThreadIdRaw.trim() ? planThreadIdRaw.trim() : null;
 		const providerId = (providerIdRaw || 'claude') as ProviderId;
 		// Switching providers invalidates the persisted session id: each
 		// provider mints ids in its own format (Claude wants a UUID, OpenAI
@@ -731,10 +736,24 @@ export const POST: RequestHandler = async ({ request }) => {
 					'</mode>'
 				].join('\n')
 			: '';
+		// Plan-first FEEDBACK (distinct from full plan mode): the plan is not a
+		// modal proposal — it lands in situ as a reply on the feedback thread,
+		// and only then may the edit be proposed. Mutation tools stay in the
+		// allowed list but are gated in canUseTool until the reply exists.
+		const planThreadInstruction = planThreadId && !planMode
+			? [
+					'',
+					'<mode>',
+					`Plan-first feedback is active for thread_id="${planThreadId}". Before proposing any edit, reply on that thread via reply_to_comment with a short reflection: the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Keep it short and concrete.`,
+					`edit_doc and write_doc are blocked until that reply is posted. After replying, propose the edit via edit_doc with thread_id="${planThreadId}" so it attaches to the same thread.`,
+					'</mode>'
+				].join('\n')
+			: '';
 		const prompt = warmup
 			? `You are the user's writing collaborator. The user has files open as tabs. Say you are ready in one or two sentences. Do not edit anything.`
 			: buildMultiTabPrompt(active, tabsForPrompt, message, { isUserMessage: !!userMessage }) +
-				planModeInstruction;
+				planModeInstruction +
+				planThreadInstruction;
 		const baseSystemPromptBlock = warmup ? undefined : buildSystemPrompt();
 		const skillsPromptBlock =
 			!warmup && (providerId === 'openai' || providerId === 'cursor')
@@ -802,8 +821,22 @@ export const POST: RequestHandler = async ({ request }) => {
 						'edit_doc', 'write_doc'
 					]);
 
+					// Plan-first feedback: flips true once the agent has replied on
+					// the flagged thread; until then edit_doc/write_doc are denied.
+					let planReflectionPosted = false;
+
 					// canUseTool logic (provider-agnostic permission checks)
 					const canUseTool = async (toolName: string, toolInput: any) => {
+						if (toolName === REPLY_TO_COMMENT_TOOL_NAME || toolName === 'reply_to_comment') {
+							const target = typeof toolInput?.thread_id === 'string' ? toolInput.thread_id : '';
+							if (!planThreadId || target === planThreadId) planReflectionPosted = true;
+						}
+						if (planThreadId && !planReflectionPosted && mutationToolNames.has(toolName)) {
+							return {
+								behavior: 'deny' as const,
+								message: `Plan-first feedback is active: reply on thread_id="${planThreadId}" via reply_to_comment (the diagnosis and your intended change) before proposing any edit.`
+							};
+						}
 						if (toolName === 'ExitPlanMode') {
 							const plan = typeof toolInput?.plan === 'string' ? toolInput.plan : '';
 							const planId =

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -665,20 +665,15 @@ function buildHooks(
 export const POST: RequestHandler = async ({ request }) => {
 	try {
 		const body = await request.json();
-		const { userMessage, model, warmup, tab, planMode, planThreadId: planThreadIdRaw, images, provider: providerIdRaw } = body as {
+		const { userMessage, model, warmup, tab, planMode, images, provider: providerIdRaw } = body as {
 			userMessage?: string;
 			model?: string;
 			warmup?: boolean;
 			tab?: string;
 			planMode?: boolean;
-			/** Feedback popup's "Plan first": the agent must reply on this
-			 * thread with its diagnosis before edit_doc/write_doc unlock. */
-			planThreadId?: string;
 			images?: ImageAttachmentPayload[];
 			provider?: string;
 		};
-		const planThreadId =
-			typeof planThreadIdRaw === 'string' && planThreadIdRaw.trim() ? planThreadIdRaw.trim() : null;
 		const providerId = (providerIdRaw || 'claude') as ProviderId;
 		// Switching providers invalidates the persisted session id: each
 		// provider mints ids in its own format (Claude wants a UUID, OpenAI
@@ -736,24 +731,10 @@ export const POST: RequestHandler = async ({ request }) => {
 					'</mode>'
 				].join('\n')
 			: '';
-		// Plan-first FEEDBACK (distinct from full plan mode): the plan is not a
-		// modal proposal — it lands in situ as a reply on the feedback thread,
-		// and only then may the edit be proposed. Mutation tools stay in the
-		// allowed list but are gated in canUseTool until the reply exists.
-		const planThreadInstruction = planThreadId && !planMode
-			? [
-					'',
-					'<mode>',
-					`Plan-first feedback is active for thread_id="${planThreadId}". Before proposing any edit, reply on that thread via reply_to_comment with a short reflection: the diagnosis (why the user likely flagged this passage and why the current text reads wrong, concretely) and the intended change in one or two sentences. Keep it short and concrete.`,
-					`edit_doc and write_doc are blocked until that reply is posted. After replying, propose the edit via edit_doc with thread_id="${planThreadId}" so it attaches to the same thread.`,
-					'</mode>'
-				].join('\n')
-			: '';
 		const prompt = warmup
 			? `You are the user's writing collaborator. The user has files open as tabs. Say you are ready in one or two sentences. Do not edit anything.`
 			: buildMultiTabPrompt(active, tabsForPrompt, message, { isUserMessage: !!userMessage }) +
-				planModeInstruction +
-				planThreadInstruction;
+				planModeInstruction;
 		const baseSystemPromptBlock = warmup ? undefined : buildSystemPrompt();
 		const skillsPromptBlock =
 			!warmup && (providerId === 'openai' || providerId === 'cursor')
@@ -821,22 +802,8 @@ export const POST: RequestHandler = async ({ request }) => {
 						'edit_doc', 'write_doc'
 					]);
 
-					// Plan-first feedback: flips true once the agent has replied on
-					// the flagged thread; until then edit_doc/write_doc are denied.
-					let planReflectionPosted = false;
-
 					// canUseTool logic (provider-agnostic permission checks)
 					const canUseTool = async (toolName: string, toolInput: any) => {
-						if (toolName === REPLY_TO_COMMENT_TOOL_NAME || toolName === 'reply_to_comment') {
-							const target = typeof toolInput?.thread_id === 'string' ? toolInput.thread_id : '';
-							if (!planThreadId || target === planThreadId) planReflectionPosted = true;
-						}
-						if (planThreadId && !planReflectionPosted && mutationToolNames.has(toolName)) {
-							return {
-								behavior: 'deny' as const,
-								message: `Plan-first feedback is active: reply on thread_id="${planThreadId}" via reply_to_comment (the diagnosis and your intended change) before proposing any edit.`
-							};
-						}
 						if (toolName === 'ExitPlanMode') {
 							const plan = typeof toolInput?.plan === 'string' ? toolInput.plan : '';
 							const planId =

--- a/src/routes/api/session/+server.ts
+++ b/src/routes/api/session/+server.ts
@@ -10,6 +10,8 @@ import {
 	clearSessionState,
 	getEditorSoftWrap,
 	setEditorSoftWrap,
+	getEditorLineNumbers,
+	setEditorLineNumbers,
 	getTheme,
 	setTheme
 } from '$lib/server/runtime-state';
@@ -24,6 +26,7 @@ export const GET: RequestHandler = async () => {
 		recentActions: getRecentActions(),
 		actionUsageCounts: getActionUsageCounts(),
 		editorSoftWrap: getEditorSoftWrap(),
+		editorLineNumbers: getEditorLineNumbers(),
 		theme: getTheme()
 	});
 };
@@ -33,6 +36,7 @@ export const PUT: RequestHandler = async ({ request }) => {
 	if (body.recentActions) setRecentActions(body.recentActions);
 	if (body.actionUsageCounts) setActionUsageCounts(body.actionUsageCounts);
 	if (typeof body.editorSoftWrap === 'boolean') setEditorSoftWrap(body.editorSoftWrap);
+	if (typeof body.editorLineNumbers === 'boolean') setEditorLineNumbers(body.editorLineNumbers);
 	if (typeof body.theme === 'string') setTheme(body.theme);
 	return json({ ok: true });
 };


### PR DESCRIPTION
## What this PR does

Nine commits spanning bug fixes, a new feedback mode, and a layout/comment redesign, all driven by hands-on feedback.

### Bug fixes
- **Menu panels no longer run off the bottom of the window.** Open submenus and panel flyouts (e.g. Writing references) clamp to the viewport and scroll internally, so controls like "Add URL" are always reachable.
- **Half-typed drafts survive clicking out.** The rules popover (toolbar pill bar and menu panel) and the references panel (sample + URL fields) used to lose in-progress text when an outside mousedown destroyed the popover before blur could fire. Drafts are now preserved and restored on reopen.
- **The Send popover can actually be closed.** The Send button's click was racing the outside-mousedown closer and reopening the popover; the button now toggles correctly, and the panel gained an explicit close button.
- **Accepting an edit no longer yanks the viewport.** The post-accept refocus used Tiptap's default scroll-caret-into-view; it now focuses without scrolling, so you stay at the card you just clicked.

### Plan-first feedback
The highlight-feedback popup now has two modes: **Direct edit** (unchanged flow) and **Plan first**. In plan-first, the trigger carries the same reflection contract as chat's plan-first mode: the agent must reply on the feedback thread explaining why the passage was likely flagged and what it intends to change, and only then propose the edit on the same thread. The reasoning lands in situ as a comment above the pending-edit card. This is a prompt-level contract, with no tool interception. A dev-only seam lets the thread rendering be exercised locally by faking an agent-authored reply.

### Layout and comments (Google-Docs-like)
- Line numbers are now a Settings toggle, default off and persisted server-side. Hiding them keeps the paper width identical: the freed column width is added to the comment margin, not the page.
- The comment margin widened from 240px to 300px, the sidebar default narrowed to 200px, and the canvas paddings tightened, so comment cards get real reading width.
- Comment messages were restyled to the Docs anatomy: 26px avatar, 13px semibold name with the timestamp stacked under it in small gray, full-width 13px/1.5 body, whitespace as the only separator (the colored left-accent bars are gone).

### Agent voice
The system prompt previously pushed staccato prose ("one idea per sentence, split stacked clauses") and gave thread replies no register at all. It now instructs the agent to prefer long, explanatory sentences that carry the reasoning along, to communicate clearly and boring with no embellishment, and to never write label-led fragments; the scope explicitly covers comment-thread replies, and the plan-first trigger asks for explanatory prose instead of a "short reflection".

## Verification
- `npm run check` passes at every commit (0 errors, 0 warnings).
- Each change was exercised in the running app under headless Chromium: panel clamping, draft persistence across popover close/reopen, Send toggle + close button, paper-width parity across the line-number toggle (measured 820px in both states), and the plan-first thread rendering (thread + agent reply + attached edit) via the dev seams.
- Not verified live: an end-to-end agent render (no provider API key in the dev container), so the plan-first reply and the new prose voice deserve a close read on the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEACFU8agYbrMUs8Fi3Pqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEACFU8agYbrMUs8Fi3Pqn)_