### PR TITLE
Rename path parameter to file_path and enforce reply-before-edit contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ first `synced` event — on localhost this is sub-20ms.
 `/api/render` streams a single `query()` call over SSE:
 
 1. Build a multi-tab prompt:
-   - Every tab: header (path + active marker) + diff vs `kv['last_seen:<tabId>']` if it changed, else "unchanged" note. No tab content is ever inlined; the agent calls `read_doc(path)` on demand.
+   - Every tab: header (path + active marker) + diff vs `kv['last_seen:<tabId>']` if it changed, else "unchanged" note. No tab content is ever inlined; the agent calls `read_doc(file_path)` on demand.
    - First-render tab (no `last_seen`): path only — agent must `read_doc` to see content.
    Agency guidance (`conservative` / `balanced` / `aggressive`) rewires
    the "how to decide whether to edit" section.

--- a/src/lib/components/AgentDock.svelte
+++ b/src/lib/components/AgentDock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Send } from 'lucide-svelte';
+	import { MessageCircle } from 'lucide-svelte';
 	import ChatPanel from './ChatPanel.svelte';
 	import { isRendering, queuedSubmissionCount } from '$lib/stores';
 	import { tooltip } from '$lib/actions/tooltip';
@@ -34,7 +34,7 @@
 		if (!chatOpen) return;
 		function onDown(e: MouseEvent) {
 			// Check against the whole dock (button + popover), not just the
-			// popover: a mousedown on the Send button would close here and the
+			// popover: a mousedown on the Chat button would close here and the
 			// button's click would immediately toggle it back open, making the
 			// button unable to ever close the popover.
 			const target = e.target as Node | null;
@@ -59,14 +59,14 @@
 		type="button"
 		aria-pressed={chatOpen}
 		use:tooltip={queuedCount > 0
-			? `Send another message to the agent. ${queuedCount} message${queuedCount === 1 ? '' : 's'} already queued. This one will run after them.`
+			? `Chat with the agent. ${queuedCount} message${queuedCount === 1 ? '' : 's'} already queued — a new message will run after them.`
 			: rendering
-				? 'Send a follow-up message. Will be queued and run after the current render finishes.'
-				: 'Send a message to the agent. Type a request and Claude will run a render with your message as the prompt.'}
+				? 'Chat with the agent. Messages sent while it works are queued and run after the current render finishes.'
+				: 'Chat with the agent. Type a request and Claude will run a render with your message as the prompt.'}
 		onclick={toggleChat}
 	>
-		<Send size={12} />
-		<span>Send</span>
+		<MessageCircle size={12} />
+		<span>Chat</span>
 		{#if queuedCount > 0}
 			<span class="queue-badge">{queuedCount}</span>
 		{/if}

--- a/src/lib/components/AgentDockShell.svelte
+++ b/src/lib/components/AgentDockShell.svelte
@@ -152,7 +152,7 @@
 					ondblclick={handlePillDblClick}
 					use:tooltip={paused
 						? 'Agent paused — double-click to resume. Single-click does nothing while paused.'
-						: 'Open the agent dock. Double-click to pause the agent (no auto-wake / Wake up / Send).'}
+						: 'Open the agent dock. Double-click to pause the agent (no auto-wake / Wake up / chat).'}
 				>
 					<span
 						class="mascot-face"

--- a/src/lib/components/AgentModal.svelte
+++ b/src/lib/components/AgentModal.svelte
@@ -302,7 +302,7 @@
 							rows="3"
 						></textarea>
 						<div class="reject-actions">
-							<span class="hint"><kbd>{modEnterLabel}</kbd> to send · <kbd>Esc</kbd> to cancel</span>
+							<span class="hint">{modEnterLabel} to send · Esc to cancel</span>
 							<button class="btn-secondary" onclick={closeRejectFeedback}>Cancel</button>
 							<button
 								class="btn-primary"
@@ -541,20 +541,7 @@
 		margin-right: auto;
 		font-size: 11px;
 		color: var(--text-faint);
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
 		white-space: nowrap;
-	}
-	.reject-actions .hint kbd {
-		font-family: inherit;
-		font-size: 10px;
-		line-height: 1;
-		padding: 2px 5px;
-		border: 1px solid var(--border-light);
-		border-radius: 4px;
-		background: var(--bg-surface);
-		color: var(--text-secondary);
 	}
 	.question-header {
 		font-size: 11px;

--- a/src/lib/components/AgentModal.svelte
+++ b/src/lib/components/AgentModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Check, HelpCircle, Sparkles, X } from 'lucide-svelte';
+	import { modEnterLabel } from '$lib/keyboard';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import {
@@ -301,7 +302,7 @@
 							rows="3"
 						></textarea>
 						<div class="reject-actions">
-							<span class="hint">⌘↵ to send · Esc to cancel</span>
+							<span class="hint"><kbd>{modEnterLabel}</kbd> to send · <kbd>Esc</kbd> to cancel</span>
 							<button class="btn-secondary" onclick={closeRejectFeedback}>Cancel</button>
 							<button
 								class="btn-primary"
@@ -540,6 +541,20 @@
 		margin-right: auto;
 		font-size: 11px;
 		color: var(--text-faint);
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		white-space: nowrap;
+	}
+	.reject-actions .hint kbd {
+		font-family: inherit;
+		font-size: 10px;
+		line-height: 1;
+		padding: 2px 5px;
+		border: 1px solid var(--border-light);
+		border-radius: 4px;
+		background: var(--bg-surface);
+		color: var(--text-secondary);
 	}
 	.question-header {
 		font-size: 11px;

--- a/src/lib/components/AgentModal.svelte
+++ b/src/lib/components/AgentModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Check, HelpCircle, Sparkles, X } from 'lucide-svelte';
-	import { modEnterToSend } from '$lib/keyboard';
+	import { isModEnter, modEnterToSend } from '$lib/keyboard';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import {
@@ -69,7 +69,7 @@
 			closeRejectFeedback();
 			return;
 		}
-		if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+		if (isModEnter(e)) {
 			e.preventDefault();
 			submitRejectFeedback(planId);
 		}

