### PR TITLE
Keyboard-selection feedback focus, plain-writing prompt wording, and user docs for the July features

### DIFF
--- a/docs/agent/comments.mdx
+++ b/docs/agent/comments.mdx
@@ -43,9 +43,23 @@ reject like any other edit.
 collapse out of the way but stay in the database; you can reopen
 them later.
 
+## When the anchored text changes
+
+A thread follows its passage through edits. Typing inside the passage
+grows the highlight, and edits elsewhere leave it in place.
+
+When the passage itself is removed, e.g. you accepted an agent edit
+that rewrote it, the thread's card disappears from the margin. The
+thread is not deleted. Undo restores the passage and the card together.
+
+A hidden card stays hidden when you later type the same words
+somewhere else in the document. The thread belongs to the passage it
+was anchored to, not to every occurrence of the same string, so
+feedback you already handled does not resurface on unrelated text.
+
 ## When you'd cause a comment instead of an edit
 
-There are two ways an agent comment gets created:
+There are three ways a comment thread gets created:
 
 1. **The agent decides.** During an auto-wake or chat-popover turn,
    the agent reads the open files and chooses to comment when its
@@ -53,12 +67,15 @@ There are two ways an agent comment gets created:
    maybe, an observation that needs your input. The autonomy level
    biases this choice (conservative is more comment-happy;
    aggressive prefers to just make the edit).
