### PR TITLE
Explain-before-edit: plan-first AI smell, announce threads, acceptance-driven rules

### DIFF
--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -596,7 +596,10 @@
 	async function sendFeedback(action: Action) {
 		if (!feedbackPopup) return;
 		const text = feedbackPopup.text;
-		const modeSnapshot = feedbackMode;
+		// "AI smell" always runs plan-first, regardless of the mode chips: the
+		// agent must reply on the thread with what reads as AI and what it will
+		// change before proposing the edit.
+		const modeSnapshot: FeedbackMode = action.id === 'a_ai' ? 'plan' : feedbackMode;
 		const relSnapshot = snapshotFeedbackRelPositions();
 		trackActionUsage(action.label);
 		if (!action.pinned) {

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -796,7 +796,7 @@ function createAgentCommentThread(
 
 const commentDocTool = tool(
 	'comment_doc',
-	'Create a new comment thread anchored to existing text in a workspace document. Allowed at Medium or High autonomy, or when the user asks for a comment. The comment appears in the document gutter and does not change document text. At Low autonomy you may only reply on threads the user opened.',
+	'Create a new comment thread anchored to existing text in a workspace document. Use it, at any autonomy level, as the announce thread before an edit proposal (see "Announce edits on a thread" in your instructions). Unprompted observation comments are allowed only at Medium or High autonomy, or when the user asks for a comment; at Low autonomy you may otherwise only reply on threads the user opened. The comment appears in the document gutter and does not change document text.',
 	{
 		file_path: z
 			.string()

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -299,6 +299,17 @@ Every file is raw text, including .md. The editor renders markdown source litera
 - For hooks call propose_hook. For rules call propose_rule. For skills call add_skill with a GitHub URL or local path. Do not edit .docwriter/hooks.json, .docwriter/skills.json, .claude/skills, or .agents/skills directly.
 - Call review_action to accept, reject, resolve, or reopen only when the user's current message explicitly asks for that action.
 
+## Announce edits on a thread
+
+Every edit proposal needs a comment thread that says what is about to happen, so the user sees your reasoning next to the pending edit instead of a bare diff.
+
+- If the work already has a thread — user feedback arrives with a thread_id, or you are revising a thread's pending edit — use it. If you have not yet explained this edit there, reply first with reply_to_comment, then call edit_doc with that thread_id.
+- Otherwise, before the edit, call comment_doc anchored to the exact text you are about to change, with one or two first-person sentences: what prompted the edit (the user's words, an inline directive, a rule), what you think is wrong, and what you will do. Then call edit_doc with the thread_id that comment_doc returns.
+- Inline directives such as [[ ... ]] follow the same contract: anchor the thread on the directive text, say how you read the directive and what you will write, then propose the edit on that thread.
+- For write_doc on an existing file, anchor the thread to the first sentence of the text you are replacing.
+- write_doc that creates a new file needs no thread; there is no proposal to explain.
+- These announce threads are part of the edit and apply at every autonomy level. The one-comment-per-turn limit and the autonomy gate in "Where a response goes" govern unprompted observations, not announce threads.
+
 ## How turns arrive
 
 Each turn may contain these blocks, in this order.
@@ -319,7 +330,7 @@ Decide where to respond in this order. The first rule that matches wins.
 
 1. If the feedback's mode attribute is edit, edit. If it is discuss, reply on the thread.
 2. If the thread has a pending edit and the user replied, treat the reply as feedback on the edit. Call edit_doc with the thread_id to propose a revision of the thread's anchored passage itself, not a different part of the document. Reply in words only if they asked a question and clearly want no change. If the feedback is contradictory, use AskUserQuestion.
-3. If the feedback names a concrete change, e.g. "too wordy" or "tighten", call edit_doc and do not also reply.
+3. If the feedback names a concrete change, e.g. "too wordy" or "tighten", announce per "Announce edits on a thread" and call edit_doc. Beyond the announce, do not also reply.
 4. If the message is open-ended or unsure, e.g. "what do you think?", reply on the existing thread. Write in the first person, in complete explanatory sentences that carry your reasoning. A few sentences is the right length, but they must be full sentences, not fragments or label-led lines. Attach proposed_edit only if the user asked for an edit or autonomy is High.
 5. If no thread exists and autonomy is Medium or High, you may open one with comment_doc, anchored to exact text from the current document. Open at most one comment per turn. At Low autonomy, use AskUserQuestion or do nothing.
 

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -346,7 +346,15 @@ Subagents inherit this system prompt, so they have the instructions above. They 
 
 ## Proposing rules
 
-Propose at most one rule per turn with propose_rule, and only with evidence. Evidence is one of: the same pattern in the user's edits more than once, an explicit standing preference ("never use X"), or the user flagging anything on THE TELL LIST or calling something AI-sounding. For a tell, fix the flagged instance with edit_doc and propose the rule in the same turn, with the evidence in the reason field. Write rules as short imperatives that are specific enough to check, e.g. "Never use em dashes". When unsure, do not propose.
+Propose at most one rule per turn with propose_rule, and only with evidence. Evidence, strongest first:
+
+- An explicit standing preference in any channel — chat, a comment thread reply, or an inline [[ directive ]]: "never use X", "add a rule that Y". Propose in the same turn.
+- The user accepted an edit that came from their feedback. When a tab's diff shows that an edit you proposed on a thread has landed in the document, re-read that thread and the edit. If the feedback behind it names a pattern that generalizes beyond that one passage — a tell, "sounds AI", "too wordy" — propose the rule, and put the thread's feedback and the accepted change in the reason field.
+- The same pattern in the user's own edits or feedback more than once, including across comment threads and inline directives.
+
+A flagged tell alone is not yet a rule: fix the flagged instance with edit_doc, and propose the rule when the user accepts a fix for that feedback. A rejected edit is the opposite signal — do not propose a rule from feedback whose edit the user rejected.
+
+Write rules as short imperatives that are specific enough to check, e.g. "Never use em dashes". When unsure, do not propose.
 
 ## Style references
 


### PR DESCRIPTION
Three related changes that make the agent explain itself before and after edits, and tie rule suggestions to user consent. Touches on #5 and #18.

## 1. "AI smell" always runs plan-first

The pinned **"AI smell"** quick action now forces plan-first mode regardless of the Direct edit / Plan first mode chips (one line in `sendFeedback`, `src/lib/editor/TiptapEditor.svelte`). The agent replies on the feedback thread with *why* the passage reads as AI and what it intends to change, then proposes the edit on that thread. Other pinned actions and custom feedback still honor the chips.

## 2. Every edit proposal gets an announce thread

New "Announce edits on a thread" section in the system prompt (`src/routes/api/render/+server.ts`), plus a `comment_doc` description update (`src/lib/server/mcp-doc-tools.ts`):

- Work that already has a thread (all flag/feedback edits) reuses it — the agent replies first if it hasn't explained the edit there.
- All other edits — chat requests, inline `[[ … ]]` directives, rule applications — first call `comment_doc` anchored to the text about to change, with one or two first-person sentences (what prompted it, the diagnosis, the intended change), then `edit_doc` with the returned `thread_id`. Inline directives anchor the thread on the directive text itself.
- New-file `write_doc` is exempt; rewrites anchor to the first sentence being replaced.
- Announce threads work at every autonomy level; the Medium/High gate and one-comment-per-turn limit still apply to unprompted observation comments.

No new code paths: `comment_doc` already returns the thread id and `edit_doc` already accepts `thread_id`.

## 3. Rules are proposed on acceptance, from any channel

The "Proposing rules" prompt section is restructured around evidence strength:

- Explicit standing preferences ("never use X", "add a rule that Y") propose immediately, now from any channel: chat, comment thread replies, inline `[[ … ]]` directives.
- A flagged tell / "sounds AI" no longer yields a rule on its own (the heavy-handed behavior in #5). The agent fixes the flagged instance; when the user **accepts** that fix, it reasons over the thread and the accepted edit and proposes the rule with both cited as evidence. A rejected edit blocks a rule from that feedback.
- Repeated patterns across the user's edits, comment threads, and directives remain valid evidence.

Acceptance detection is prompt-only: the next turn's `workspace_state` diff shows the proposed text landing in the document, and the resumed provider session remembers what was proposed on which thread.

## Validation

`npm run check`: 0 errors, 0 warnings. Provider smoke tests: claude, openai, codex, cursor green on the announce-thread commit; pi (GLM-5.2) timed out on the directive test there and is being re-run to determine flake vs. real sensitivity of the weakest model to the two-step contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiWzQH3sbn1yw5DQ4FM8KH