--- a/src/lib/components/AgentModal.svelte
+++ b/src/lib/components/AgentModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Check, HelpCircle, Sparkles, X } from 'lucide-svelte';
-	import { modEnterLabel } from '$lib/keyboard';
+	import { modEnterToSend } from '$lib/keyboard';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import {
@@ -302,7 +302,7 @@
 							rows="3"
 						></textarea>
 						<div class="reject-actions">
-							<span class="hint">{modEnterLabel} to send · Esc to cancel</span>
+							<span class="kbd-hint reject-hint">{modEnterToSend} · Esc to cancel</span>
 							<button class="btn-secondary" onclick={closeRejectFeedback}>Cancel</button>
 							<button
 								class="btn-primary"
@@ -537,11 +537,8 @@
 		justify-content: flex-end;
 		gap: 8px;
 	}
-	.reject-actions .hint {
+	.reject-actions .reject-hint {
 		margin-right: auto;
-		font-size: 11px;
-		color: var(--text-faint);
-		white-space: nowrap;
 	}
 	.question-header {
 		font-size: 11px;

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { Send, X, Image } from 'lucide-svelte';
-	import { modEnterLabel } from '$lib/keyboard';
+	import { modEnterToSend } from '$lib/keyboard';
 	import {
 		ALLOWED_IMAGE_TYPES,
 		type AllowedImageMediaType,
@@ -171,7 +171,7 @@
 			<span>Plan first</span>
 		</label>
 		<div class="footer-right">
-			<span class="hint">{modEnterLabel} to send</span>
+			<span class="kbd-hint">{modEnterToSend}</span>
 			<button class="send-btn" onclick={send} disabled={!message.trim() && attachedImages.length === 0}>
 				<Send size={12} />
 				{#if rendering}
@@ -348,11 +348,6 @@
 	.plan-toggle input {
 		margin: 0;
 		cursor: pointer;
-	}
-	.hint {
-		font-size: 11px;
-		color: var(--text-faint);
-		white-space: nowrap;
 	}
 	.send-btn {
 		display: inline-flex;

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { Send, X, Image } from 'lucide-svelte';
-	import { modEnterToSend } from '$lib/keyboard';
+	import { isModEnter, modEnterToSend } from '$lib/keyboard';
 	import {
 		ALLOWED_IMAGE_TYPES,
 		type AllowedImageMediaType,
@@ -43,7 +43,7 @@
 	}
 
 	function onKeyDown(e: KeyboardEvent) {
-		if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+		if (isModEnter(e)) {
 			e.preventDefault();
 			send();
 		}

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -171,7 +171,7 @@
 			<span>Plan first</span>
 		</label>
 		<div class="footer-right">
-			<span class="hint"><kbd>{modEnterLabel}</kbd> to send</span>
+			<span class="hint">{modEnterLabel} to send</span>
 			<button class="send-btn" onclick={send} disabled={!message.trim() && attachedImages.length === 0}>
 				<Send size={12} />
 				{#if rendering}
@@ -352,20 +352,7 @@
 	.hint {
 		font-size: 11px;
 		color: var(--text-faint);
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
 		white-space: nowrap;
-	}
-	.hint kbd {
-		font-family: inherit;
-		font-size: 10px;
-		line-height: 1;
-		padding: 2px 5px;
-		border: 1px solid var(--border-light);
-		border-radius: 4px;
-		background: var(--bg-surface);
-		color: var(--text-secondary);
 	}
 	.send-btn {
 		display: inline-flex;

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { Send, X, Image } from 'lucide-svelte';
+	import { modEnterLabel } from '$lib/keyboard';
 	import {
 		ALLOWED_IMAGE_TYPES,
 		type AllowedImageMediaType,
@@ -170,7 +171,7 @@
 			<span>Plan first</span>
 		</label>
 		<div class="footer-right">
-			<span class="hint">⌘↵ to send</span>
+			<span class="hint"><kbd>{modEnterLabel}</kbd> to send</span>
 			<button class="send-btn" onclick={send} disabled={!message.trim() && attachedImages.length === 0}>
 				<Send size={12} />
 				{#if rendering}
@@ -351,6 +352,20 @@
 	.hint {
 		font-size: 11px;
 		color: var(--text-faint);
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		white-space: nowrap;
+	}
+	.hint kbd {
+		font-family: inherit;
+		font-size: 10px;
+		line-height: 1;
+		padding: 2px 5px;
+		border: 1px solid var(--border-light);
+		border-radius: 4px;
+		background: var(--bg-surface);
+		color: var(--text-secondary);
 	}
 	.send-btn {
 		display: inline-flex;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -465,6 +465,26 @@
 			)
 	);
 
+	// Keep the newest message visible: when a message lands on the open
+	// thread — the user's own reply syncing back, or the agent's response —
+	// scroll the card's message list to the bottom. Counts are tracked per
+	// thread so the first open of a card doesn't jump; only growth after
+	// that (including messages that arrived while the card was closed)
+	// scrolls.
+	const seenMsgCounts = new Map<string, number>();
+	$effect(() => {
+		const id = openThreadId;
+		if (!id) return;
+		const count = threads.find((t) => t.id === id)?.messages.length ?? 0;
+		const prev = seenMsgCounts.get(id);
+		seenMsgCounts.set(id, count);
+		if (prev === undefined || count <= prev) return;
+		requestAnimationFrame(() => {
+			const list = gutterEl?.querySelector('.gutter-card.expanded .card-messages');
+			if (list) list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
+		});
+	});
+
 	async function sendReply(thread: CommentThread) {
 		const text = (replyDrafts[thread.id] ?? '').trim();
 		if (!text || replying[thread.id]) return;
@@ -694,9 +714,10 @@
 									>
 										<Copy size={11} />
 									</button>
-									<button class="mini-btn reject" title="Reject this edit" onclick={() => onRejectRound(ed.id)}>
-										<X size={12} />
-									</button>
+									<!-- No per-edit reject on thread cards: the natural "no" is a
+									     follow-up reply asking for a revision (or Resolve, which
+									     drops the thread's pending edits). Loose edit cards keep
+									     their X — they have no reply box. -->
 									<button
 										class="mini-btn accept"
 										title={ed.stale ? 'Stale — can no longer apply' : 'Accept this edit'}

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { Send, Sparkles, Cat, Check, Copy, X, User } from 'lucide-svelte';
+	import { modEnterLabel } from '$lib/keyboard';
 
 	/** Minimal inline markdown → HTML. Matches the renderer used in
 	 * HistoryPane so assistant_text and comments look the same. Escapes
@@ -739,8 +740,12 @@
 						{thread.resolved ? 'Reopen' : 'Resolve'}
 					</button>
 					<div class="card-actions-right">
+						<kbd class="send-kbd" title="Pressing {modEnterLabel} in the reply box also sends"
+							>{modEnterLabel}</kbd
+						>
 						<button
 							class="send-btn"
+							title="Send reply ({modEnterLabel})"
 							onclick={() => sendReply(thread)}
 							disabled={replying[thread.id] || !(replyDrafts[thread.id] ?? '').trim()}
 						>
@@ -1159,6 +1164,20 @@
 	}
 	.resolve-link:disabled {
 		opacity: 0.5;
+		cursor: default;
+	}
+	/* Keycap hint beside Send — ⌘↵ / Ctrl+↵ in the reply box also
+	 * submits, and nothing else on the card says so. */
+	.send-kbd {
+		font-family: inherit;
+		font-size: 10px;
+		line-height: 1;
+		padding: 2px 5px;
+		border: 1px solid var(--border-light);
+		border-radius: 4px;
+		background: var(--bg-surface);
+		color: var(--text-faint);
+		white-space: nowrap;
 		cursor: default;
 	}
 	.send-btn {

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { Send, Sparkles, Cat, Check, Copy, X, User } from 'lucide-svelte';
-	import { modEnterLabel } from '$lib/keyboard';
+	import { modEnterToSend } from '$lib/keyboard';
 
 	/** Minimal inline markdown → HTML. Matches the renderer used in
 	 * HistoryPane so assistant_text and comments look the same. Escapes
@@ -465,25 +465,26 @@
 			)
 	);
 
-	// Keep the newest message visible: when a message lands on the open
-	// thread — the user's own reply syncing back, or the agent's response —
-	// scroll the card's message list to the bottom. Counts are tracked per
-	// thread so the first open of a card doesn't jump; only growth after
-	// that (including messages that arrived while the card was closed)
-	// scrolls.
+	// Keep the newest message visible: attached to the open card's message
+	// list (use:followNewMessages), scroll to the bottom when a message
+	// lands — the user's own reply syncing back, or the agent's response.
+	// Counts are remembered per thread across open/close so the first open
+	// of a card doesn't jump; only growth after that (including messages
+	// that arrived while the card was closed) scrolls.
 	const seenMsgCounts = new Map<string, number>();
-	$effect(() => {
-		const id = openThreadId;
-		if (!id) return;
-		const count = threads.find((t) => t.id === id)?.messages.length ?? 0;
-		const prev = seenMsgCounts.get(id);
-		seenMsgCounts.set(id, count);
-		if (prev === undefined || count <= prev) return;
-		requestAnimationFrame(() => {
-			const list = gutterEl?.querySelector('.gutter-card.expanded .card-messages');
-			if (list) list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
-		});
-	});
+	function followNewMessages(node: HTMLElement, params: { id: string; count: number }) {
+		const track = ({ id, count }: { id: string; count: number }) => {
+			const prev = seenMsgCounts.get(id);
+			seenMsgCounts.set(id, count);
+			if (prev !== undefined && count > prev) {
+				requestAnimationFrame(() =>
+					node.scrollTo({ top: node.scrollHeight, behavior: 'smooth' })
+				);
+			}
+		};
+		track(params);
+		return { update: track };
+	}
 
 	async function sendReply(thread: CommentThread) {
 		const text = (replyDrafts[thread.id] ?? '').trim();
@@ -618,7 +619,10 @@
 						/>
 					</span>
 				{/if}
-				<div class="card-messages">
+				<div
+					class="card-messages"
+					use:followNewMessages={{ id: thread.id, count: thread.messages.length }}
+				>
 					{#each thread.messages as message (message.id)}
 						{@const rv = message.author === 'agent' ? messageReviewer(message) : null}
 						<div class="message" class:from-agent={message.author === 'agent'} class:from-user={message.author === 'user'}>
@@ -761,10 +765,9 @@
 						{thread.resolved ? 'Reopen' : 'Resolve'}
 					</button>
 					<div class="card-actions-right">
-						<span class="send-hint">{modEnterLabel} to send</span>
+						<span class="kbd-hint">{modEnterToSend}</span>
 						<button
 							class="send-btn"
-							title="Send reply ({modEnterLabel})"
 							onclick={() => sendReply(thread)}
 							disabled={replying[thread.id] || !(replyDrafts[thread.id] ?? '').trim()}
 						>
@@ -1184,14 +1187,6 @@
 	.resolve-link:disabled {
 		opacity: 0.5;
 		cursor: default;
-	}
-	/* Shortcut hint beside Send — ⌘↵ / Ctrl+↵ in the reply box also
-	 * submits, and nothing else on the card says so. Plain muted text,
-	 * not a keycap box: a box next to a real button reads as clickable. */
-	.send-hint {
-		font-size: 11px;
-		color: var(--text-faint);
-		white-space: nowrap;
 	}
 	.send-btn {
 		display: inline-flex;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -761,9 +761,7 @@
 						{thread.resolved ? 'Reopen' : 'Resolve'}
 					</button>
 					<div class="card-actions-right">
-						<kbd class="send-kbd" title="Pressing {modEnterLabel} in the reply box also sends"
-							>{modEnterLabel}</kbd
-						>
+						<span class="send-hint">{modEnterLabel} to send</span>
 						<button
 							class="send-btn"
 							title="Send reply ({modEnterLabel})"
@@ -1187,19 +1185,13 @@
 		opacity: 0.5;
 		cursor: default;
 	}
-	/* Keycap hint beside Send — ⌘↵ / Ctrl+↵ in the reply box also
-	 * submits, and nothing else on the card says so. */
-	.send-kbd {
-		font-family: inherit;
-		font-size: 10px;
-		line-height: 1;
-		padding: 2px 5px;
-		border: 1px solid var(--border-light);
-		border-radius: 4px;
-		background: var(--bg-surface);
+	/* Shortcut hint beside Send — ⌘↵ / Ctrl+↵ in the reply box also
+	 * submits, and nothing else on the card says so. Plain muted text,
+	 * not a keycap box: a box next to a real button reads as clickable. */
+	.send-hint {
+		font-size: 11px;
 		color: var(--text-faint);
 		white-space: nowrap;
-		cursor: default;
 	}
 	.send-btn {
 		display: inline-flex;

--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { Send, Sparkles, Cat, Check, Copy, X, User } from 'lucide-svelte';
-	import { modEnterToSend } from '$lib/keyboard';
+	import { isModEnter, modEnterToSend } from '$lib/keyboard';
 
 	/** Minimal inline markdown → HTML. Matches the renderer used in
 	 * HistoryPane so assistant_text and comments look the same. Escapes
@@ -747,7 +747,7 @@
 						};
 					}}
 					onkeydown={(e) => {
-						if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+						if (isModEnter(e)) {
 							e.preventDefault();
 							void sendReply(thread);
 						}

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -3,6 +3,7 @@
 	import { cubicOut } from 'svelte/easing';
 	import { AlertTriangle } from 'lucide-svelte';
 	import { dialogQueue, resolveDialog, type DialogSpec } from '$lib/dialogs';
+	import { isModEnter } from '$lib/keyboard';
 
 	let queue = $state<DialogSpec[]>([]);
 	dialogQueue.subscribe((v) => (queue = v));
@@ -33,7 +34,7 @@
 			// Alert-style dialogs (no cancel) resolve true on Escape — the
 			// user is just dismissing the notice.
 			resolveDialog(active.id, !active.cancelLabel);
-		} else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey || !active.cancelLabel)) {
+		} else if (isModEnter(e) || (e.key === 'Enter' && !active.cancelLabel)) {
 			e.preventDefault();
 			resolveDialog(active.id, true);
 		}

--- a/src/lib/components/HistoryPane.svelte
+++ b/src/lib/components/HistoryPane.svelte
@@ -3,7 +3,7 @@
 	import { flip } from 'svelte/animate';
 	import { cubicOut } from 'svelte/easing';
 	import { marked } from 'marked';
-	import { FileEdit, User, Bot, Play, CheckCircle, XCircle, Eye, Terminal, Maximize2, X, RotateCcw, MessagesSquare, Cat, Sparkles, BellOff, Bell, ChevronDown, Pause } from 'lucide-svelte';
+	import { FileEdit, User, Bot, Play, CheckCircle, XCircle, Eye, Terminal, Maximize2, X, RotateCcw, ScrollText, Cat, Sparkles, BellOff, Bell, ChevronDown, Pause } from 'lucide-svelte';
 	import type { HistoryEntry } from '$lib/types';
 	import { agentHistory, isRendering, historyVerbosity, sessionCost, agentSettings, pendingReviewRounds, submitCountdown, activeReviewer, type SessionCost } from '$lib/stores';
 	import type { HistoryVerbosity } from '$lib/stores';
@@ -141,7 +141,7 @@
 	let agentTooltip = $derived.by(() => {
 		const pauseHint = 'Double-click to pause or resume the agent.';
 		const action = paused
-			? `Agent paused — no auto-wake, Wake up, or Send until you resume. ${pauseHint}`
+			? `Agent paused — no auto-wake, Wake up, or chat messages until you resume. ${pauseHint}`
 			: rendering
 				? `Click to stop the agent and cancel any queued messages. ${pauseHint}`
 				: `Wake up the agent. It reviews the open files, reacts to any pending changes, and proposes edits or comments based on the current agency setting. ${pauseHint}`;
@@ -449,7 +449,7 @@
 					aria-label="Transcript"
 					use:tooltip={'Open the current session transcript. Shows user messages, agent responses, tool calls, and tool results.'}
 				>
-					<MessagesSquare size={12} />
+					<ScrollText size={12} />
 				</button>
 				{@render dock()}
 				<button
@@ -901,7 +901,7 @@
 		flex: 0 0 auto;
 	}
 	/* Shared pill-button chrome — applied to all 3 action buttons in
-	 * the trailing group (Wake from AgentDock, Send from AgentDock,
+	 * the trailing group (Wake from AgentDock, Chat from AgentDock,
 	 * New session from this component). Icon + text label, ghost until
 	 * hovered. :global() so the AgentDock's buttons inherit it. */
 	/* ShineBorder (BorderBeam) inline so it sits flush in the flex row. */

--- a/src/lib/components/HistoryPane.svelte
+++ b/src/lib/components/HistoryPane.svelte
@@ -12,6 +12,7 @@
 	import ReviewerMascot from './ReviewerMascot.svelte';
 	import ShineBorder from './ShineBorder.svelte';
 	import { tooltip } from '$lib/actions/tooltip';
+	import { modEnterLabel } from '$lib/keyboard';
 
 	let transcriptOpen = $state(false);
 
@@ -415,7 +416,7 @@
 						{:else if rendering}
 							<span class="bounce-dots"><span>.</span><span>.</span><span>.</span></span>
 						{:else if countdown > 0}
-							<span class="countdown" title="Auto-wake in {countdown}s — click Wake up to skip">{countdown}s</span>
+							<span class="countdown" title="Auto-wake in {countdown}s — click Wake up or press {modEnterLabel} in the editor to skip">{countdown}s</span>
 						{:else}
 							<span class="sleep-dots"><span>z</span><span>z</span><span>z</span></span>
 						{/if}

--- a/src/lib/components/ReviewerEditorDialog.svelte
+++ b/src/lib/components/ReviewerEditorDialog.svelte
@@ -3,6 +3,7 @@
 	import { cubicOut } from 'svelte/easing';
 	import ReviewerMascot from './ReviewerMascot.svelte';
 	import { REVIEWER_ICONS, REVIEWER_COLORS, type Reviewer } from '$lib/shared/reviewers';
+	import { isModEnter } from '$lib/keyboard';
 
 	interface Props {
 		open: boolean;
@@ -63,7 +64,7 @@
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			close();
-		} else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+		} else if (isModEnter(e)) {
 			e.preventDefault();
 			void save();
 		}

--- a/src/lib/components/RulesPillBar.svelte
+++ b/src/lib/components/RulesPillBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { X, Plus, Play, BookOpen } from 'lucide-svelte';
 	import { rules, pushHistory } from '$lib/stores';
+	import { isModEnter } from '$lib/keyboard';
 	import type { Rule } from '$lib/types';
 
 	interface Props {
@@ -169,7 +170,7 @@
 	}
 
 	function handleEditKeydown(e: KeyboardEvent, id: string) {
-		if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+		if (isModEnter(e)) {
 			e.preventDefault();
 			saveEditedRule(id);
 		}

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -60,6 +60,7 @@
 		showAiProvenance
 	} from '$lib/stores';
 	import type { Action, CommentThread, FeedbackMode } from '$lib/types';
+	import { isModEnter } from '$lib/keyboard';
 	import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
 
 	const IDLE_MS = 3_000;
@@ -1366,7 +1367,7 @@
 					// Cmd/Ctrl+Enter wakes the agent immediately, skipping the
 					// idle countdown. Plain Enter still inserts a new line.
 					// No-op while paused — same gate as Wake up / chat.
-					if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+					if (isModEnter(event)) {
 						event.preventDefault();
 						if ($agentSettings.paused) return true;
 						if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -349,7 +349,7 @@
 		if (!editor || !editor.isFocused) return;
 		// No feedback while the agent is paused: a paused agent won't act on
 		// edits or comments, so the selection popup would be a dead end. Same
-		// gate as Wake up / Send / auto-wake.
+		// gate as Wake up / chat / auto-wake.
 		if ($agentSettings.paused) {
 			dismissedFeedbackSelectionRange = null;
 			feedbackPopup = null;
@@ -1365,7 +1365,7 @@
 					if (handleSourceCommentShortcut(event)) return true;
 					// Cmd/Ctrl+Enter wakes the agent immediately, skipping the
 					// idle countdown. Plain Enter still inserts a new line.
-					// No-op while paused — same gate as Wake up / Send.
+					// No-op while paused — same gate as Wake up / chat.
 					if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
 						event.preventDefault();
 						if ($agentSettings.paused) return true;

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -13,3 +13,8 @@ const isApplePlatform =
 
 /** "⌘↵" on Apple platforms, "Ctrl+↵" elsewhere. */
 export const modEnterLabel = isApplePlatform ? '⌘↵' : 'Ctrl+↵';
+
+/** The standard send-surface hint ("⌘↵ to send"), composed once so every
+ * Send button shows identical wording. Style it with the shared
+ * `.kbd-hint` class (+layout.svelte). */
+export const modEnterToSend = `${modEnterLabel} to send`;

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -18,3 +18,12 @@ export const modEnterLabel = isApplePlatform ? '⌘↵' : 'Ctrl+↵';
  * Send button shows identical wording. Style it with the shared
  * `.kbd-hint` class (+layout.svelte). */
 export const modEnterToSend = `${modEnterLabel} to send`;
+
+/** True when a keyboard event is the send/submit shortcut the labels
+ * above advertise. Both modifiers are accepted on every platform (only
+ * the label is platform-specific) so muscle memory works across OSes.
+ * Keep every submit-on-Enter handler on this predicate — a hand-rolled
+ * variant that drifts would contradict the rendered hint. */
+export function isModEnter(e: KeyboardEvent): boolean {
+	return e.key === 'Enter' && (e.metaKey || e.ctrlKey);
+}

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,0 +1,15 @@
+/**
+ * Platform-aware keyboard-shortcut labels for UI hints.
+ *
+ * Every send/submit shortcut in the app accepts both modifiers
+ * (`e.key === 'Enter' && (e.metaKey || e.ctrlKey)`), but the label users
+ * see should match their platform — "⌘↵" means nothing on Windows/Linux.
+ * SSR has no `navigator`; the server renders the Ctrl fallback and the
+ * browser corrects it during hydration.
+ */
+const isApplePlatform =
+	typeof navigator !== 'undefined' &&
+	/Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent);
+
+/** "⌘↵" on Apple platforms, "Ctrl+↵" elsewhere. */
+export const modEnterLabel = isApplePlatform ? '⌘↵' : 'Ctrl+↵';

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -164,6 +164,13 @@ export function setActiveFeedbackThreadId(id: string | null) {
 	activeFeedbackThreadId = id;
 }
 
+/** The enforcement promise interpolated into the system prompt's "Announce
+ * edits on a thread" section. Defined here, beside the runTabWrite gate
+ * that enforces it, so the prompt and the enforcement can't drift apart —
+ * change the gate's behavior and this sentence in the same place. */
+export const REPLY_BEFORE_EDIT_PROMPT_NOTE =
+	"This is enforced: while a thread's latest message is the user's, edit_doc and write_doc targeting it fail until you have replied.";
+
 /** Reviewer running the current critique pass, if any. Set by /api/render
  * for the duration of a critique render (same lifecycle as
  * `activeFeedbackThreadId`) and stamped onto every review round and
@@ -200,33 +207,34 @@ export async function runTabWrite(
 				result = { beforeMd, afterMd };
 				return;
 			}
-			// If this edit targets a feedback thread the user already RESOLVED
-			// (e.g. they resolved while the agent was still thinking), the user
-			// is done with it — toss the edit instead of reviving a resolved
-			// thread with a new proposal.
+			// Edits targeting a feedback thread pass two gates. (1) The user
+			// already RESOLVED it (e.g. while the agent was still thinking):
+			// they are done with it — toss the edit instead of reviving the
+			// thread with a new proposal. (2) The prompt's "Announce edits on
+			// a thread" contract: if the thread's latest message is the
+			// user's, the agent hasn't said anything about this proposal yet,
+			// and letting it land would show a bare diff with no explanation.
+			// Bounce the write with instructions; the agent replies on the
+			// thread and retries. The error string is the whole contract
+			// because every provider path (MCP tools and tool-handlers.ts)
+			// surfaces it verbatim — which is also why it names no parameter
+			// syntax: the surfaces' reply_to_comment schemas differ.
 			const targetThreadId = activeFeedbackThreadId ?? undefined;
-			if (targetThreadId && getCommentsMap(doc).get(targetThreadId)?.resolved) {
-				result = { beforeMd, afterMd: beforeMd, discarded: true };
-				return;
-			}
-			// The prompt's "Announce edits on a thread" contract, enforced: if
-			// the thread's latest message is the user's, the agent hasn't said
-			// anything about this proposal yet, and letting it land would show
-			// the user a bare diff with no explanation. Bounce the write with
-			// instructions; the agent replies on the thread and retries. The
-			// error string is the whole contract because every provider path
-			// (MCP tools and tool-handlers.ts) surfaces it verbatim.
 			if (targetThreadId) {
 				const thread = getCommentsMap(doc).get(targetThreadId);
+				if (thread?.resolved) {
+					result = { beforeMd, afterMd: beforeMd, discarded: true };
+					return;
+				}
 				const lastMessage = thread?.messages[thread.messages.length - 1];
 				if (lastMessage?.author === 'user') {
 					result = {
 						error:
 							`the user's latest message on thread "${targetThreadId}" has no reply yet, ` +
-							`so this proposal would land as a bare diff with no explanation. First call ` +
-							`reply_to_comment(file_path: "${tabId}", thread_id: "${targetThreadId}") with one ` +
-							`or two first-person sentences — what you make of the user's feedback and what ` +
-							`you are changing — then retry this exact call.`
+							`so this proposal would land as a bare diff with no explanation. First reply ` +
+							`on that thread with reply_to_comment — one or two first-person sentences on ` +
+							`what you make of the user's feedback and what you are changing — then retry ` +
+							`this exact call.`
 					};
 					return;
 				}

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -209,6 +209,28 @@ export async function runTabWrite(
 				result = { beforeMd, afterMd: beforeMd, discarded: true };
 				return;
 			}
+			// The prompt's "Announce edits on a thread" contract, enforced: if
+			// the thread's latest message is the user's, the agent hasn't said
+			// anything about this proposal yet, and letting it land would show
+			// the user a bare diff with no explanation. Bounce the write with
+			// instructions; the agent replies on the thread and retries. The
+			// error string is the whole contract because every provider path
+			// (MCP tools and tool-handlers.ts) surfaces it verbatim.
+			if (targetThreadId) {
+				const thread = getCommentsMap(doc).get(targetThreadId);
+				const lastMessage = thread?.messages[thread.messages.length - 1];
+				if (lastMessage?.author === 'user') {
+					result = {
+						error:
+							`the user's latest message on thread "${targetThreadId}" has no reply yet, ` +
+							`so this proposal would land as a bare diff with no explanation. First call ` +
+							`reply_to_comment(file_path: "${tabId}", thread_id: "${targetThreadId}") with one ` +
+							`or two first-person sentences — what you make of the user's feedback and what ` +
+							`you are changing — then retry this exact call.`
+					};
+					return;
+				}
+			}
 			doc.transact(() => {
 				const reviewArr = getReviewArray(doc);
 				const threadIdExplicit = activeFeedbackThreadId ?? undefined;

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -106,7 +106,7 @@ function buildDocwriterMcp() {
 			'review_action',
 			'Accept or reject pending edits, or resolve or reopen comment threads, only when the user\'s current message explicitly asks for that action. This mutates document review state.',
 			{
-				path: z.string().describe('Workspace-relative path or absolute path inside the workspace.'),
+				file_path: z.string().describe('Workspace-relative path or absolute path inside the workspace.'),
 				action: z.enum(['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread']).describe('The explicit review action requested by the user.'),
 				round_id: z.string().optional().describe('Required for accept_round or reject_round.'),
 				thread_id: z.string().optional().describe('Required for resolve_thread or reopen_thread.')

--- a/src/lib/server/providers/tool-handlers.ts
+++ b/src/lib/server/providers/tool-handlers.ts
@@ -53,14 +53,14 @@ function toToolResult(r: any): ToolResult {
 }
 
 export async function executeReviewAction(input: unknown): Promise<ToolResult> {
-	const { path, action, round_id, thread_id } = input as {
-		path?: string;
+	const { file_path: path, action, round_id, thread_id } = input as {
+		file_path?: string;
 		action?: string;
 		round_id?: string;
 		thread_id?: string;
 	};
 	if (!path) {
-		return { isError: true, content: [{ type: 'text' as const, text: 'review_action requires `path`.' }] };
+		return { isError: true, content: [{ type: 'text' as const, text: 'review_action requires `file_path`.' }] };
 	}
 	const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
 	if (!opened.ok) return toToolResult(opened.error);
@@ -134,19 +134,22 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string', description: 'Workspace-relative tab id, absolute path, or scratch path.' },
+					file_path: { type: 'string', description: 'Workspace-relative tab id, absolute path, or scratch path.' },
 					old_string: { type: 'string', description: 'Exact substring to replace.' },
 					new_string: { type: 'string', description: 'The replacement string.' },
 					replace_all: { type: 'boolean', description: 'Replace all occurrences.' },
 					thread_id: { type: 'string', description: 'Attach this edit to an existing comment thread.' }
 				},
-				required: ['path', 'old_string', 'new_string']
+				required: ['file_path', 'old_string', 'new_string']
 			},
 			execute: async (input) => {
-				const { path, old_string, new_string, replace_all, thread_id } = input as {
-					path: string; old_string: string; new_string: string;
+				const { file_path: path, old_string, new_string, replace_all, thread_id } = input as {
+					file_path: string; old_string: string; new_string: string;
 					replace_all?: boolean; thread_id?: string;
 				};
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'edit_doc requires `file_path`.' }] };
+				}
 				const replaceAll = replace_all === true;
 				const normOld = normalizeTypography(old_string);
 				const normNew = normalizeTypography(new_string);
@@ -206,12 +209,15 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string', description: 'Tab id, absolute path, or scratch path.' }
+					file_path: { type: 'string', description: 'Tab id, absolute path, or scratch path.' }
 				},
-				required: ['path']
+				required: ['file_path']
 			},
 			execute: async (input) => {
-				const { path } = input as { path: string };
+				const { file_path: path } = input as { file_path: string };
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'read_doc requires `file_path`.' }] };
+				}
 				if (isScratchPath(path)) return toToolResult(readScratch(path));
 				const tabId = resolveTabFromPath(path);
 				if (tabId && isOpenTab(tabId)) {
@@ -254,13 +260,16 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string', description: 'Workspace-relative path or scratch path.' },
+					file_path: { type: 'string', description: 'Workspace-relative path or scratch path.' },
 					content: { type: 'string', description: 'The new full content.' }
 				},
-				required: ['path', 'content']
+				required: ['file_path', 'content']
 			},
 			execute: async (input) => {
-				const { path, content } = input as { path: string; content: string };
+				const { file_path: path, content } = input as { file_path: string; content: string };
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'write_doc requires `file_path`.' }] };
+				}
 				if (isScratchPath(path)) return toToolResult(writeScratch(path, content));
 				const normalized = normalizeTypography(content);
 				const opened = ensureWorkspaceTabOpen(path, { createIfMissing: true });
@@ -343,7 +352,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string', description: 'Workspace-relative path or absolute path inside the workspace.' },
+					file_path: { type: 'string', description: 'Workspace-relative path or absolute path inside the workspace.' },
 					action: {
 						type: 'string',
 						enum: ['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread'],
@@ -352,7 +361,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 					round_id: { type: 'string', description: 'Required for accept_round or reject_round.' },
 					thread_id: { type: 'string', description: 'Required for resolve_thread or reopen_thread.' }
 				},
-				required: ['path', 'action']
+				required: ['file_path', 'action']
 			},
 			execute: executeReviewAction
 		},
@@ -396,7 +405,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string', description: 'Workspace-relative tab id or absolute path.' },
+					file_path: { type: 'string', description: 'Workspace-relative tab id or absolute path.' },
 					anchor_text: { type: 'string', description: 'Exact current document text to anchor the comment to.' },
 					message: { type: 'string', description: 'The comment text.' },
 					occurrence_index: { type: 'number', description: 'Zero-based occurrence when anchor_text appears more than once.' },
@@ -408,16 +417,19 @@ export function buildToolDefinitions(): ToolDefinition[] {
 						required: ['old_string', 'new_string']
 					}
 				},
-				required: ['path', 'anchor_text', 'message']
+				required: ['file_path', 'anchor_text', 'message']
 			},
 			execute: async (input) => {
-				const { path, anchor_text, message: msg, occurrence_index, proposed_edit } = input as {
-					path: string;
+				const { file_path: path, anchor_text, message: msg, occurrence_index, proposed_edit } = input as {
+					file_path: string;
 					anchor_text: string;
 					message: string;
 					occurrence_index?: number;
 					proposed_edit?: { old_string: string; new_string: string };
 				};
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'comment_doc requires `file_path`.' }] };
+				}
 				if (isScratchPath(path)) return { isError: true, content: [{ type: 'text' as const, text: 'comment_doc cannot be used on scratch paths.' }] };
 				const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
 				if (!opened.ok) return toToolResult(opened.error);
@@ -487,7 +499,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			inputSchema: {
 				type: 'object',
 				properties: {
-					path: { type: 'string' },
+					file_path: { type: 'string' },
 					thread_id: { type: 'string' },
 					message: { type: 'string' },
 					proposed_edit: {
@@ -496,13 +508,16 @@ export function buildToolDefinitions(): ToolDefinition[] {
 						required: ['old_string', 'new_string']
 					}
 				},
-				required: ['path', 'thread_id', 'message']
+				required: ['file_path', 'thread_id', 'message']
 			},
 			execute: async (input) => {
-				const { path, thread_id, message: msg, proposed_edit } = input as {
-					path: string; thread_id: string; message: string;
+				const { file_path: path, thread_id, message: msg, proposed_edit } = input as {
+					file_path: string; thread_id: string; message: string;
 					proposed_edit?: { old_string: string; new_string: string };
 				};
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'reply_to_comment requires `file_path`.' }] };
+				}
 				if (isScratchPath(path)) return { isError: true, content: [{ type: 'text' as const, text: 'reply_to_comment cannot be used on scratch paths.' }] };
 				const opened = ensureWorkspaceTabOpen(path, { createIfMissing: false });
 				if (!opened.ok) return toToolResult(opened.error);
@@ -533,11 +548,14 @@ export function buildToolDefinitions(): ToolDefinition[] {
 			description: 'Return all open (unresolved) comment threads for a workspace tab.',
 			inputSchema: {
 				type: 'object',
-				properties: { path: { type: 'string' } },
-				required: ['path']
+				properties: { file_path: { type: 'string' } },
+				required: ['file_path']
 			},
 			execute: async (input) => {
-				const { path } = input as { path: string };
+				const { file_path: path } = input as { file_path: string };
+				if (!path) {
+					return { isError: true, content: [{ type: 'text' as const, text: 'list_threads requires `file_path`.' }] };
+				}
 				if (isScratchPath(path)) return { isError: true, content: [{ type: 'text' as const, text: 'list_threads cannot be used on scratch paths.' }] };
 				const tabId = resolveTabFromPath(path);
 				if (!tabId || !isOpenTab(tabId)) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -78,12 +78,23 @@
 		background: var(--bg);
 	}
 
+	/* Keyboard-shortcut hint rendered beside a Send button (comment reply
+	 * card, chat popover, plan-feedback footer). Plain muted text, not a
+	 * keycap box — a box next to a real button reads as clickable. Global
+	 * for the same reason as the button shells above: every send surface
+	 * stays identical without redefining the style. */
+	:global(.kbd-hint) {
+		font-size: 11px;
+		color: var(--text-faint);
+		white-space: nowrap;
+	}
+
 	/* Veil applied to right-pane content (history entries + pending
 	 * review cards) when the agent is muted. Heavy fade + blur + no
 	 * pointer events, so the user really cannot follow what the agent
 	 * is doing until they unmute. The agent dock at the top of the
 	 * pane stays unaffected so the user always has access to the
-	 * Bell / Send / Restart controls. */
+	 * Bell / Chat / New session controls. */
 	:global(.muted-veil) {
 		opacity: 0.18;
 		filter: blur(3px);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -847,7 +847,7 @@
 	}
 
 	/** Fully pause / unpause the agent. Pause cancels any in-flight render,
-	 * clears the idle countdown, and blocks Wake up / Send / auto-submit
+	 * clears the idle countdown, and blocks Wake up / chat / auto-submit
 	 * until the user double-clicks the Agent pill again. */
 	function togglePaused() {
 		let next: AgentSettings | null = null;

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -329,7 +329,7 @@ Every edit proposal needs a comment thread that says what is about to happen, so
 
 Each turn may contain these blocks, in this order.
 
-- <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and open comment threads as one-line stubs. Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
+- <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and open comment threads as one-line stubs. Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(file_path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
 - <session_state>: rules, style references, and the agency level. Sent in full on the first turn, then only when something changed. If the block is absent, nothing changed.
 - <mode>: present only in special modes, such as plan-first.
 - <user_message>: the user's words, verbatim.
@@ -399,7 +399,7 @@ The agency level arrives in session_state when it changes.
  * Content-inlining policy: never inline full content. Every tab gets a
  * header (path + active marker if it's the focused tab) plus the diff
  * since the agent's `last_seen` baseline if there is one. The agent calls
- * `read_doc(path)` to fetch full content on demand — free in-process
+ * `read_doc(file_path)` to fetch full content on demand — free in-process
  * fetch against the live Y.Doc, no token cost on the prompt side.
  *
  * The previous design re-inlined the active tab's full content on every
@@ -873,13 +873,13 @@ export const POST: RequestHandler = async ({ request }) => {
 							if (toolName === 'Read') {
 								const matched = findReferencedOpenTabPath(toolInput?.file_path, openTabPaths);
 								if (matched) {
-									return { behavior: 'deny' as const, message: 'Open tab files must be read with `read_doc(path)`.' };
+									return { behavior: 'deny' as const, message: 'Open tab files must be read with `read_doc(file_path)`.' };
 								}
 							}
 							if (toolName === 'Glob' || toolName === 'Grep') {
 								const matched = findReferencedOpenTabPath(toolInput?.path, openTabPaths);
 								if (matched) {
-									return { behavior: 'deny' as const, message: 'Use `read_doc(path)` for open tab files.' };
+									return { behavior: 'deny' as const, message: 'Use `read_doc(file_path)` for open tab files.' };
 								}
 							}
 							if (toolName === 'Bash') {

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -35,7 +35,8 @@ import {
 	COMMENT_DOC_TOOL_NAME,
 	REPLY_TO_COMMENT_TOOL_NAME,
 	setActiveFeedbackThreadId,
-	setActiveReviewerId
+	setActiveReviewerId,
+	REPLY_BEFORE_EDIT_PROMPT_NOTE
 } from '$lib/server/mcp-doc-tools';
 import { getReviewerById, buildCritiqueMessage } from '$lib/server/reviewers';
 import type { Reviewer } from '$lib/shared/reviewers';
@@ -317,7 +318,7 @@ Every file is raw text, including .md. The editor renders markdown source litera
 
 Every edit proposal needs a comment thread that says what is about to happen, so the user sees your reasoning next to the pending edit instead of a bare diff.
 
-- If the work already has a thread — user feedback arrives with a thread_id, or you are revising a thread's pending edit — use it. If you have not yet explained this edit there, reply first with reply_to_comment, then call edit_doc with that thread_id. This is enforced: while a thread's latest message is the user's, edit_doc and write_doc targeting it fail until you have replied.
+- If the work already has a thread — user feedback arrives with a thread_id, or you are revising a thread's pending edit — use it. If you have not yet explained this edit there, reply first with reply_to_comment, then call edit_doc with that thread_id. ${REPLY_BEFORE_EDIT_PROMPT_NOTE}
 - Otherwise, before the edit, call comment_doc anchored to the exact text you are about to change, with one or two first-person sentences: what prompted the edit (the user's words, an inline directive, a rule), what you think is wrong, and what you will do. Then call edit_doc with the thread_id that comment_doc returns.
 - Inline directives such as [[ ... ]] follow the same contract: anchor the thread on the directive text, say how you read the directive and what you will write, then propose the edit on that thread.
 - For write_doc on an existing file, anchor the thread to the first sentence of the text you are replacing.

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -317,7 +317,7 @@ Every file is raw text, including .md. The editor renders markdown source litera
 
 Every edit proposal needs a comment thread that says what is about to happen, so the user sees your reasoning next to the pending edit instead of a bare diff.
 
-- If the work already has a thread — user feedback arrives with a thread_id, or you are revising a thread's pending edit — use it. If you have not yet explained this edit there, reply first with reply_to_comment, then call edit_doc with that thread_id.
+- If the work already has a thread — user feedback arrives with a thread_id, or you are revising a thread's pending edit — use it. If you have not yet explained this edit there, reply first with reply_to_comment, then call edit_doc with that thread_id. This is enforced: while a thread's latest message is the user's, edit_doc and write_doc targeting it fail until you have replied.
 - Otherwise, before the edit, call comment_doc anchored to the exact text you are about to change, with one or two first-person sentences: what prompted the edit (the user's words, an inline directive, a rule), what you think is wrong, and what you will do. Then call edit_doc with the thread_id that comment_doc returns.
 - Inline directives such as [[ ... ]] follow the same contract: anchor the thread on the directive text, say how you read the directive and what you will write, then propose the edit on that thread.
 - For write_doc on an existing file, anchor the thread to the first sentence of the text you are replacing.


### PR DESCRIPTION
## Summary

This PR standardizes the `path` parameter to `file_path` across all document tool definitions and adds enforcement of the "reply before edit" contract: agents must reply on a feedback thread before proposing edits to it, preventing bare diffs without explanation.

## Key Changes

**Parameter Standardization:**
- Renamed `path` → `file_path` in all tool schemas and implementations:
  - `edit_doc`, `read_doc`, `write_doc`, `review_action`, `comment_doc`, `reply_to_comment`, `list_threads`
  - Updated both input schema definitions and destructuring in execute handlers
  - Added validation checks in each tool to return a clear error if `file_path` is missing
  - Updated error messages to reference `file_path` instead of `path`

**Reply-Before-Edit Enforcement:**
- Added `REPLY_BEFORE_EDIT_PROMPT_NOTE` constant in `mcp-doc-tools.ts` documenting the contract
- Enhanced `runTabWrite` gate in `mcp-doc-tools.ts` to check if the thread's latest message is from the user
- If user's message has no agent reply yet, the write fails with a clear error directing the agent to reply first via `reply_to_comment`, then retry
- Error message is surfaced verbatim across all provider paths (MCP tools and tool-handlers) so the contract is consistent
- Updated system prompt in `/api/render` to reference the enforcement note

**UI/UX Improvements:**
- Created new `src/lib/keyboard.ts` module for platform-aware keyboard shortcut labels
  - `modEnterLabel`: "⌘↵" on Apple, "Ctrl+↵" elsewhere
  - `modEnterToSend`: standardized hint text ("⌘↵ to send" / "Ctrl+↵ to send")
  - `isModEnter()`: predicate for detecting send/submit shortcuts
- Unified all send-button keyboard hints to use `modEnterToSend` and `.kbd-hint` CSS class
- Added `.kbd-hint` global style in `+layout.svelte` for consistent keyboard hint appearance
- Renamed "Send" button to "Chat" in `AgentDock` with updated icon and tooltips
- Added auto-scroll to newest message in comment thread cards via `followNewMessages` action
- Removed per-edit reject button from thread cards (users reply to request revisions instead)
- Updated all keyboard event handlers to use `isModEnter()` predicate for consistency

**Documentation & Messaging:**
- Updated system prompt to clarify the reply-before-edit contract
- Updated tooltips and help text throughout (e.g., "Wake up / chat / auto-wake" instead of "Wake up / Send / auto-wake")
- Added comment explaining the per-edit reject removal from thread cards

## Implementation Details

- The `file_path` rename is purely a parameter naming change with no functional impact beyond clarity
- The reply-before-edit enforcement prevents a UX issue where agents could propose edits with no explanation, leaving users confused by bare diffs
- The keyboard shortcut centralization ensures every send surface (comment replies, chat, plan feedback) shows identical hints and accepts the same key combination
- SSR-safe platform detection in `keyboard.ts` handles server rendering by defaulting to Ctrl, then hydrating to the correct platform label

https://claude.ai/code/session_01DJrrNv32dbvijnRydBVjEP