-2. **You force it.** When you give [inline
-   feedback](/agent/steering-the-agent#inline-feedback) on a passage,
-   the popup has three mode chips: **Auto** (the agent decides),
-   **Edit** (force an edit), **Discuss** (force a comment thread).
-   Pick Discuss when you want the agent to weigh in without
-   committing to a rewrite.
+2. **You give feedback on a passage.** Feedback you send from
+   [the feedback popup](/agent/feedback-popup) opens a thread anchored
+   to the selected passage, and the agent responds on that thread.
+   With **Plan first** on, the agent replies with its reasoning there
+   before it proposes the edit.
+3. **The agent announces an edit.** Every edit proposal comes with a
+   thread that explains what the agent is about to change and why, so
+   a pending edit never appears as a bare diff. The explanation sits
+   next to the edit in the margin.
 
 ## When to reply vs. when to approve
 

--- a/docs/agent/comments.mdx
+++ b/docs/agent/comments.mdx
@@ -45,21 +45,21 @@ them later.
 
 ## When the anchored text changes
 
-A thread follows its passage through edits. Typing inside the passage
-grows the highlight, and edits elsewhere leave it in place.
+You can edit a passage without losing its comment thread. When you type
+inside the passage, you see the highlighted range expand. The highlighted
+range is unchanged when you edit text elsewhere.
 
-When the passage itself is removed, e.g. you accepted an agent edit
-that rewrote it, the thread's card disappears from the margin. The
-thread is not deleted. Undo restores the passage and the card together.
+When you remove the passage, e.g. by accepting an agent edit that rewrites
+it, you no longer see the thread card in the margin. The thread is still
+saved. If you undo the edit, you see the passage and the card again.
 
-A hidden card stays hidden when you later type the same words
-somewhere else in the document. The thread belongs to the passage it
-was anchored to, not to every occurrence of the same string, so
-feedback you already handled does not resurface on unrelated text.
+If you later type the same words elsewhere, the hidden card is not shown
+again. A thread is attached to one passage rather than to every copy of
+the same text, so you do not see old feedback on unrelated text.
 
 ## When you'd cause a comment instead of an edit
 
-There are three ways a comment thread gets created:
+A comment thread is created when:
 
 1. **The agent decides.** During an auto-wake or chat-popover turn,
    the agent reads the open files and chooses to comment when its
@@ -67,15 +67,14 @@ There are three ways a comment thread gets created:
    maybe, an observation that needs your input. The autonomy level
    biases this choice (conservative is more comment-happy;
    aggressive prefers to just make the edit).
-2. **You give feedback on a passage.** Feedback you send from
-   [the feedback popup](/agent/feedback-popup) opens a thread anchored
-   to the selected passage, and the agent responds on that thread.
-   With **Plan first** on, the agent replies with its reasoning there
-   before it proposes the edit.
-3. **The agent announces an edit.** Every edit proposal comes with a
-   thread that explains what the agent is about to change and why, so
-   a pending edit never appears as a bare diff. The explanation sits
-   next to the edit in the margin.
+2. **You give feedback on a passage.** When you use
+   [the feedback popup](/agent/feedback-popup), you start a thread on
+   the selected passage. The agent responds on the thread. With
+   **Plan first** on, the agent explains its reasoning before it proposes
+   an edit.
+3. **The agent proposes an edit.** Before the agent proposes an edit,
+   it starts a thread. The agent explains what it will change, and you
+   can read the explanation next to the edit in the margin.
 
 ## When to reply vs. when to approve
 

--- a/docs/agent/feedback-popup.mdx
+++ b/docs/agent/feedback-popup.mdx
@@ -1,91 +1,83 @@
 ---
 title: "The feedback popup"
-description: "Give the agent feedback on a selected passage, choose how it responds, and control the popup from the keyboard."
+description: "Give the agent feedback on a selected passage and choose how it responds. You can also use the popup with the keyboard."
 ---
 
-Select any passage in the editor and a feedback popup appears anchored
-to the selection. The popup is how you tell the agent what is wrong
-with a specific piece of text, and every action you can take on a
-selection is in it.
+When you select a passage in the editor, you see a feedback popup next
+to the selected text. Use the popup to tell the agent what is wrong or
+choose another action for the selected text.
 
 <Frame>
   ![The inline feedback popup, with text input, mode chips, and quick-action pills](/images/inline-feedback-popup.png)
 </Frame>
 
-The popup opens with its input focused, so you can type your feedback
-right away. Focus moves when the selection gesture ends. For a mouse
-selection that is when you release the button, and for a keyboard
-selection that is when you release the modifier key, e.g. releasing
-Shift after extending a selection with the arrow keys. Both kinds of
-selection behave the same, so the habit is the same everywhere. If you
-selected text because you want to edit it yourself, press Esc and keep
-typing.
+You can type as soon as you finish selecting text, because the input is
+already focused. With a mouse, finish the selection by releasing the
+button. With a keyboard, release the modifier key, e.g. release Shift
+after extending a selection with the arrow keys. If you selected text
+because you want to edit it yourself, press Esc and keep typing.
 
 ## Sending feedback
 
 Type what is wrong and press Enter, or click **Go**. The agent
-receives the selected passage and your feedback, opens a comment
-thread anchored to the passage, and responds on that thread in the
-next turn. Whatever you type also becomes a quick-action pill for
-later, as described below.
+receives the selected passage and your feedback, then starts a comment
+thread on the passage. The agent responds on that thread in the next
+turn. Your message is then available as a quick action for later use.
 
 ## Direct edit and plan first
 
 You choose how the agent responds with the two chips under the input.
 
 - **Direct edit.** The agent proposes its edit right away. The edit
-  appears as a pending review on the thread, and you accept or reject
-  it as usual.
-- **Plan first.** The agent first replies on the thread and explains
-  what it thinks is wrong and what it intends to change, and only then
-  proposes the edit on the same thread. The explanation sits in the
-  margin next to the pending edit, so you can read the reasoning
-  before you decide.
+  is shown as a pending review on the thread, where you can accept or
+  reject it.
+- **Plan first.** The agent first explains the problem and its planned
+  change. It then proposes an edit on the same
+  thread, so you can read the explanation before you decide.
 
-Direct edit is the default. The choice applies to the feedback you are
-about to send, and the popup returns to Direct edit the next time it
-opens.
+Direct edit is selected by default. Your selection is used for the
+current feedback only. When you select another passage, Direct edit is
+selected again.
 
 ## Quick actions
 
-The pills under the mode chips send the passage with a preset
-label, so common feedback takes one click.
+Use the quick actions under the mode choices when you want to send
+common feedback with one click.
 
-- **Too verbose** and **Incorrect** send the passage with that label
-  in the mode the chips show.
-- **AI smell** always runs plan first, whatever the chips show. The
-  agent explains on the thread why the passage reads as
-  machine-written before it proposes a fix.
+- **Too verbose** and **Incorrect** give the agent the selected passage
+  and the label you clicked. The agent follows the mode you chose.
+- **AI smell** always asks the agent to explain its reasoning first. The
+  agent explains why it thinks a machine wrote the passage. After the
+  explanation, it proposes a fix.
 
-The remaining pills are your own recent feedback messages. The popup
-keeps up to six of them, most recent first, and anything you type as
-custom feedback joins the list.
+Your six most recent feedback messages are also available as quick
+actions, with the newest message first. When you enter a new message,
+it is added to the list.
 
 ## Freeze for agent
 
-The **Freeze for agent** chip marks the selection as off-limits, so
-the agent cannot edit it until you unlock it. Freezing is described in
-[Writing rules](/customize/rules#freezing-a-passage).
+Click **Freeze for agent** to prevent the agent from editing the selected
+text. The selected text is locked until you unlock it. Read
+[Writing rules](/customize/rules#freezing-a-passage) for details.
 
 ## Keyboard behavior
 
-- **Esc** closes the popup, keeps your selection, and puts the caret
-  back in the document. The popup does not reopen for that same
-  selection, so you can type, copy, or delete without it coming back.
-  Selecting a different range brings it back.
-- **Backspace** or **Delete** with the input empty deletes the
-  selected text from the document. Use it when you selected a passage
-  to comment on and then decide to cut it instead.
-- Selections made with the keyboard open the popup too. Extend a
-  selection with Shift and the arrow keys, or select everything with
-  `Cmd/Ctrl+A`, and the popup opens with its input focused when you
-  release the modifier key.
+- Press **Esc** to close the popup without clearing your selection.
+  You can then type, copy, or delete in the document without
+  seeing the popup again for that selection. When you select a different
+  range, you see the popup again.
+- Press **Backspace** or **Delete** while the input is empty to delete
+  the selected text. Use either key when you decide to cut the passage
+  instead of commenting on it.
+- You can also select text with the keyboard. Hold Shift while you use
+  the arrow keys, or select everything with `Cmd/Ctrl+A`. When you
+  release the modifier key, you can type in the focused input.
 
 ## Where to go next
 
-- [Comments](/agent/comments). What happens on the thread your
-  feedback opens.
-- [Reviewing edits](/agent/reviewing-edits). Accept and reject the
-  edits your feedback produces.
-- [Writing rules](/customize/rules). Turn recurring feedback into a
-  standing rule.
+- Read [Comments](/agent/comments) to learn how to reply to or resolve
+  the thread that you started with your feedback.
+- Read [Reviewing edits](/agent/reviewing-edits) to learn how you can
+  accept or reject an edit from the agent.
+- Read [Writing rules](/customize/rules) to turn repeated feedback into
+  a rule for the agent.

--- a/docs/agent/feedback-popup.mdx
+++ b/docs/agent/feedback-popup.mdx
@@ -1,0 +1,91 @@
+---
+title: "The feedback popup"
+description: "Give the agent feedback on a selected passage, choose how it responds, and control the popup from the keyboard."
+---
+
+Select any passage in the editor and a feedback popup appears anchored
+to the selection. The popup is how you tell the agent what is wrong
+with a specific piece of text, and every action you can take on a
+selection is in it.
+
+<Frame>
+  ![The inline feedback popup, with text input, mode chips, and quick-action pills](/images/inline-feedback-popup.png)
+</Frame>
+
+The popup opens with its input focused, so you can type your feedback
+right away. Focus moves when the selection gesture ends. For a mouse
+selection that is when you release the button, and for a keyboard
+selection that is when you release the modifier key, e.g. releasing
+Shift after extending a selection with the arrow keys. Both kinds of
+selection behave the same, so the habit is the same everywhere. If you
+selected text because you want to edit it yourself, press Esc and keep
+typing.
+
+## Sending feedback
+
+Type what is wrong and press Enter, or click **Go**. The agent
+receives the selected passage and your feedback, opens a comment
+thread anchored to the passage, and responds on that thread in the
+next turn. Whatever you type also becomes a quick-action pill for
+later, as described below.
+
+## Direct edit and plan first
+
+You choose how the agent responds with the two chips under the input.
+
+- **Direct edit.** The agent proposes its edit right away. The edit
+  appears as a pending review on the thread, and you accept or reject
+  it as usual.
+- **Plan first.** The agent first replies on the thread and explains
+  what it thinks is wrong and what it intends to change, and only then
+  proposes the edit on the same thread. The explanation sits in the
+  margin next to the pending edit, so you can read the reasoning
+  before you decide.
+
+Direct edit is the default. The choice applies to the feedback you are
+about to send, and the popup returns to Direct edit the next time it
+opens.
+
+## Quick actions
+
+The pills under the mode chips send the passage with a preset
+label, so common feedback takes one click.
+
+- **Too verbose** and **Incorrect** send the passage with that label
+  in the mode the chips show.
+- **AI smell** always runs plan first, whatever the chips show. The
+  agent explains on the thread why the passage reads as
+  machine-written before it proposes a fix.
+
+The remaining pills are your own recent feedback messages. The popup
+keeps up to six of them, most recent first, and anything you type as
+custom feedback joins the list.
+
+## Freeze for agent
+
+The **Freeze for agent** chip marks the selection as off-limits, so
+the agent cannot edit it until you unlock it. Freezing is described in
+[Writing rules](/customize/rules#freezing-a-passage).
+
+## Keyboard behavior
+
+- **Esc** closes the popup, keeps your selection, and puts the caret
+  back in the document. The popup does not reopen for that same
+  selection, so you can type, copy, or delete without it coming back.
+  Selecting a different range brings it back.
+- **Backspace** or **Delete** with the input empty deletes the
+  selected text from the document. Use it when you selected a passage
+  to comment on and then decide to cut it instead.
+- Selections made with the keyboard open the popup too. Extend a
+  selection with Shift and the arrow keys, or select everything with
+  `Cmd/Ctrl+A`, and the popup opens with its input focused when you
+  release the modifier key.
+
+## Where to go next
+
+- [Comments](/agent/comments). What happens on the thread your
+  feedback opens.
+- [Reviewing edits](/agent/reviewing-edits). Accept and reject the
+  edits your feedback produces.
+- [Writing rules](/customize/rules). Turn recurring feedback into a
+  standing rule.

--- a/docs/agent/observability.mdx
+++ b/docs/agent/observability.mdx
@@ -27,17 +27,16 @@ open the transcript viewer.
 
 ## When a run fails
 
-A failed run shows a red toast in the top right of the window, in
-addition to the error row in the history pane. The toast stays until
-you dismiss it, so a failure cannot pass silently while the history
-pane is collapsed.
+When a run fails, you see a red toast in the top right of the window
+and an error row in the history pane. You continue to see the toast
+until you dismiss it, even when the history pane is collapsed.
 
-An authentication failure gets its own label and tells you to
-re-authenticate with your provider, e.g. run `claude` in a terminal
-and use `/login`. The provider can retry quietly for a couple of
-minutes before it reports the failure, so an auth problem often looks
-like a long stall and then a toast. If runs keep failing after you
-re-authenticate, start a new session from the agent dock.
+If your login is no longer valid, you see an authentication label and
+instructions for signing in again. For Claude, run `claude` in a terminal
+and use `/login`. The agent may retry for a couple of minutes before
+reporting the problem, so you may wait without seeing an error. If the
+agent still fails after you sign in again, start a new session from the
+agent dock.
 
 ## The transcript viewer
 

--- a/docs/agent/observability.mdx
+++ b/docs/agent/observability.mdx
@@ -25,6 +25,20 @@ The history pane only covers the current turn (the latest agent pass).
 For the full session — every turn since the last `--new-session` —
 open the transcript viewer.
 
+## When a run fails
+
+A failed run shows a red toast in the top right of the window, in
+addition to the error row in the history pane. The toast stays until
+you dismiss it, so a failure cannot pass silently while the history
+pane is collapsed.
+
+An authentication failure gets its own label and tells you to
+re-authenticate with your provider, e.g. run `claude` in a terminal
+and use `/login`. The provider can retry quietly for a couple of
+minutes before it reports the failure, so an auth problem often looks
+like a long stall and then a toast. If runs keep failing after you
+re-authenticate, start a new session from the agent dock.
+
 ## The transcript viewer
 
 At the top of the history pane is a **Transcript** button. Clicking it

--- a/docs/agent/reviewing-edits.mdx
+++ b/docs/agent/reviewing-edits.mdx
@@ -60,6 +60,25 @@ click.
   ![The comment gutter with Accept all and Reject all above pending suggestion cards](/images/agent-accept-reject-all.png)
 </Frame>
 
+## Copying proposed text
+
+You can take text out of a proposal without accepting it. Drag across
+the green proposed text to select it and copy with `Cmd/Ctrl+C`, or
+use the copy button that appears when you hover a proposed line. Each
+edit row on a thread card has a copy button as well. Copying is useful
+when part of a proposal is right and you want to place it yourself.
+
+## Seeing which text the agent wrote
+
+The **Highlight AI-written text** button in the top right of the
+editor colors the text that came from accepted agent edits. The
+coloring is word-level, so only the words the agent introduced are
+marked, and your own words that survived an edit stay unmarked.
+
+Typing over a marked word removes the mark, because text you rework
+becomes yours. The button only changes the display. It never changes
+the document, and the setting persists across reloads.
+
 ## Typing while a review is open
 
 You can type normally while a pending review is open. Your edits and the

--- a/docs/agent/reviewing-edits.mdx
+++ b/docs/agent/reviewing-edits.mdx
@@ -62,22 +62,21 @@ click.
 
 ## Copying proposed text
 
-You can take text out of a proposal without accepting it. Drag across
-the green proposed text to select it and copy with `Cmd/Ctrl+C`, or
-use the copy button that appears when you hover a proposed line. Each
-edit row on a thread card has a copy button as well. Copying is useful
-when part of a proposal is right and you want to place it yourself.
+You can copy text from a proposal without accepting the edit. Drag
+across the green text and press `Cmd/Ctrl+C`, or hover over a proposed
+line and use its copy button. You can also use the copy button on each
+edit row in the thread. Copy the text when you want to use only part
+of the proposal.
 
 ## Seeing which text the agent wrote
 
-The **Highlight AI-written text** button in the top right of the
-editor colors the text that came from accepted agent edits. The
-coloring is word-level, so only the words the agent introduced are
-marked, and your own words that survived an edit stay unmarked.
+Click **Highlight AI-written text** in the top right of the editor to
+see which words came from accepted agent edits. You see only the words
+that the agent added, while your unchanged words are not marked.
 
-Typing over a marked word removes the mark, because text you rework
-becomes yours. The button only changes the display. It never changes
-the document, and the setting persists across reloads.
+When you type over a marked word, the word is no longer marked. Turning
+the highlighting on or off does not change the document. You keep the
+same highlighting choice after you reload the page.
 
 ## Typing while a review is open
 

--- a/docs/agent/steering-the-agent.mdx
+++ b/docs/agent/steering-the-agent.mdx
@@ -55,28 +55,27 @@ from running.
 
 ## Inline feedback
 
-Select any passage, with the mouse or the keyboard, and a feedback
-popup appears anchored to the selection with its input focused. Type
-what is wrong and press Enter, or use one of the quick actions. The
-popup, its Direct edit and Plan first modes, the quick actions, and
-its keyboard behavior have their own page. See
-[The feedback popup](/agent/feedback-popup).
+When you select a passage with the mouse or keyboard, you can type your
+feedback without another click. Type what is wrong and press Enter.
+You can also use one of the quick actions. Read
+[The feedback popup](/agent/feedback-popup) for details about its modes,
+quick actions, and keyboard controls.
 
 ## Questions from the agent
 
-When the agent needs a decision it cannot infer, e.g. which of two
-tones you want, it pauses its turn and shows a question card over the
-editor. Each card holds up to four multiple-choice questions.
+When the agent needs you to choose between several options, it pauses
+its turn. You then see a question card over the editor. For example,
+the agent may ask which of two tones you want. The agent may ask up to
+four questions on one card.
 
-A card with one question submits your answer as soon as you click an
-option. A card with several questions stays open until every question
-has an answer. The footer shows how many questions you have answered,
-and you can submit once every question has an answer. A multi-select
-question uses checkboxes, and the agent receives your picks as a
-comma-separated list.
+For one question, click an option to send your answer immediately. For
+several questions, answer every question before you submit the card.
+You can see the number of completed answers in the footer. When you may
+choose more than one answer, select the checkboxes you want. The agent
+receives your choices in a list separated by commas.
 
-The agent waits up to 15 minutes for your answer. If the card times
-out, the agent continues without your input.
+The agent waits up to 15 minutes for your answer. If you do not answer
+in that time, the agent continues without your input.
 
 ## Sending a typed prompt
 

--- a/docs/agent/steering-the-agent.mdx
+++ b/docs/agent/steering-the-agent.mdx
@@ -55,35 +55,28 @@ from running.
 
 ## Inline feedback
 
-Highlight any passage in the editor and a feedback popup appears
-anchored to the selection.
+Select any passage, with the mouse or the keyboard, and a feedback
+popup appears anchored to the selection with its input focused. Type
+what is wrong and press Enter, or use one of the quick actions. The
+popup, its Direct edit and Plan first modes, the quick actions, and
+its keyboard behavior have their own page. See
+[The feedback popup](/agent/feedback-popup).
 
-<Frame>
-  ![The inline feedback popup, with text input, mode chips, and quick-action pills](/images/inline-feedback-popup.png)
-</Frame>
+## Questions from the agent
 
-The popup has three things:
+When the agent needs a decision it cannot infer, e.g. which of two
+tones you want, it pauses its turn and shows a question card over the
+editor. Each card holds up to four multiple-choice questions.
 
-- A **text input** auto-focused for typing custom feedback. Hit Enter
-  (or click **Go**) to submit. The agent receives the selected passage
-  plus your feedback and runs in the next turn.
-- **Mode chips**: **Auto** (the agent decides whether to edit or
-  comment), **Edit** (force an edit), **Discuss** (force a comment
-  thread). Auto is the default.
-- **Quick-action pills** below the input. The first three are pinned
-  defaults — *Too verbose*, *AI smell*, *Incorrect* — that send the
-  passage with that label as the feedback. The remaining pills are
-  your most recent custom feedbacks, kept as an LRU cache (up to six).
-  Whatever you type as custom feedback becomes a pill on the next
-  selection.
+A card with one question submits your answer as soon as you click an
+option. A card with several questions stays open until every question
+has an answer. The footer shows how many questions you have answered,
+and you can submit once every question has an answer. A multi-select
+question uses checkboxes, and the agent receives your picks as a
+comma-separated list.
 
-Two keyboard shortcuts that aren't obvious:
-
-- **Backspace** (with the feedback input empty) deletes the highlighted
-  text from the document instead of doing nothing. Useful when you
-  highlighted a passage planning to give feedback but then decide to
-  just cut it.
-- **Esc** closes the popup and collapses the selection.
+The agent waits up to 15 minutes for your answer. If the card times
+out, the agent continues without your input.
 
 ## Sending a typed prompt
 
@@ -171,6 +164,8 @@ already proposed remains. Cancellation only stops further tool calls.
 
 ## Where to go next
 
+- [The feedback popup](/agent/feedback-popup). Give feedback on a
+  selected passage.
 - [Inline directives](/agent/inline-directives). Leave `[[ ... ]]`
   notes in the prose for the agent to pick up.
 - [Reviewing edits](/agent/reviewing-edits). Accept and reject in

--- a/docs/changelog/2026-07-22.mdx
+++ b/docs/changelog/2026-07-22.mdx
@@ -1,0 +1,69 @@
+---
+title: "July 2026"
+description: "Feedback popup parity, agent questions, error toasts, AI-written text highlighting, plan-first feedback, pause, freeze, and rule violation examples."
+---
+
+## New features
+
+- **Highlight AI-written text.** A button in the top right of the
+  editor colors the text that came from accepted agent edits, at the
+  level of single words. Typing over a marked word removes the mark.
+  See [Reviewing edits](/agent/reviewing-edits#seeing-which-text-the-agent-wrote).
+- **Plan-first feedback.** The feedback popup has **Direct edit** and
+  **Plan first** modes. With Plan first, the agent explains its
+  reasoning on the comment thread before it proposes the edit. The
+  **AI smell** quick action always runs plan first. See
+  [The feedback popup](/agent/feedback-popup).
+- **Pause the agent.** Double-click the Agent pill to stop auto-wake,
+  sends, and in-flight turns until you resume. See
+  [Steering the agent](/agent/steering-the-agent#pausing-the-agent).
+- **Accept all and Reject all.** When a tab has pending suggestions,
+  the comment gutter shows a bar that clears the whole stack in one
+  click. See [Reviewing edits](/agent/reviewing-edits#multiple-pending-rounds).
+- **Freeze a passage.** Select text and click **Freeze for agent** to
+  make it off-limits until you unlock it. See
+  [Writing rules](/customize/rules#freezing-a-passage).
+- **Rule violation examples.** A rule can carry the passage that broke
+  it, added by hand or captured when you reject an edit with feedback
+  and accept the rule the agent proposes from it. See
+  [Writing rules](/customize/rules#violation-examples).
+
+## Updates
+
+- **Every edit is announced on a thread.** An edit proposal now comes
+  with a comment that says what is changing and why, so a pending edit
+  never appears as a bare diff. See [Comments](/agent/comments).
+- **Proposed text is copyable.** Select and copy green proposal text,
+  or use the copy button on a proposed line or an edit row, without
+  accepting the edit. See
+  [Reviewing edits](/agent/reviewing-edits#copying-proposed-text).
+- **The agent writes plainer prose.** The agent's default register
+  prefers long explanatory sentences over short punchy ones, keeps
+  wording boring rather than catchy, and still matches your voice when
+  your document has one.
+- **Smaller screens.** The floating agent pill and the editor columns
+  narrow below 1600px, so the pill no longer overlaps the margin cards
+  on a 14-inch display.
+
+## Bug fixes
+
+- **Agent questions work.** Question cards from the agent failed on
+  every answer, and a card with several questions closed after the
+  first click. A card now stays open until every question has an
+  answer. See
+  [Steering the agent](/agent/steering-the-agent#questions-from-the-agent).
+- **Failed runs are visible.** A failed run shows a dismissable toast,
+  and an authentication failure says to re-authenticate, instead of a
+  row buried in the collapsed history pane. See
+  [Observability](/agent/observability#when-a-run-fails).
+- **Handled feedback stays gone.** A thread whose passage was edited
+  away no longer reappears when you type the same words elsewhere.
+  Undo still restores it with the passage. See
+  [Comments](/agent/comments#when-the-anchored-text-changes).
+- **Keyboard selections open the feedback popup.** Selecting with
+  Shift and the arrow keys now focuses the popup the same way a mouse
+  selection does, so Esc-then-type works everywhere. See
+  [The feedback popup](/agent/feedback-popup).
+- **The document scrolls under the rules popover.** Composing a rule
+  no longer blocks scrolling and clicking in the document, and an
+  unfinished draft survives.

--- a/docs/changelog/2026-07-22.mdx
+++ b/docs/changelog/2026-07-22.mdx
@@ -1,69 +1,67 @@
 ---
 title: "July 2026"
-description: "Feedback popup parity, agent questions, error toasts, AI-written text highlighting, plan-first feedback, pause, freeze, and rule violation examples."
+description: "Read about the changes to feedback, agent questions, errors, writing rules, and the review process."
 ---
 
 ## New features
 
-- **Highlight AI-written text.** A button in the top right of the
-  editor colors the text that came from accepted agent edits, at the
-  level of single words. Typing over a marked word removes the mark.
+- **Highlight AI-written text.** Click the button in the top right of
+  the editor to see which words came from accepted agent edits. When
+  you type over a marked word, the word is no longer marked.
   See [Reviewing edits](/agent/reviewing-edits#seeing-which-text-the-agent-wrote).
-- **Plan-first feedback.** The feedback popup has **Direct edit** and
-  **Plan first** modes. With Plan first, the agent explains its
-  reasoning on the comment thread before it proposes the edit. The
-  **AI smell** quick action always runs plan first. See
+- **Plan first feedback.** Choose **Direct edit** when you want an edit
+  immediately. Choose **Plan first** when you want an explanation before
+  the edit. When you click **AI smell**, the agent always explains its
+  reasoning first. See
   [The feedback popup](/agent/feedback-popup).
-- **Pause the agent.** Double-click the Agent pill to stop auto-wake,
-  sends, and in-flight turns until you resume. See
+- **Pause the agent.** Double-click the Agent pill to stop the current
+  turn and prevent the agent from waking while you are idle. You also
+  cannot send a new message until you resume the agent. See
   [Steering the agent](/agent/steering-the-agent#pausing-the-agent).
-- **Accept all and Reject all.** When a tab has pending suggestions,
-  the comment gutter shows a bar that clears the whole stack in one
-  click. See [Reviewing edits](/agent/reviewing-edits#multiple-pending-rounds).
+- **Accept or reject all edits.** You can accept or reject every pending
+  edit in a tab with one click. See
+  [Reviewing edits](/agent/reviewing-edits#multiple-pending-rounds).
 - **Freeze a passage.** Select text and click **Freeze for agent** to
-  make it off-limits until you unlock it. See
+  prevent the agent from editing it until you unlock it. See
   [Writing rules](/customize/rules#freezing-a-passage).
-- **Rule violation examples.** A rule can carry the passage that broke
-  it, added by hand or captured when you reject an edit with feedback
-  and accept the rule the agent proposes from it. See
+- **Save examples with rules.** You can add a passage that breaks a
+  rule as an example for the agent. You can add the example yourself,
+  or accept one that the agent proposes after you reject an edit. See
   [Writing rules](/customize/rules#violation-examples).
 
 ## Updates
 
-- **Every edit is announced on a thread.** An edit proposal now comes
-  with a comment that says what is changing and why, so a pending edit
-  never appears as a bare diff. See [Comments](/agent/comments).
-- **Proposed text is copyable.** Select and copy green proposal text,
-  or use the copy button on a proposed line or an edit row, without
-  accepting the edit. See
+- **Read an explanation before every edit.** The agent now starts a
+  comment thread before it proposes an edit. On the thread, the agent
+  explains what it will change and why. See [Comments](/agent/comments).
+- **Copy proposed text.** You can select and copy green text without
+  accepting the edit. You can also use a copy button on a proposed line
+  or an edit row. See
   [Reviewing edits](/agent/reviewing-edits#copying-proposed-text).
-- **The agent writes plainer prose.** The agent's default register
-  prefers long explanatory sentences over short punchy ones, keeps
-  wording boring rather than catchy, and still matches your voice when
-  your document has one.
-- **Smaller screens.** The floating agent pill and the editor columns
-  narrow below 1600px, so the pill no longer overlaps the margin cards
-  on a 14-inch display.
+- **The agent writes plainer prose.** By default, the agent now uses
+  long explanatory sentences instead of short punchy ones. The agent
+  also uses plain wording and matches the voice of your document.
+- **More room on smaller screens.** You can now use a 14 inch display
+  without the agent pill covering the margin cards.
 
 ## Bug fixes
 
-- **Agent questions work.** Question cards from the agent failed on
-  every answer, and a card with several questions closed after the
-  first click. A card now stays open until every question has an
-  answer. See
+- **Answer several agent questions.** You can now answer every question
+  on a card before you submit it. Previously, every answer failed, and
+  you could answer only the first question. See
   [Steering the agent](/agent/steering-the-agent#questions-from-the-agent).
-- **Failed runs are visible.** A failed run shows a dismissable toast,
-  and an authentication failure says to re-authenticate, instead of a
-  row buried in the collapsed history pane. See
+- **See failed runs.** You now see a toast when a run fails, even when
+  the history pane is collapsed. When authentication fails, you also
+  see instructions for signing in again. See
   [Observability](/agent/observability#when-a-run-fails).
-- **Handled feedback stays gone.** A thread whose passage was edited
-  away no longer reappears when you type the same words elsewhere.
-  Undo still restores it with the passage. See
+- **Keep old feedback hidden.** After you remove a passage, you do not
+  see its comment thread when you type the same words elsewhere. If you
+  undo the edit, you see the passage and its thread again. See
   [Comments](/agent/comments#when-the-anchored-text-changes).
-- **Keyboard selections open the feedback popup.** Selecting with
-  Shift and the arrow keys now focuses the popup the same way a mouse
-  selection does, so Esc-then-type works everywhere. See
+- **Use the keyboard to select feedback.** When you select text with
+  Shift and the arrow keys, you can type feedback without another click.
+  You now get the same behavior when you select text with a mouse. See
   [The feedback popup](/agent/feedback-popup).
-- **The document scrolls under the rules popover.** Composing a rule
-  no longer blocks scrolling and clicking in the document, and an
-  unfinished draft survives.
+- **Scroll while writing a rule.** You can now scroll and click in the
+  document while you write a rule. You can also close the rule editor
+  without losing your unfinished draft.

--- a/docs/customize/rules.mdx
+++ b/docs/customize/rules.mdx
@@ -41,6 +41,23 @@ This routes through the `propose_rule` MCP tool. See [How it
 works](/reference/how-it-works) for the architectural details if you're
 curious.
 
+## Violation examples
+
+A rule can carry an example of the writing it forbids. The agent sees
+each example under its rule, so it checks fresh prose against a
+concrete case instead of interpreting the rule in the abstract.
+
+You can add an example by hand. Each rule in the panel has a
+**+ example violation** affordance; paste the offending passage there.
+Each example has its own remove control.
+
+The agent can also supply the example. When you reject an agent edit
+with feedback and the agent proposes a rule from that feedback, it
+quotes the passage that broke the rule, and accepting the proposal
+stores the passage as the rule's first example. A rule such as "Never
+hedge with 'quite', 'rather', or 'somewhat'" then carries the sentence
+that prompted it.
+
 ## Freezing a passage
 
 To stop the agent from editing a specific paragraph (or any selection),

--- a/docs/customize/rules.mdx
+++ b/docs/customize/rules.mdx
@@ -43,20 +43,19 @@ curious.
 
 ## Violation examples
 
-A rule can carry an example of the writing it forbids. The agent sees
-each example under its rule, so it checks fresh prose against a
-concrete case instead of interpreting the rule in the abstract.
+You can give the agent a violation example for each rule. The agent
+compares new prose with each example, so it does not have to infer your
+meaning from abstract wording.
 
-You can add an example by hand. Each rule in the panel has a
-**+ example violation** affordance; paste the offending passage there.
-Each example has its own remove control.
+To add an example yourself, click **+ example violation** under the rule
+and paste the passage that broke it. Use the remove control next to an
+example when you no longer need it.
 
-The agent can also supply the example. When you reject an agent edit
-with feedback and the agent proposes a rule from that feedback, it
-quotes the passage that broke the rule, and accepting the proposal
-stores the passage as the rule's first example. A rule such as "Never
-hedge with 'quite', 'rather', or 'somewhat'" then carries the sentence
-that prompted it.
+The agent can also propose an example. When you reject an edit with
+feedback, the agent may propose a rule based on your feedback. If you
+accept the rule, the agent saves the original passage as its first
+example. For example, the rule "Never hedge with 'quite', 'rather', or
+'somewhat'" can include the sentence that led you to write the rule.
 
 ## Freezing a passage
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,7 @@
 				"group": "Working with the agent",
 				"pages": [
 					"agent/steering-the-agent",
+					"agent/feedback-popup",
 					"agent/inline-directives",
 					"agent/reviewing-edits",
 					"agent/delegating-tasks",
@@ -92,6 +93,7 @@
 			{
 				"group": "Changelog",
 				"pages": [
+					"changelog/2026-07-22",
 					"changelog/2026-05-22",
 					"changelog/2026-05-15"
 				]

--- a/docs/reference/shortcuts.mdx
+++ b/docs/reference/shortcuts.mdx
@@ -21,14 +21,17 @@ else.
 
 ## In the inline-feedback popup
 
-The popup auto-focuses its text input, so most keys go to the input.
+Any selection opens the popup, whether you make it with the mouse or
+with the keyboard, e.g. Shift with the arrow keys or `Cmd/Ctrl+A`. The
+input takes focus when the selection gesture ends, so most keys go to
+the input.
 A few are routed elsewhere:
 
 | Shortcut                    | What it does                                                                  |
 | --------------------------- | ----------------------------------------------------------------------------- |
 | `Enter`                     | Submit the typed feedback to the agent.                                       |
 | `Shift+Enter`               | Newline in the input (multi-line feedback).                                   |
-| `Esc`                       | Close the popup and collapse the selection.                                   |
+| `Esc`                       | Close the popup, keep the selection, and return the caret to the document. The popup does not reopen for that same selection. |
 | `Cmd/Ctrl+A` (empty input)  | Select all in the editor (not the input).                                     |
 | `Backspace` / `Delete` (empty input) | Delete the highlighted text from the document. Useful when you highlighted a passage planning to give feedback but then decided to just cut it. |
 

--- a/docs/reference/shortcuts.mdx
+++ b/docs/reference/shortcuts.mdx
@@ -21,11 +21,10 @@ else.
 
 ## In the inline-feedback popup
 
-Any selection opens the popup, whether you make it with the mouse or
-with the keyboard, e.g. Shift with the arrow keys or `Cmd/Ctrl+A`. The
-input takes focus when the selection gesture ends, so most keys go to
-the input.
-A few are routed elsewhere:
+You can use the mouse or keyboard to select text and open the popup. For
+example, hold Shift while you use the arrow keys, or press `Cmd/Ctrl+A`.
+The cursor is already in the input when you finish the selection, so
+you enter text there with most keys. Use these keys for other actions:
 
 | Shortcut                    | What it does                                                                  |
 | --------------------------- | ----------------------------------------------------------------------------- |

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -1418,6 +1418,27 @@
 		editorRoot.addEventListener('pointerdown', handlePointerDown);
 		window.addEventListener('pointerup', handlePointerUp);
 
+		// Keyboard selections get the same treatment as mouse selections: the
+		// feedback popup takes focus when the selection GESTURE ends. For the
+		// mouse that's pointerup (above); for the keyboard it's releasing the
+		// modifier that drove the selection — Shift for shift+arrow/Home/End,
+		// Meta/Ctrl for select-all. Focusing on every selectionUpdate would
+		// break mid-gesture extension (the first shift+arrow would yank focus
+		// out of the editor), so only the modifier release promotes the
+		// popup to focused. Without this, mouse selections focused the
+		// feedback box while keyboard selections silently didn't, and the
+		// "press Esc to type into the document" habit never formed.
+		// updateFeedbackPopup carries all the guards this needs: it no-ops
+		// unless the editor itself is focused (so releasing Shift while
+		// typing IN the popup can't re-trigger), requires a non-empty
+		// TextSelection, and respects an Esc-dismissed range.
+		const handleSelectionKeyup = (e: KeyboardEvent) => {
+			if (e.key !== 'Shift' && e.key !== 'Meta' && e.key !== 'Control') return;
+			if (pointerSelecting) return;
+			requestAnimationFrame(() => updateFeedbackPopup(true));
+		};
+		editorRoot.addEventListener('keyup', handleSelectionKeyup);
+
 		// Comment thread decorations dispatch this event when the user
 		// clicks an inline highlight or the gutter pill. With cards in
 		// the right-side comment gutter we just set the store — the
@@ -1513,6 +1534,7 @@
 		detachFeedbackPointerHandlers = () => {
 			editorRoot.removeEventListener('pointerdown', handlePointerDown);
 			window.removeEventListener('pointerup', handlePointerUp);
+			editorRoot.removeEventListener('keyup', handleSelectionKeyup);
 			detachOpenThread();
 		};
 	});

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -277,7 +277,7 @@ Apply this to every word you write: edits, new prose, and your replies on commen
 
 - Use plain, everyday words. Write "use", not "leverage" or "utilize".
 - Write complete sentences, and prefer long, explanatory sentences over short, punchy ones. Write the way people explain things out loud, in longer sentences with commas and one or two related clauses that carry the reasoning along. A sentence should end because the thought is complete, not because a short sentence would sound stronger. Plain means explanatory, not terse.
-- Communicate clearly and boring. State the literal thing with no embellishment and no performance. Never write a staccato run of short sentences for emphasis, and never lead with a colon-headed label fragment such as "The problem: fixed." Explain in prose.
+- Communicate clearly and boring. State the literal thing with no embellishment and no performance. Never reach for a catchy or quotable phrasing; the dull version is correct. Never write a staccato run of short sentences for emphasis, and never lead with a colon-headed label fragment such as "The problem: fixed." Explain in prose.
 - Prefer concrete verbs and named things. Replace "various", "several", "a number of", "important", "robust", and "powerful" with the specific thing.
 - Repeat a word rather than swapping in a synonym.
 - Do not use analogies, metaphors, or imagery unless the user's text uses them.

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -277,7 +277,7 @@ Apply this to every word you write: edits, new prose, and your replies on commen
 
 - Use plain, everyday words. Write "use", not "leverage" or "utilize".
 - Write complete sentences, and prefer long, explanatory sentences over short, punchy ones. Write the way people explain things out loud, in longer sentences with commas and one or two related clauses that carry the reasoning along. A sentence should end because the thought is complete, not because a short sentence would sound stronger. Plain means explanatory, not terse.
-- Communicate clearly and boring. State the literal thing with no embellishment and no performance. Never reach for a catchy or quotable phrasing; the dull version is correct. Never write a staccato run of short sentences for emphasis, and never lead with a colon-headed label fragment such as "The problem: fixed." Explain in prose.
+- Keep the writing boring, descriptive, and explanatory. Do not use a catchy phrase, slogan, clever label, metaphorical summary, or wording meant to sound memorable; state the actual concept, action, condition, or relationship in literal terms. This applies to headings, topic sentences, callouts, labels, summaries, and ordinary prose. Never write a staccato run of short sentences for emphasis, and never lead with a colon-headed label fragment such as "The problem: fixed." Explain in prose.
 - Prefer concrete verbs and named things. Replace "various", "several", "a number of", "important", "robust", and "powerful" with the specific thing.
 - Repeat a word rather than swapping in a synonym.
 - Do not use analogies, metaphors, or imagery unless the user's text uses them.


### PR DESCRIPTION
Three follow-ups from user feedback.

## 1. Keyboard selections now focus the feedback popup, matching mouse selections

Selecting text with the mouse focused the inline feedback input on pointerup, but selecting with shift+arrows never moved focus — the popup appeared unfocused and typing kept editing the document. The two paths demanded opposite habits (press Esc first vs just type), so neither stuck.

The fix treats releasing the selection modifier (Shift for shift+arrow/Home/End, Meta/Ctrl for select-all) as the keyboard's selection-gesture end, symmetric with pointerup for the mouse, and promotes the popup to focused there. Focusing on every `selectionUpdate` instead would break mid-gesture extension: the first shift+arrow would yank focus out of the editor. `updateFeedbackPopup`'s existing guards carry the rest — it no-ops unless the editor itself is focused (so releasing Shift while typing in the popup can't re-trigger), requires a real ≥2-char text selection, and respects an Esc-dismissed range.

Verified in the running app with Playwright:
- mid-gesture (Shift held): focus stays in the editor
- Shift release: popup visible and its input focused
- Esc: focus returns to the document, selection preserved, typing edits the document
- typing capital letters never opens the popup
- mouse drag-selection unchanged (still focuses)

## 2. Boring-register prompt rule now uses the plain-writing skill's own wording

The system prompt's register rule banned staccato runs and label fragments but only implied the ban on catchy phrasing. The first attempt at making it explicit was an ad-libbed paraphrase ("never reach for…" — itself the kind of idiom the section bans). The rule now carries Rule 7 of the plain-writing skill verbatim: keep the writing boring, descriptive, and explanatory; no catchy phrase, slogan, clever label, metaphorical summary, or wording meant to sound memorable; applies to headings, topic sentences, callouts, labels, summaries, and ordinary prose.

## 3. User docs reorganized around surfaces, with coverage for the July features

The feedback popup was documented in pieces across three pages. It now has one page, `docs/agent/feedback-popup.mdx`, covering how it opens (mouse or keyboard selection), Direct edit vs Plan first, the quick actions (including AI smell always running plan first), Freeze for agent, and the Esc / Backspace / keyboard-selection behavior. The stale Auto/Edit/Discuss chip docs are gone.

New coverage, one section per surface:
- **Steering the agent**: the agent's question cards (multi-question cards collect every answer; 15-minute timeout).
- **Observability**: failed runs show a dismissable toast; auth failures say to re-authenticate; the quiet retry stall is explained.
- **Comments**: threads also announce edits, plus a section on what happens when the anchored text is edited away (card hides, undo restores it, retyped duplicates don't resurrect it).
- **Reviewing edits**: copying proposed text; the Highlight AI-written text toggle.
- **Writing rules**: violation examples, added by hand or captured from a rejected edit's feedback.
- **Shortcuts**: Esc keeps the selection; keyboard selections open the popup.
- **Changelog**: a July 2026 entry for the whole batch.

All new doc prose follows the plain-writing skill (no dashes, complete sentences, longer explanatory sentences, boring wording, sentence-case headings).

`npm run check` clean at every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9yk4Z9yotQXNmJGEW46FE