### PR TITLE
Set up Cloud dev environment + minor AGENTS.md fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ AI agent (for end-to-end testing of the headline feature):
 - The editor loads and edits without any key, but the agent loop
   (Send → propose edit → review card) needs a provider credential. Prompt
   the agent via the **Send** button (top-right of the center pane); proposed
-  edits appear as tracked changes plus an **Accept/Reject/Retry** review card
-  in the right pane. Accept writes through to `document.md`.
+ edits appear as tracked changes plus an **Accept/Reject/Retry** review card
+ floating inline near the edit in the center editor (there is no separate
+ review pane). Accept writes through to the tab's file on disk (e.g.
+ `document.md`, or whichever tab is open).
 - **Claude** (default provider) needs `ANTHROPIC_API_KEY` (a secret). Two
   non-obvious gotchas when present:
   - The `@anthropic-ai/claude-agent-sdk` ships both a glibc and a musl native


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the DocWriter development environment for Cursor Cloud and verified it end-to-end. No application code was changed; the only committed change is a small documentation correction.

## Environment setup

- Node pinned to **22.22.2** via `.nvmrc` (the system `/exec-daemon/node` 22.14.0 fails `engine-strict` for `@earendil-works/pi-ai` which needs `>=22.19.0`). Update script sources nvm, installs the pinned version, prepends its bin to `PATH`, runs `npm install` (which also downloads the pinned PDF.js viewer via the `prepare` script), and removes the musl `claude-agent-sdk` binary so the glibc one is selected.
- A one-time `~/.bashrc` pin was added during setup so future interactive shells resolve Node 22.22.2 ahead of `/exec-daemon`.

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Type-check | `npm run check` | 0 errors, 0 warnings |
| Build | `npm run build` | Built successfully (adapter-node) |
| Dev server | `npm run dev` | Vite on `:5173`, Y.Doc WS sync on `:3001` (both HTTP 200) |
| Hello-world | Agent edit via OpenAI GPT-5.5 | Proposed tracked-change accepted, written through to disk |

Hello-world task: typed markdown into the editor, prompted the AI agent (OpenAI provider / GPT-5.5, since `OPENAI_API_KEY` is set and Claude has no key) to fix a sentence, reviewed the inline tracked change, and accepted it — the corrected text wrote through to the file on disk.

[docwriter_agent_edit_end_to_end.mp4](https://cursor.com/agents/bc-39d36ff2-0601-40bb-be45-fc1885f4ff7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocwriter_agent_edit_end_to_end.mp4)
[Proposed edit review card](https://cursor.com/agents/bc-39d36ff2-0601-40bb-be45-fc1885f4ff7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocwriter_proposed_edit_review_card.webp)
[Edit accepted and applied](https://cursor.com/agents/bc-39d36ff2-0601-40bb-be45-fc1885f4ff7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocwriter_edit_accepted.webp)

## Doc change

Corrected the AGENTS.md cloud note: the review card renders as a floating inline card near the edit (per `CLAUDE.md` there is no separate review column), not "in the right pane."

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39d36ff2-0601-40bb-be45-fc1885f4ff7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39d36ff2-0601-40bb-be45-fc1885f4ff7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

