### PR TITLE
Unify comment anchor quote matching across client and server

### DIFF
--- a/src/lib/editor/comment-overlay.ts
+++ b/src/lib/editor/comment-overlay.ts
@@ -15,8 +15,9 @@ import {
 import {
 	getCommentsMap,
 	SYSTEM_ORIGIN,
-	ANCHOR_CONTEXT_RADIUS,
-	captureAnchorContext
+	captureAnchorContext,
+	matchCommentAnchor,
+	nthIndexOf
 } from '$lib/shared/ydoc-codec';
 import { buildCharIndex as cachedBuildCharIndex } from './char-index';
 import type { CommentThread } from '$lib/types';
@@ -64,20 +65,6 @@ export function setCommentOverlayState(editor: Editor, state: CommentOverlayStat
 // buildCharIndex moved to ./char-index for cross-overlay caching.
 // Aliased here so the rest of this file reads cleanly.
 const buildCharIndex = cachedBuildCharIndex;
-
-/** Locate the Nth occurrence of `needle` in `haystack`. Returns -1 when
- * fewer than N+1 matches exist. */
-function nthIndexOf(haystack: string, needle: string, occurrenceIndex: number): number {
-	if (!needle) return -1;
-	let idx = 0;
-	let found = 0;
-	while ((idx = haystack.indexOf(needle, idx)) !== -1) {
-		if (found === occurrenceIndex) return idx;
-		found += 1;
-		idx += needle.length;
-	}
-	return -1;
-}
 
 /** Base64 encode/decode for storing Y.RelativePosition (a Uint8Array) in
  * a JSON-friendly Y.Map value. We pass through atob/btoa because (a) it
@@ -153,68 +140,6 @@ function getYBinding(state: EditorState): {
 	return { doc: binding.doc, type: binding.type, mapping: binding.mapping };
 }
 
-/** How many characters of stored anchor context must still match for a
- * quote fallback to re-attach a thread whose rel-position anchor died.
- * (The context itself is captured via `captureAnchorContext`, radius
- * `ANCHOR_CONTEXT_RADIUS`, shared with the server in ydoc-codec.) */
-const ANCHOR_CONTEXT_MIN_MATCH = 8;
-
-/** Contexts are compared in the editor's paragraph-concatenated plain-text
- * space (no separators), while server-captured contexts come from the
- * newline-joined serialization — strip newlines so both agree. */
-function normalizeAnchorContext(s: string): string {
-	return s.replace(/\n/g, '');
-}
-
-function commonSuffixLen(a: string, b: string): number {
-	let n = 0;
-	while (n < a.length && n < b.length && a[a.length - 1 - n] === b[b.length - 1 - n]) n += 1;
-	return n;
-}
-
-function commonPrefixLen(a: string, b: string): number {
-	let n = 0;
-	while (n < a.length && n < b.length && a[n] === b[n]) n += 1;
-	return n;
-}
-
-/** Among all occurrences of `quote`, pick the one whose surroundings best
- * match the anchor's stored context; -1 when none matches well enough.
- * `preferredIdx` breaks score ties (the plain occurrenceIndex match). */
-function findContextMatch(
-	plainText: string,
-	quote: string,
-	contextBefore: string,
-	contextAfter: string,
-	preferredIdx: number
-): number {
-	const storedBefore = normalizeAnchorContext(contextBefore);
-	const storedAfter = normalizeAnchorContext(contextAfter);
-	// The bar adapts to how much context exists: a quote at the very start
-	// of a short document may have less than ANCHOR_CONTEXT_MIN_MATCH chars
-	// of context in total, and that's fine.
-	const required = Math.min(ANCHOR_CONTEXT_MIN_MATCH, storedBefore.length + storedAfter.length);
-	let bestIdx = -1;
-	let bestScore = -1;
-	let scan = 0;
-	while ((scan = plainText.indexOf(quote, scan)) !== -1) {
-		const actualBefore = normalizeAnchorContext(
-			plainText.slice(Math.max(0, scan - ANCHOR_CONTEXT_RADIUS), scan)
-		);
-		const actualAfter = normalizeAnchorContext(
-			plainText.slice(scan + quote.length, scan + quote.length + ANCHOR_CONTEXT_RADIUS)
-		);
-		const score =
-			commonSuffixLen(storedBefore, actualBefore) + commonPrefixLen(storedAfter, actualAfter);
-		if (score >= required && (score > bestScore || (score === bestScore && scan === preferredIdx))) {
-			bestScore = score;
-			bestIdx = scan;
-		}
-		scan += quote.length;
-	}
-	return bestIdx;
-}
-
 /** Resolve a thread's anchor to PM positions. Tries rel positions first
  * (live, CRDT-tracked); falls back to indexOf when rel positions are
  * missing or no longer resolvable. Returns null when neither finds a
@@ -259,41 +184,17 @@ function resolveAnchorPMRange(
 		}
 	}
 
-	// Tier 2: indexOf fallback, context-checked when context is stored.
+	// Tier 2: quote-lookup fallback — the exact ladder (occurrenceIndex →
+	// first occurrence → first-non-empty-line for multi-line quotes, plus
+	// the context check) lives in `matchCommentAnchor`, shared with the
+	// per-tab thread counting behind the TabBar dots so the two can't
+	// disagree about which threads are attached.
 	const { charPositions, plainText } = buildCharIndex(state.doc);
-	let quote = anchor.quote;
-	let idx = nthIndexOf(plainText, quote, anchor.occurrenceIndex);
-	if (idx < 0) idx = nthIndexOf(plainText, quote, 0);
-	// Multi-line anchors (e.g. an edit thread auto-anchored to a multi-line
-	// `old_string`) often don't match verbatim — the stored quote is markdown
-	// form (with `\n`/escapes) while `plainText` is the editor's plain text.
-	// Fall back to the first non-empty line, which matches reliably and is
-	// enough to position the card. Without this, a multi-line edit's thread
-	// card silently disappears even though its diff renders.
-	let usedFirstLineFallback = false;
-	if (idx < 0 && quote.includes('\n')) {
-		const firstLine = quote.split('\n').find((l) => l.trim()) ?? '';
-		if (firstLine) {
-			quote = firstLine;
-			idx = nthIndexOf(plainText, quote, 0);
-			usedFirstLineFallback = true;
-		}
-	}
-	if (idx < 0) return null;
-	const hasContext = !!(anchor.contextBefore || anchor.contextAfter);
-	if (hasContext && !usedFirstLineFallback) {
-		idx = findContextMatch(
-			plainText,
-			quote,
-			anchor.contextBefore ?? '',
-			anchor.contextAfter ?? '',
-			idx
-		);
-		if (idx < 0) return null;
-	}
-	const endOffset = idx + quote.length - 1;
+	const match = matchCommentAnchor(plainText, anchor);
+	if (!match) return null;
+	const endOffset = match.idx + match.quote.length - 1;
 	if (endOffset >= charPositions.length) return null;
-	const from = charPositions[idx];
+	const from = charPositions[match.idx];
 	const to = charPositions[endOffset] + 1;
 	if (from === undefined || to === undefined || to <= from) return null;
 	return { from, to };

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -30,7 +30,8 @@ import {
 	getCommentsMap,
 	AGENT_ORIGIN,
 	normalizeTypography,
-	captureAnchorContext
+	captureAnchorContext,
+	nthIndexOf
 } from '$lib/shared/ydoc-codec';
 import { isScratchPath, resolveTabFromPath, isOpenTab } from './path-router';
 import { classifyRoundKind } from '$lib/review-diff';
@@ -358,7 +359,7 @@ function createAgentEditThread(
 ): string {
 	const threadId = 'thread_' + cryptoRandomId();
 	const now = Date.now();
-	const anchorIdx = nthOccurrenceIndex(docText, oldString, occurrenceIndex);
+	const anchorIdx = nthIndexOf(docText, oldString, occurrenceIndex);
 	const thread: CommentThread = {
 		id: threadId,
 		anchor: {
@@ -383,20 +384,6 @@ function createAgentEditThread(
 	};
 	getCommentsMap(doc).set(threadId, thread);
 	return threadId;
-}
-
-/** Character index of the `occurrenceIndex`-th occurrence of `needle` in
- * `haystack`, or -1 when there are fewer occurrences. */
-function nthOccurrenceIndex(haystack: string, needle: string, occurrenceIndex: number): number {
-	if (!needle) return -1;
-	let idx = 0;
-	let found = 0;
-	while ((idx = haystack.indexOf(needle, idx)) !== -1) {
-		if (found === occurrenceIndex) return idx;
-		found += 1;
-		idx += needle.length;
-	}
-	return -1;
 }
 
 // ---- Auto-open-as-tab -----------------------------------------------------
@@ -824,7 +811,7 @@ function createAgentCommentThread(
 	const threadId = 'thread_' + cryptoRandomId();
 	const now = Date.now();
 	const liveText = serializeYDoc(doc);
-	const anchorIdx = nthOccurrenceIndex(liveText, anchorText, occurrenceIndex);
+	const anchorIdx = nthIndexOf(liveText, anchorText, occurrenceIndex);
 	const thread: CommentThread = {
 		id: threadId,
 		anchor: {

--- a/src/lib/server/providers/tool-handlers.ts
+++ b/src/lib/server/providers/tool-handlers.ts
@@ -28,7 +28,9 @@ import {
 	serializeYDoc,
 	getCommentsMap,
 	AGENT_ORIGIN,
-	normalizeTypography
+	normalizeTypography,
+	captureAnchorContext,
+	nthIndexOf
 } from '$lib/shared/ydoc-codec';
 import type {
 	CommentMessage,
@@ -440,9 +442,20 @@ export function buildToolDefinitions(): ToolDefinition[] {
 					const commentsMap = getCommentsMap(doc);
 					const now = Date.now();
 					threadId = 'thread_' + cryptoRandomId();
+					// Snapshot the anchor's surroundings (same as the Claude-path
+					// comment tools) so the client's quote fallback can tell "this
+					// text came back" (undo) apart from "the same string appears
+					// somewhere else" once the passage is deleted.
+					const anchorIdx = nthIndexOf(liveText, anchorText, occurrence);
 					const thread: CommentThread = {
 						id: threadId,
-						anchor: { quote: anchorText, occurrenceIndex: occurrence },
+						anchor: {
+							quote: anchorText,
+							occurrenceIndex: occurrence,
+							...(anchorIdx >= 0
+								? captureAnchorContext(liveText, anchorIdx, anchorText.length)
+								: {})
+						},
 						messages: [{
 							id: 'msg_' + cryptoRandomId(),
 							author: 'agent',

--- a/src/lib/shared/ydoc-codec.ts
+++ b/src/lib/shared/ydoc-codec.ts
@@ -85,6 +85,145 @@ export function captureAnchorContext(
 	};
 }
 
+/** Locate the Nth occurrence of `needle` in `haystack`. Returns -1 when
+ * fewer than N+1 matches exist. */
+export function nthIndexOf(haystack: string, needle: string, occurrenceIndex: number): number {
+	if (!needle) return -1;
+	let idx = 0;
+	let found = 0;
+	while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+		if (found === occurrenceIndex) return idx;
+		found += 1;
+		idx += needle.length;
+	}
+	return -1;
+}
+
+/** How many characters of stored anchor context must still match for a
+ * quote fallback to re-attach a thread whose rel-position anchor died. */
+const ANCHOR_CONTEXT_MIN_MATCH = 8;
+
+/** Anchor contexts are compared newline-free: the editor's char index
+ * concatenates paragraphs with no separator while server-captured contexts
+ * come from the newline-joined serialization — strip newlines so both text
+ * spaces agree. */
+function normalizeAnchorContext(s: string): string {
+	return s.replace(/\n/g, '');
+}
+
+function commonSuffixLen(a: string, b: string): number {
+	let n = 0;
+	while (n < a.length && n < b.length && a[a.length - 1 - n] === b[b.length - 1 - n]) n += 1;
+	return n;
+}
+
+function commonPrefixLen(a: string, b: string): number {
+	let n = 0;
+	while (n < a.length && n < b.length && a[n] === b[n]) n += 1;
+	return n;
+}
+
+/** Among all occurrences of `quote`, pick the one whose surroundings best
+ * match the anchor's stored context; -1 when none matches well enough.
+ * `preferredIdx` breaks score ties (the plain occurrenceIndex match). */
+function findContextMatch(
+	plainText: string,
+	quote: string,
+	contextBefore: string,
+	contextAfter: string,
+	preferredIdx: number
+): number {
+	const storedBefore = normalizeAnchorContext(contextBefore);
+	const storedAfter = normalizeAnchorContext(contextAfter);
+	// The bar adapts to how much context exists: a quote at the very start
+	// of a short document may have less than ANCHOR_CONTEXT_MIN_MATCH chars
+	// of context in total, and that's fine.
+	const required = Math.min(ANCHOR_CONTEXT_MIN_MATCH, storedBefore.length + storedAfter.length);
+	let bestIdx = -1;
+	let bestScore = -1;
+	let scan = 0;
+	while ((scan = plainText.indexOf(quote, scan)) !== -1) {
+		const actualBefore = normalizeAnchorContext(
+			plainText.slice(Math.max(0, scan - ANCHOR_CONTEXT_RADIUS), scan)
+		);
+		const actualAfter = normalizeAnchorContext(
+			plainText.slice(scan + quote.length, scan + quote.length + ANCHOR_CONTEXT_RADIUS)
+		);
+		const score =
+			commonSuffixLen(storedBefore, actualBefore) + commonPrefixLen(storedAfter, actualAfter);
+		if (score >= required && (score > bestScore || (score === bestScore && scan === preferredIdx))) {
+			bestScore = score;
+			bestIdx = scan;
+		}
+		scan += quote.length;
+	}
+	return bestIdx;
+}
+
+/** A resolved quote match: `idx` into the plain text that was searched, and
+ * the `quote` that actually matched there (the anchor's full quote, or its
+ * first non-empty line when the multi-line fallback kicked in). */
+export interface AnchorQuoteMatch {
+	idx: number;
+	quote: string;
+}
+
+/**
+ * Locate a comment-thread anchor's quote in `plainText` — the single
+ * matching policy shared by the comment overlay's fallback resolver (which
+ * maps the match to ProseMirror positions) and the per-tab thread counting
+ * that drives the TabBar dots. Keeping one implementation is what keeps
+ * "the dot pulses" and "a card renders" in agreement; they drifted once
+ * (the overlay gained the context check, the dot count didn't) and the
+ * dots nagged about threads that no longer rendered anywhere.
+ *
+ * The ladder, in order:
+ *   1. Full quote at `occurrenceIndex` (falling back to the first
+ *      occurrence when that index no longer exists).
+ *   2. Multi-line quotes whose full text no longer matches fall back to
+ *      their first non-empty line — enough to position/count the thread.
+ *   3. When the anchor stores surrounding context (`contextBefore` /
+ *      `contextAfter`) and the full quote matched, the occurrence must
+ *      ALSO match that context (`findContextMatch`), so a thread whose
+ *      passage was deleted doesn't re-attach to an unrelated occurrence
+ *      of the same string elsewhere. The first-line fallback skips the
+ *      context check — the stored context surrounds the full quote, not
+ *      its first line.
+ *
+ * Returns null when nothing matches — the thread is detached.
+ */
+export function matchCommentAnchor(
+	plainText: string,
+	anchor: CommentThread['anchor']
+): AnchorQuoteMatch | null {
+	let quote = anchor.quote;
+	if (!quote) return null;
+	let idx = nthIndexOf(plainText, quote, anchor.occurrenceIndex);
+	if (idx < 0) idx = nthIndexOf(plainText, quote, 0);
+	let usedFirstLineFallback = false;
+	if (idx < 0 && quote.includes('\n')) {
+		const firstLine = quote.split('\n').find((l) => l.trim()) ?? '';
+		if (firstLine) {
+			quote = firstLine;
+			idx = nthIndexOf(plainText, quote, 0);
+			usedFirstLineFallback = true;
+		}
+	}
+	if (idx < 0) return null;
+	const hasContext = !!(anchor.contextBefore || anchor.contextAfter);
+	if (hasContext && !usedFirstLineFallback) {
+		idx = findContextMatch(
+			plainText,
+			quote,
+			anchor.contextBefore ?? '',
+			anchor.contextAfter ?? '',
+			idx
+		);
+		if (idx < 0) return null;
+	}
+	return { idx, quote };
+}
+
 export function getFragment(ydoc: Y.Doc): Y.XmlFragment {
 	return ydoc.getXmlFragment(FRAGMENT_NAME);
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -30,8 +30,11 @@ export const reviewBaseline = writable<string | null>(null);
 export const pendingReviewRounds = writable<MaterializedPendingReviewRound[]>([]);
 
 /** Agent comment threads for EVERY open tab. Each entry contains a tabId
- * and the unresolved threads that have at least one agent message.
- * Used by OutlinePane's cross-tab comment section. */
+ * and the unresolved, still-anchored threads that have at least one agent
+ * message — the same attachment test the comment gutter renders by
+ * (`matchCommentAnchor`), so a tab never advertises threads that wouldn't
+ * show. Drives the per-tab dot badges on the TabBar (via
+ * `mergedPendingTabs` in +page.svelte). */
 export const allTabCommentThreads = writable<Array<{ tabId: string; threads: CommentThread[] }>>([]);
 
 /** Set of comment thread IDs the user has already seen (opened or clicked).

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,7 +29,10 @@
 	import { themes, applyTheme } from '$lib/themes';
 	import { unifiedLineDiff } from '$lib/diff';
 	import { materializePendingReviewRounds } from '$lib/review-rounds';
-	import { serializeFragment as plainTextFromFragment } from '$lib/shared/ydoc-codec';
+	import {
+		serializeFragment as plainTextFromFragment,
+		matchCommentAnchor
+	} from '$lib/shared/ydoc-codec';
 
 	/** Turn a submit trigger into a compact description for the history
 	 * pane. Full text of long prompts (including feedback-on-passage quotes)
@@ -253,15 +256,18 @@
 		return plainTextFromFragment(getYDocForTab(tabId).getXmlFragment('default'));
 	}
 
-	/** Whether a thread anchor still maps to text in the doc — mirrors the
-	 * comment overlay's resolver (full quote, else its first non-empty line,
-	 * so multi-line anchors aren't falsely treated as detached). Used to keep
-	 * detached threads out of the tab count without mutating them. */
-	function anchorPresentInText(quote: string, text: string): boolean {
-		if (!quote) return false;
-		if (text.includes(quote)) return true;
-		const firstLine = quote.split('\n').find((l) => l.trim());
-		return !!firstLine && text.includes(firstLine);
+	/** Whether a thread anchor still maps to text in the doc — delegates to
+	 * `matchCommentAnchor`, the SAME quote-matching ladder the comment
+	 * overlay's fallback resolver uses, including the anchor-context check.
+	 * A naive `includes(quote)` here once let a thread whose passage was
+	 * deleted keep the tab dot pulsing forever just because the same string
+	 * recurred elsewhere (constant in LaTeX boilerplate) while the gutter —
+	 * which context-checks — rendered nothing. Detached threads stay out of
+	 * the tab count without being mutated: if the text comes back (Ctrl+Z),
+	 * the thread re-attaches and counts/renders again. */
+	function anchorPresentInText(anchor: CommentThread['anchor'] | undefined, text: string): boolean {
+		if (!anchor?.quote) return false;
+		return matchCommentAnchor(text, anchor) !== null;
 	}
 
 	function materializedRoundsForTab(
@@ -431,7 +437,7 @@
 			getCommentsMapForTab(id).forEach((t) => {
 				if (t.resolved) return;
 				if (!t.messages.some((m) => m.author === 'agent')) return;
-				if (!anchorPresentInText(t.anchor?.quote ?? '', tabText)) return;
+				if (!anchorPresentInText(t.anchor, tabText)) return;
 				threads.push(t);
 			});
 			if (threads.length > 0) {


### PR DESCRIPTION
## Summary

Consolidates the comment thread anchor quote-matching logic into a single shared implementation (`matchCommentAnchor` in `ydoc-codec.ts`) used by both the comment overlay's fallback resolver and the per-tab thread counting that drives TabBar dots. This prevents the two from drifting and disagreeing about which threads are attached.

## Key Changes

- **Extract shared quote-matching ladder** (`matchCommentAnchor`, `nthIndexOf`, helper functions) from `comment-overlay.ts` to `ydoc-codec.ts`:
  - Tries full quote at `occurrenceIndex`, falls back to first occurrence
  - Falls back to first non-empty line for multi-line quotes
  - Validates context match (before/after) when stored, skipping context check only for first-line fallback
  - Returns `AnchorQuoteMatch` interface with matched index and quote text

- **Update comment overlay** (`comment-overlay.ts`):
  - Import and use `matchCommentAnchor` instead of inline quote-matching logic
  - Simplifies `resolveAnchorPMRange` by delegating to the shared function

- **Update TabBar thread counting** (`+page.svelte`):
  - Replace naive `anchorPresentInText` (which only checked `includes(quote)`) with call to `matchCommentAnchor`
  - Now uses the same context-aware matching as the gutter, preventing false positives when a deleted passage's text recurs elsewhere

- **Update server-side anchor creation** (`mcp-doc-tools.ts`, `tool-handlers.ts`):
  - Replace local `nthOccurrenceIndex` with imported `nthIndexOf`
  - Ensure server-created anchors capture context via `captureAnchorContext` (already done in `mcp-doc-tools.ts`; now added to `tool-handlers.ts` for consistency)

- **Update store documentation** (`stores.ts`):
  - Clarify that `allTabCommentThreads` filters to only attached threads using the same matching logic as the gutter

## Notable Details

The context-matching check is critical: a thread whose passage was deleted should not re-attach to an unrelated occurrence of the same string elsewhere (e.g., boilerplate LaTeX). The first-line fallback for multi-line quotes skips the context check because stored context surrounds the full quote, not its first line. This unified implementation ensures the TabBar dots and comment gutter never disagree about thread attachment.

https://claude.ai/code/session_019LWvZ6YumBmyebcjjuAr41