### PR TITLE
Fix AskUserQuestion schema errors, silent auth failures, and comment-thread re-anchoring

### DIFF
--- a/src/lib/components/AgentModal.svelte
+++ b/src/lib/components/AgentModal.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/stores';
 
 	interface Props {
-		onAnswerQuestion: (id: string, answers: string[]) => void;
+		onAnswerQuestion: (id: string, answers: Record<string, string>) => void;
 		onRunPlan: (id: string) => void;
 		onDismissPlan: (id: string) => void;
 		onRejectPlan: (id: string, feedback: string) => void;
@@ -30,7 +30,12 @@
 	let activePlan = $derived(!activeQuestion ? (plans[0] ?? null) : null);
 	let visible = $derived(activeQuestion !== null || activePlan !== null);
 
-	let multiSelections = $state<Record<string, Set<string>>>({});
+	/** Per-question selections, keyed `${cardId}:${questionIdx}`. Single-select
+	 * questions hold a one-element set (radio behavior); multiSelect questions
+	 * hold any number. The card is only submitted once EVERY question has a
+	 * selection — a card with several questions must not vanish after the
+	 * first click. */
+	let selections = $state<Record<string, Set<string>>>({});
 
 	// "Reject with feedback" flow for plan cards. Null = footer shows the
 	// primary action buttons; non-null = textarea is open for this plan id.
@@ -71,34 +76,61 @@
 
 	function toggleMultiSelection(cardId: string, qIdx: number, label: string) {
 		const key = `${cardId}:${qIdx}`;
-		const current = multiSelections[key] ?? new Set<string>();
+		const current = selections[key] ?? new Set<string>();
 		const next = new Set(current);
 		if (next.has(label)) next.delete(label);
 		else next.add(label);
-		multiSelections = { ...multiSelections, [key]: next };
+		selections = { ...selections, [key]: next };
 	}
 
-	function isMultiSelected(cardId: string, qIdx: number, label: string): boolean {
-		return multiSelections[`${cardId}:${qIdx}`]?.has(label) ?? false;
+	function isSelected(cardId: string, qIdx: number, label: string): boolean {
+		return selections[`${cardId}:${qIdx}`]?.has(label) ?? false;
 	}
 
-	function submitMultiAnswer(card: PendingUserQuestion) {
-		const answers: string[] = [];
+	/** Build the record the SDK schema expects: question text → answer
+	 * (multi-select labels comma-joined, matching the SDK's documented
+	 * "multi-select answers are comma-separated" output shape). Option
+	 * order is preserved so the joined answer reads in display order. */
+	function buildAnswers(card: PendingUserQuestion): Record<string, string> | null {
+		const answers: Record<string, string> = {};
 		for (let i = 0; i < card.questions.length; i++) {
-			const sel = multiSelections[`${card.id}:${i}`];
-			if (sel && sel.size > 0) {
-				for (const label of sel) answers.push(label);
-			}
+			const q = card.questions[i];
+			const sel = selections[`${card.id}:${i}`];
+			if (!sel || sel.size === 0) return null;
+			const ordered = q.options.map((o) => o.label).filter((l) => sel.has(l));
+			answers[q.question] = ordered.join(', ');
 		}
-		if (answers.length === 0) return;
-		const next = { ...multiSelections };
+		return answers;
+	}
+
+	function allQuestionsAnswered(card: PendingUserQuestion): boolean {
+		return card.questions.every((_, i) => (selections[`${card.id}:${i}`]?.size ?? 0) > 0);
+	}
+
+	function clearCardSelections(card: PendingUserQuestion) {
+		const next = { ...selections };
 		for (let i = 0; i < card.questions.length; i++) delete next[`${card.id}:${i}`];
-		multiSelections = next;
+		selections = next;
+	}
+
+	function submitAnswers(card: PendingUserQuestion) {
+		const answers = buildAnswers(card);
+		if (!answers) return;
+		clearCardSelections(card);
 		onAnswerQuestion(card.id, answers);
 	}
 
-	function pickSingle(card: PendingUserQuestion, label: string) {
-		onAnswerQuestion(card.id, [label]);
+	/** Single-select click. A one-question card submits immediately (the
+	 * common quick-clarification case keeps its one-click feel); a card
+	 * with more questions records the choice radio-style and waits for
+	 * the Submit button so every question gets answered. */
+	function pickSingle(card: PendingUserQuestion, qIdx: number, label: string) {
+		if (card.questions.length === 1) {
+			clearCardSelections(card);
+			onAnswerQuestion(card.id, { [card.questions[0].question]: label });
+			return;
+		}
+		selections = { ...selections, [`${card.id}:${qIdx}`]: new Set([label]) };
 	}
 
 	// Render the plan as minimally-formatted markdown-ish HTML. Full
@@ -187,12 +219,12 @@
 									<!-- svelte-ignore a11y_no_static_element_interactions -->
 									<div
 										class="question-option multi"
-										class:selected={isMultiSelected(card.id, qIdx, opt.label)}
+										class:selected={isSelected(card.id, qIdx, opt.label)}
 										onclick={() => toggleMultiSelection(card.id, qIdx, opt.label)}
 									>
 										<div class="question-option-label">
 											<span class="question-checkbox">
-												{#if isMultiSelected(card.id, qIdx, opt.label)}
+												{#if isSelected(card.id, qIdx, opt.label)}
 													<Check size={10} />
 												{/if}
 											</span>
@@ -203,8 +235,21 @@
 										{/if}
 									</div>
 								{:else}
-									<button class="question-option single" onclick={() => pickSingle(card, opt.label)}>
-										<div class="question-option-label">{opt.label}</div>
+									<button
+										class="question-option single"
+										class:selected={isSelected(card.id, qIdx, opt.label)}
+										onclick={() => pickSingle(card, qIdx, opt.label)}
+									>
+										<div class="question-option-label">
+											{#if card.questions.length > 1}
+												<span class="question-radio">
+													{#if isSelected(card.id, qIdx, opt.label)}
+														<Check size={10} />
+													{/if}
+												</span>
+											{/if}
+											{opt.label}
+										</div>
 										{#if opt.description}
 											<div class="question-option-desc">{opt.description}</div>
 										{/if}
@@ -214,9 +259,17 @@
 						</div>
 					{/each}
 				</div>
-				{#if card.questions.some((q) => q.multiSelect)}
+				{#if card.questions.length > 1 || card.questions.some((q) => q.multiSelect)}
 					<div class="modal-footer">
-						<button class="btn-primary" onclick={() => submitMultiAnswer(card)}>
+						<span class="answer-progress">
+							{card.questions.filter((_, i) => (selections[`${card.id}:${i}`]?.size ?? 0) > 0).length}
+							/ {card.questions.length} answered
+						</span>
+						<button
+							class="btn-primary"
+							onclick={() => submitAnswers(card)}
+							disabled={!allQuestionsAnswered(card)}
+						>
 							<Check size={12} /> Submit
 						</button>
 					</div>
@@ -525,9 +578,35 @@
 		border-color: var(--accent-light);
 		background: var(--bg);
 	}
-	.question-option.multi.selected {
+	.question-option.multi.selected,
+	.question-option.single.selected {
 		border-color: var(--accent);
 		background: var(--accent-bg);
+	}
+	.question-radio {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		border: 1px solid var(--border-light);
+		background: var(--bg);
+		color: var(--accent);
+	}
+	.question-option.single.selected .question-radio {
+		background: var(--accent);
+		color: white;
+		border-color: var(--accent);
+	}
+	.answer-progress {
+		margin-right: auto;
+		font-size: 11px;
+		color: var(--text-faint);
+	}
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 	.question-option-label {
 		display: flex;

--- a/src/lib/components/ToastStack.svelte
+++ b/src/lib/components/ToastStack.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
-	import { Check, X, Sparkles, Terminal } from 'lucide-svelte';
+	import { Check, X, Sparkles, Terminal, AlertTriangle } from 'lucide-svelte';
 	import { toastQueue, type ToastSpec } from '$lib/toasts';
 
 	interface Props {
@@ -19,25 +19,33 @@
 {#if toasts.length > 0}
 	<div class="toast-stack" role="region" aria-label="Agent proposals">
 		{#each toasts as toast (toast.id)}
-			<div class="toast" transition:fly={{ x: 16, duration: 220, easing: cubicOut }}>
+			<div
+				class="toast"
+				class:toast-error={toast.kind === 'error'}
+				transition:fly={{ x: 16, duration: 220, easing: cubicOut }}
+			>
 				<div class="toast-header">
 					<span class="toast-avatar">
 						{#if toast.kind === 'rule'}
 							<Sparkles size={12} strokeWidth={1.9} />
+						{:else if toast.kind === 'error'}
+							<AlertTriangle size={12} strokeWidth={1.9} />
 						{:else}
 							<Terminal size={12} strokeWidth={1.9} />
 						{/if}
 					</span>
-					<span class="toast-kicker">Proposed {toast.kind}</span>
+					<span class="toast-kicker">{toast.kind === 'error' ? toast.title : `Proposed ${toast.kind}`}</span>
 				</div>
 				<div class="toast-body">{toast.body}</div>
 				<div class="toast-footer">
 					<button class="toast-btn dismiss" onclick={() => onDismiss(toast)}>
 						<X size={12} /> Dismiss
 					</button>
-					<button class="toast-btn accept" onclick={() => onAccept(toast)}>
-						<Check size={12} /> Accept
-					</button>
+					{#if toast.kind !== 'error'}
+						<button class="toast-btn accept" onclick={() => onAccept(toast)}>
+							<Check size={12} /> Accept
+						</button>
+					{/if}
 				</div>
 			</div>
 		{/each}
@@ -132,5 +140,15 @@
 	}
 	.toast-btn.accept:hover {
 		filter: brightness(1.05);
+	}
+	.toast-error {
+		border-color: color-mix(in srgb, #d5484f 45%, var(--border-light));
+	}
+	.toast-error .toast-avatar {
+		background: color-mix(in srgb, #d5484f 14%, transparent);
+		color: #d5484f;
+	}
+	.toast-error .toast-kicker {
+		color: #d5484f;
 	}
 </style>

--- a/src/lib/editor/comment-overlay.ts
+++ b/src/lib/editor/comment-overlay.ts
@@ -12,7 +12,12 @@ import {
 	absolutePositionToRelativePosition,
 	relativePositionToAbsolutePosition
 } from '$lib/editor-extensions';
-import { getCommentsMap, SYSTEM_ORIGIN } from '$lib/shared/ydoc-codec';
+import {
+	getCommentsMap,
+	SYSTEM_ORIGIN,
+	ANCHOR_CONTEXT_RADIUS,
+	captureAnchorContext
+} from '$lib/shared/ydoc-codec';
 import { buildCharIndex as cachedBuildCharIndex } from './char-index';
 import type { CommentThread } from '$lib/types';
 
@@ -148,10 +153,82 @@ function getYBinding(state: EditorState): {
 	return { doc: binding.doc, type: binding.type, mapping: binding.mapping };
 }
 
+/** How many characters of stored anchor context must still match for a
+ * quote fallback to re-attach a thread whose rel-position anchor died.
+ * (The context itself is captured via `captureAnchorContext`, radius
+ * `ANCHOR_CONTEXT_RADIUS`, shared with the server in ydoc-codec.) */
+const ANCHOR_CONTEXT_MIN_MATCH = 8;
+
+/** Contexts are compared in the editor's paragraph-concatenated plain-text
+ * space (no separators), while server-captured contexts come from the
+ * newline-joined serialization — strip newlines so both agree. */
+function normalizeAnchorContext(s: string): string {
+	return s.replace(/\n/g, '');
+}
+
+function commonSuffixLen(a: string, b: string): number {
+	let n = 0;
+	while (n < a.length && n < b.length && a[a.length - 1 - n] === b[b.length - 1 - n]) n += 1;
+	return n;
+}
+
+function commonPrefixLen(a: string, b: string): number {
+	let n = 0;
+	while (n < a.length && n < b.length && a[n] === b[n]) n += 1;
+	return n;
+}
+
+/** Among all occurrences of `quote`, pick the one whose surroundings best
+ * match the anchor's stored context; -1 when none matches well enough.
+ * `preferredIdx` breaks score ties (the plain occurrenceIndex match). */
+function findContextMatch(
+	plainText: string,
+	quote: string,
+	contextBefore: string,
+	contextAfter: string,
+	preferredIdx: number
+): number {
+	const storedBefore = normalizeAnchorContext(contextBefore);
+	const storedAfter = normalizeAnchorContext(contextAfter);
+	// The bar adapts to how much context exists: a quote at the very start
+	// of a short document may have less than ANCHOR_CONTEXT_MIN_MATCH chars
+	// of context in total, and that's fine.
+	const required = Math.min(ANCHOR_CONTEXT_MIN_MATCH, storedBefore.length + storedAfter.length);
+	let bestIdx = -1;
+	let bestScore = -1;
+	let scan = 0;
+	while ((scan = plainText.indexOf(quote, scan)) !== -1) {
+		const actualBefore = normalizeAnchorContext(
+			plainText.slice(Math.max(0, scan - ANCHOR_CONTEXT_RADIUS), scan)
+		);
+		const actualAfter = normalizeAnchorContext(
+			plainText.slice(scan + quote.length, scan + quote.length + ANCHOR_CONTEXT_RADIUS)
+		);
+		const score =
+			commonSuffixLen(storedBefore, actualBefore) + commonPrefixLen(storedAfter, actualAfter);
+		if (score >= required && (score > bestScore || (score === bestScore && scan === preferredIdx))) {
+			bestScore = score;
+			bestIdx = scan;
+		}
+		scan += quote.length;
+	}
+	return bestIdx;
+}
+
 /** Resolve a thread's anchor to PM positions. Tries rel positions first
  * (live, CRDT-tracked); falls back to indexOf when rel positions are
  * missing or no longer resolvable. Returns null when neither finds a
- * range — the thread is detached. */
+ * range — the thread is detached.
+ *
+ * The quote fallback is context-aware: when the anchor stores the text
+ * that surrounded the passage (captured at creation or backfilled while
+ * the anchor was alive), a fallback match must ALSO match that context.
+ * Without this, a thread whose passage was deleted (e.g. the user
+ * accepted an agent edit replacing it) re-attached to ANY occurrence of
+ * the same string typed anywhere later — feedback left on "ABC" and long
+ * dealt with popped back up as soon as "ABC" was typed elsewhere (a real
+ * shipped bug). Undo still re-attaches: restored text brings its
+ * original surroundings back, so the context matches. */
 function resolveAnchorPMRange(
 	state: EditorState,
 	thread: CommentThread
@@ -182,7 +259,7 @@ function resolveAnchorPMRange(
 		}
 	}
 
-	// Tier 2: indexOf fallback.
+	// Tier 2: indexOf fallback, context-checked when context is stored.
 	const { charPositions, plainText } = buildCharIndex(state.doc);
 	let quote = anchor.quote;
 	let idx = nthIndexOf(plainText, quote, anchor.occurrenceIndex);
@@ -193,14 +270,27 @@ function resolveAnchorPMRange(
 	// Fall back to the first non-empty line, which matches reliably and is
 	// enough to position the card. Without this, a multi-line edit's thread
 	// card silently disappears even though its diff renders.
+	let usedFirstLineFallback = false;
 	if (idx < 0 && quote.includes('\n')) {
 		const firstLine = quote.split('\n').find((l) => l.trim()) ?? '';
 		if (firstLine) {
 			quote = firstLine;
 			idx = nthIndexOf(plainText, quote, 0);
+			usedFirstLineFallback = true;
 		}
 	}
 	if (idx < 0) return null;
+	const hasContext = !!(anchor.contextBefore || anchor.contextAfter);
+	if (hasContext && !usedFirstLineFallback) {
+		idx = findContextMatch(
+			plainText,
+			quote,
+			anchor.contextBefore ?? '',
+			anchor.contextAfter ?? '',
+			idx
+		);
+		if (idx < 0) return null;
+	}
 	const endOffset = idx + quote.length - 1;
 	if (endOffset >= charPositions.length) return null;
 	const from = charPositions[idx];
@@ -314,14 +404,16 @@ export const CommentOverlay = Extension.create({
 					}
 				},
 				view(editorView) {
-					// Backfill rel positions for any thread that doesn't have them
-					// yet (server-created or pre-rel-position legacy). Runs after
-					// every state update; cheap because the filter exits early
-					// once every thread has rel positions. Threads in the local
-					// `attempted` set are skipped to avoid re-attempting in the
-					// (rare) case `absolutePositionToRelativePosition` returns a
-					// position that re-resolves to a different range — the loop
-					// would otherwise repeatedly write back.
+					// Backfill anchor metadata for any thread that is missing it:
+					// rel positions (server-created or pre-rel-position legacy
+					// threads) and the surrounding-text context that the quote
+					// fallback validates against. Runs after every state update;
+					// cheap because the filter exits early once every thread is
+					// fully stamped. Threads in the local `attempted` set are
+					// skipped to avoid re-attempting in the (rare) case
+					// `absolutePositionToRelativePosition` returns a position that
+					// re-resolves to a different range — the loop would otherwise
+					// repeatedly write back.
 					const attempted = new Set<string>();
 					const tryBackfill = () => {
 						const binding = getYBinding(editorView.state);
@@ -330,7 +422,10 @@ export const CommentOverlay = Extension.create({
 						const candidates = pluginState.threads.filter(
 							(t) =>
 								!t.resolved &&
-								(!t.anchor.relStart || !t.anchor.relEnd) &&
+								(!t.anchor.relStart ||
+									!t.anchor.relEnd ||
+									(t.anchor.contextBefore === undefined &&
+										t.anchor.contextAfter === undefined)) &&
 								!attempted.has(t.id)
 						);
 						if (candidates.length === 0) return;
@@ -339,10 +434,28 @@ export const CommentOverlay = Extension.create({
 						const updates: { id: string; thread: CommentThread }[] = [];
 						for (const thread of candidates) {
 							attempted.add(thread.id);
-							const idx = nthIndexOf(plainText, thread.anchor.quote, thread.anchor.occurrenceIndex);
-							const resolvedIdx = idx >= 0 ? idx : nthIndexOf(plainText, thread.anchor.quote, 0);
+							// Prefer the LIVE rel-position range when present — it is
+							// the authoritative anchor location (an exact selection may
+							// not be the occurrenceIndex-th quote match). Fall back to
+							// the quote lookup for threads without rel positions.
+							let resolvedIdx = -1;
+							let quoteLen = thread.anchor.quote.length;
+							const live = resolveAnchorPMRange(editorView.state, thread);
+							if (live && thread.anchor.relStart && thread.anchor.relEnd) {
+								const startIdx = charPositions.indexOf(live.from);
+								const endIdx = charPositions.indexOf(live.to - 1);
+								if (startIdx >= 0 && endIdx >= startIdx) {
+									resolvedIdx = startIdx;
+									quoteLen = endIdx - startIdx + 1;
+								}
+							}
+							if (resolvedIdx < 0) {
+								const idx = nthIndexOf(plainText, thread.anchor.quote, thread.anchor.occurrenceIndex);
+								resolvedIdx = idx >= 0 ? idx : nthIndexOf(plainText, thread.anchor.quote, 0);
+								quoteLen = thread.anchor.quote.length;
+							}
 							if (resolvedIdx < 0) continue;
-							const endOffset = resolvedIdx + thread.anchor.quote.length - 1;
+							const endOffset = resolvedIdx + quoteLen - 1;
 							if (endOffset >= charPositions.length) continue;
 							const fromPM = charPositions[resolvedIdx];
 							const toPM = charPositions[endOffset] + 1;
@@ -360,12 +473,18 @@ export const CommentOverlay = Extension.create({
 							} catch {
 								continue;
 							}
+							const context =
+								thread.anchor.contextBefore === undefined &&
+								thread.anchor.contextAfter === undefined
+									? captureAnchorContext(plainText, resolvedIdx, quoteLen)
+									: {};
 							const updated: CommentThread = {
 								...thread,
 								anchor: {
 									...thread.anchor,
-									relStart: encodeRelPos(relStart),
-									relEnd: encodeRelPos(relEnd)
+									relStart: thread.anchor.relStart ?? encodeRelPos(relStart),
+									relEnd: thread.anchor.relEnd ?? encodeRelPos(relEnd),
+									...context
 								}
 							};
 							updates.push({ id: thread.id, thread: updated });

--- a/src/lib/server/ask-user-state.ts
+++ b/src/lib/server/ask-user-state.ts
@@ -7,13 +7,20 @@
  * `resolvePendingAskUser` when the user picks answers, which unblocks
  * the render loop with the user's selections.
  *
+ * Answers are a record keyed by question text (multi-select answers
+ * comma-joined) because that is the shape the SDK's AskUserQuestion
+ * input schema requires for `updatedInput.answers` — passing an array
+ * fails schema validation and the tool call errors out.
+ *
  * This lives in a shared module (not inside a `+server.ts`) because
  * SvelteKit restricts `+server.ts` exports to HTTP methods — sharing
  * state across routes needs a plain lib module.
  */
 
+export type AskUserAnswers = Record<string, string>;
+
 interface PendingAskUser {
-	resolve: (answers: string[]) => void;
+	resolve: (answers: AskUserAnswers) => void;
 	timer: ReturnType<typeof setTimeout>;
 }
 
@@ -22,12 +29,12 @@ const pending = new Map<string, PendingAskUser>();
 /** Park a resolver, return the timer so callers can cancel on abort. */
 export function registerPendingAskUser(
 	id: string,
-	resolve: (answers: string[]) => void,
+	resolve: (answers: AskUserAnswers) => void,
 	timeoutMs: number
 ): ReturnType<typeof setTimeout> {
 	const timer = setTimeout(() => {
 		pending.delete(id);
-		resolve([]);
+		resolve({});
 	}, timeoutMs);
 	pending.set(id, { resolve, timer });
 	return timer;
@@ -35,7 +42,7 @@ export function registerPendingAskUser(
 
 /** Resolve the pending promise with the user's answers. Returns false
  * if the id wasn't found (timed out or already answered). */
-export function resolvePendingAskUser(id: string, answers: string[]): boolean {
+export function resolvePendingAskUser(id: string, answers: AskUserAnswers): boolean {
 	const p = pending.get(id);
 	if (!p) return false;
 	clearTimeout(p.timer);

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -29,7 +29,8 @@ import {
 	readReviewRounds,
 	getCommentsMap,
 	AGENT_ORIGIN,
-	normalizeTypography
+	normalizeTypography,
+	captureAnchorContext
 } from '$lib/shared/ydoc-codec';
 import { isScratchPath, resolveTabFromPath, isOpenTab } from './path-router';
 import { classifyRoundKind } from '$lib/review-diff';
@@ -254,7 +255,7 @@ export async function runTabWrite(
 						const occIdx = computeAnchorOccurrenceIndex(
 							baseForRound, anchorQuote, fullOldStr
 						);
-						threadId = createAgentEditThread(doc, anchorQuote, occIdx);
+						threadId = createAgentEditThread(doc, anchorQuote, occIdx, baseForRound);
 					}
 				}
 				const round: PendingReviewRound = {
@@ -338,12 +339,25 @@ function computeAnchorOccurrenceIndex(
 	}
 }
 
-function createAgentEditThread(doc: Y.Doc, oldString: string, occurrenceIndex: number): string {
+function createAgentEditThread(
+	doc: Y.Doc,
+	oldString: string,
+	occurrenceIndex: number,
+	docText: string
+): string {
 	const threadId = 'thread_' + cryptoRandomId();
 	const now = Date.now();
+	const anchorIdx = nthOccurrenceIndex(docText, oldString, occurrenceIndex);
 	const thread: CommentThread = {
 		id: threadId,
-		anchor: { quote: oldString, occurrenceIndex },
+		anchor: {
+			quote: oldString,
+			occurrenceIndex,
+			// Snapshot the surroundings so the client's quote fallback can
+			// tell "this text came back" (undo) apart from "the same string
+			// was typed somewhere else" once the passage is deleted.
+			...(anchorIdx >= 0 ? captureAnchorContext(docText, anchorIdx, oldString.length) : {})
+		},
 		messages: [
 			{
 				id: 'msg_' + cryptoRandomId(),
@@ -357,6 +371,20 @@ function createAgentEditThread(doc: Y.Doc, oldString: string, occurrenceIndex: n
 	};
 	getCommentsMap(doc).set(threadId, thread);
 	return threadId;
+}
+
+/** Character index of the `occurrenceIndex`-th occurrence of `needle` in
+ * `haystack`, or -1 when there are fewer occurrences. */
+function nthOccurrenceIndex(haystack: string, needle: string, occurrenceIndex: number): number {
+	if (!needle) return -1;
+	let idx = 0;
+	let found = 0;
+	while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+		if (found === occurrenceIndex) return idx;
+		found += 1;
+		idx += needle.length;
+	}
+	return -1;
 }
 
 // ---- Auto-open-as-tab -----------------------------------------------------
@@ -783,9 +811,15 @@ function createAgentCommentThread(
 ): string {
 	const threadId = 'thread_' + cryptoRandomId();
 	const now = Date.now();
+	const liveText = serializeYDoc(doc);
+	const anchorIdx = nthOccurrenceIndex(liveText, anchorText, occurrenceIndex);
 	const thread: CommentThread = {
 		id: threadId,
-		anchor: { quote: anchorText, occurrenceIndex },
+		anchor: {
+			quote: anchorText,
+			occurrenceIndex,
+			...(anchorIdx >= 0 ? captureAnchorContext(liveText, anchorIdx, anchorText.length) : {})
+		},
 		messages: [
 			{
 				id: 'msg_' + cryptoRandomId(),

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -237,6 +237,19 @@ export class ClaudeProvider implements AgentProvider {
 					usage: anyMsg.usage,
 					subtype: anyMsg.subtype
 				};
+				// Surface failed runs. The CLI does not always exit non-zero
+				// after an error result (in which case query() never throws),
+				// so without this the render ends looking successful and the
+				// failure — e.g. an expired-OAuth 401 — is completely silent.
+				if (anyMsg.is_error || (anyMsg.subtype && anyMsg.subtype !== 'success')) {
+					const detail =
+						(anyMsg.subtype === 'success'
+							? anyMsg.result
+							: Array.isArray(anyMsg.errors) && anyMsg.errors.length > 0
+								? anyMsg.errors.map((e: unknown) => String(e)).join('\n')
+								: anyMsg.result) || `run failed (${anyMsg.subtype ?? 'unknown error'})`;
+					yield { type: 'error', error: String(detail) };
+				}
 			}
 
 			if (msg.type === 'user') {

--- a/src/lib/server/providers/types.ts
+++ b/src/lib/server/providers/types.ts
@@ -50,7 +50,12 @@ export type ProviderEvent =
 	| { type: 'hook_proposal'; event: string; matcher?: string; command: string; reason?: string }
 	| { type: 'plan_proposed'; id: string; plan: string; originalMessage: string }
 	| { type: 'user_question'; id: string; questions: unknown[] }
-	| { type: 'hook_run'; hookId: string; event: string; command: string; status: string; exitCode?: number; stdout?: string; stderr?: string; durationMs?: number };
+	| { type: 'hook_run'; hookId: string; event: string; command: string; status: string; exitCode?: number; stdout?: string; stderr?: string; durationMs?: number }
+	/** A run that finished with an error result. Providers MUST yield this for
+	 * failed runs even when their SDK doesn't throw (e.g. the Claude CLI can
+	 * exit 0 after an error result) — otherwise the failure is invisible to
+	 * the user. */
+	| { type: 'error'; error: string };
 
 // ── canUseTool callback ─────────────────────────────────────────────────────
 

--- a/src/lib/shared/ydoc-codec.ts
+++ b/src/lib/shared/ydoc-codec.ts
@@ -61,6 +61,30 @@ export const AI_ATTR = 'ai';
 /** One contiguous span of paragraph text with a single provenance flag. */
 export type ProvenanceRun = { text: string; ai: boolean };
 
+/** How much surrounding plain text (each side) a comment-thread anchor
+ * snapshots as its context. Shared by the server (captures at thread
+ * creation from the newline-joined serialization) and the client (captures
+ * via backfill from the editor's paragraph-concatenated plain text, and
+ * validates fallback re-attachment against it). Newlines are stripped so
+ * both text spaces agree. */
+export const ANCHOR_CONTEXT_RADIUS = 32;
+
+/** Capture the anchor context around [idx, idx + quoteLen) in `text`. */
+export function captureAnchorContext(
+	text: string,
+	idx: number,
+	quoteLen: number
+): { contextBefore: string; contextAfter: string } {
+	return {
+		contextBefore: text
+			.slice(Math.max(0, idx - ANCHOR_CONTEXT_RADIUS), idx)
+			.replace(/\n/g, ''),
+		contextAfter: text
+			.slice(idx + quoteLen, idx + quoteLen + ANCHOR_CONTEXT_RADIUS)
+			.replace(/\n/g, '')
+	};
+}
+
 export function getFragment(ydoc: Y.Doc): Y.XmlFragment {
 	return ydoc.getXmlFragment(FRAGMENT_NAME);
 }

--- a/src/lib/toasts.ts
+++ b/src/lib/toasts.ts
@@ -15,7 +15,11 @@ import { writable } from 'svelte/store';
 
 export interface ToastSpec {
 	id: string;
-	kind: 'rule' | 'hook';
+	/** 'rule' / 'hook' are agent proposals (Accept / Dismiss); 'error' is a
+	 * dismiss-only notification for failed agent runs — errors used to be
+	 * visible only inside the collapsed history pane, i.e. effectively
+	 * silent. */
+	kind: 'rule' | 'hook' | 'error';
 	title: string;
 	body: string;
 	/** The ProposedRule / ProposedHook id this toast represents. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -166,6 +166,19 @@ interface CommentThreadAnchor {
 	 * When absent, the overlay falls back to indexOf-based anchoring. */
 	relStart?: string;
 	relEnd?: string;
+	/** Plain-text snapshot of what surrounded the anchored passage when the
+	 * anchor was (last) known to be alive — up to ~32 chars each side,
+	 * newlines stripped. Used by the overlay's quote fallback: when the rel
+	 * positions die (the anchored text was deleted, e.g. by accepting an
+	 * agent edit), the thread may only re-attach to an occurrence of the
+	 * quote whose surroundings match this context. That keeps undo working
+	 * (restored text brings back the same context) while preventing the
+	 * thread from resurrecting on an unrelated occurrence of the same
+	 * string typed elsewhere later. Optional: captured server-side at
+	 * creation when the occurrence is unambiguous, and backfilled by the
+	 * client whenever the thread renders anchored. */
+	contextBefore?: string;
+	contextAfter?: string;
 }
 
 type CommentAuthor = 'user' | 'agent';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1426,10 +1426,25 @@
 						});
 					} else if (event === 'error') {
 						success = false;
+						const errText = String(parsed.error ?? 'Unknown error');
 						pushHistory({
 							type: 'assistant_text',
 							timestamp: Date.now(),
-							text: `Error: ${parsed.error}`
+							text: `Error: ${errText}`
+						});
+						// Errors buried in the collapsed history pane are
+						// effectively silent — surface a sticky toast too. Keyed
+						// by renderStart so repeat errors from one render (e.g.
+						// an error result followed by the SDK throwing on exit)
+						// collapse into a single toast.
+						const isAuthError = /auth|401|oauth|credential|api key/i.test(errText);
+						pushToast({
+							kind: 'error',
+							title: isAuthError ? 'Agent auth failed' : 'Agent run failed',
+							body: isAuthError
+								? `${errText}\n\nRe-authenticate your provider (e.g. run \`claude\` in a terminal and /login), then try again.`
+								: errText,
+							refId: String(renderStart)
 						});
 					}
 				}
@@ -1865,8 +1880,10 @@
 
 	/** Send the user's selections for an AskUserQuestion card back to the
 	 * server, which resolves the SDK's paused tool call and lets the
-	 * agent continue with the answers in context. */
-	async function answerUserQuestion(id: string, answers: string[]) {
+	 * agent continue with the answers in context. `answers` is keyed by
+	 * question text (multi-select labels comma-joined) — the shape the
+	 * SDK's AskUserQuestion input schema requires. */
+	async function answerUserQuestion(id: string, answers: Record<string, string>) {
 		pendingUserQuestions.update((list) => list.filter((q) => q.id !== id));
 		try {
 			await fetch('/api/ask-user-reply', {
@@ -1880,7 +1897,7 @@
 		pushHistory({
 			type: 'user_action',
 			timestamp: Date.now(),
-			description: `Answered: ${answers.join(', ')}`
+			description: `Answered: ${Object.values(answers).join(' · ')}`
 		});
 	}
 
@@ -3065,8 +3082,15 @@
 {/if}
 
 <ToastStack
-	onAccept={(t) => (t.kind === 'rule' ? acceptProposedRule(t.refId) : acceptProposedHook(t.refId))}
-	onDismiss={(t) => (t.kind === 'rule' ? rejectProposedRule(t.refId) : rejectProposedHook(t.refId))}
+	onAccept={(t) => {
+		if (t.kind === 'rule') acceptProposedRule(t.refId);
+		else if (t.kind === 'hook') acceptProposedHook(t.refId);
+	}}
+	onDismiss={(t) => {
+		if (t.kind === 'rule') rejectProposedRule(t.refId);
+		else if (t.kind === 'hook') rejectProposedHook(t.refId);
+		else dismissToast(t.id);
+	}}
 />
 
 <Dialog />

--- a/src/routes/api/ask-user-reply/+server.ts
+++ b/src/routes/api/ask-user-reply/+server.ts
@@ -1,18 +1,25 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { resolvePendingAskUser } from '$lib/server/ask-user-state';
+import { resolvePendingAskUser, type AskUserAnswers } from '$lib/server/ask-user-state';
 
 /**
  * POST /api/ask-user-reply
- *   body: { id: string, answers: string[] }
+ *   body: { id: string, answers: Record<string, string> }
  *
  * The client calls this when the user answers an AskUserQuestion card.
- * Resolves the pending promise held by canUseTool in /api/render so the
- * SDK's paused tool call can complete with the user's selections. */
+ * `answers` is keyed by question text (multi-select labels comma-joined)
+ * — the exact shape the SDK's AskUserQuestion schema expects. Resolves
+ * the pending promise held by canUseTool in /api/render so the SDK's
+ * paused tool call can complete with the user's selections. */
 export const POST: RequestHandler = async ({ request }) => {
 	const body = await request.json();
 	const id = typeof body.id === 'string' ? body.id : '';
-	const answers = Array.isArray(body.answers) ? body.answers.map((a: unknown) => String(a)) : [];
+	const answers: AskUserAnswers = {};
+	if (body.answers && typeof body.answers === 'object' && !Array.isArray(body.answers)) {
+		for (const [question, answer] of Object.entries(body.answers as Record<string, unknown>)) {
+			answers[question] = String(answer);
+		}
+	}
 	if (!id) throw error(400, 'id required');
 	const ok = resolvePendingAskUser(id, answers);
 	if (!ok) throw error(404, `Question ${id} not pending (timed out or already answered)`);

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -6,6 +6,7 @@ import type { Document } from '@hocuspocus/server';
 import {
 	getCommentsMap,
 	serializeYDoc,
+	captureAnchorContext,
 	USER_ORIGIN
 } from '$lib/shared/ydoc-codec';
 import { isValidTabId } from '$lib/server/document-files';
@@ -100,12 +101,20 @@ export const POST: RequestHandler = async ({ request }) => {
 				text: messageText,
 				timestamp: now
 			});
+			// Snapshot the anchor's surroundings when the occurrence is
+			// unambiguous, so the client's quote fallback can refuse to
+			// re-attach to an unrelated occurrence typed later. With multiple
+			// occurrences the client backfill stamps context from the actual
+			// resolved range instead.
+			const anchorIdx =
+				countOccurrences(liveText, anchorText) === 1 ? liveText.indexOf(anchorText) : -1;
 			const thread: CommentThread = {
 				id: threadId,
 				anchor: {
 					quote: anchorText,
 					occurrenceIndex: 0,
-					...(relStart && relEnd ? { relStart, relEnd } : {})
+					...(relStart && relEnd ? { relStart, relEnd } : {}),
+					...(anchorIdx >= 0 ? captureAnchorContext(liveText, anchorIdx, anchorText.length) : {})
 				},
 				messages,
 				resolved: false,

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -883,7 +883,11 @@ export const POST: RequestHandler = async ({ request }) => {
 							const id = 'q_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 							const questions = toolInput?.questions ?? [];
 							send('user_question', { id, questions });
-							const answers = await new Promise<string[]>((resolve) => {
+							// The SDK's AskUserQuestion schema requires `answers` to be a
+							// record keyed by question text (multi-select answers
+							// comma-joined). An array here fails schema validation and the
+							// tool call errors out for every question the agent asks.
+							const answers = await new Promise<Record<string, string>>((resolve) => {
 								registerPendingAskUser(id, resolve, 15 * 60_000);
 							});
 							return { behavior: 'allow' as const, updatedInput: { ...toolInput, answers } };


### PR DESCRIPTION
Three user-reported bugs, each reproduced before fixing:

1. AskUserQuestion always failed with 'answers type is expected as record
   but provided as array'. canUseTool returned updatedInput.answers as a
   string[], but the SDK schema requires a record keyed by question text
   (multi-select labels comma-joined). The answer pipeline (AgentModal →
   /api/ask-user-reply → ask-user-state → canUseTool) now carries that
   record. The modal also no longer submits and vanishes on the first
   click of a multi-question card: selections are tracked per question
   (radio for single-select, checkboxes for multiSelect) and a Submit
   button gates until every question is answered; a one-question
   single-select card keeps its one-click behavior.

2. Failed agent runs were near-invisible: the Claude provider dropped
   is_error/result text from result messages (a CLI that exits 0 after an
   error result surfaced NOTHING), and errors that did surface only
   landed as rows inside the collapsed history pane. The provider now
   yields an explicit error event for error results, and the client
   surfaces every render error as a sticky dismissable toast — with
   re-authentication guidance when the message looks auth-related (401 /
   OAuth expiry, which the CLI retries for ~2 minutes before reporting).

3. Inline feedback anchored to text (say 'ABC') popped back up when the
   same text was typed elsewhere after the original passage was handled:
   once a thread's Yjs rel-positions died (e.g. accepting the agent's
   edit deleted the passage), the overlay's quote fallback re-attached
   the still-open thread to ANY occurrence of the quote. Anchors now
   snapshot the surrounding text (captured at creation server-side and
   backfilled client-side while the anchor is alive), and a fallback
   match must also match that context. Undo still re-attaches (restored
   text restores its context); unrelated occurrences typed elsewhere no
   longer resurrect the thread.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D9yk4Z9yotQXNmJGEW46FE