### PR TITLE
Add Intended audience setting in Settings menu

### DIFF
--- a/src/lib/components/AgentSettingsPanel.svelte
+++ b/src/lib/components/AgentSettingsPanel.svelte
@@ -10,7 +10,12 @@
 	}
 	let { onSettingsChange }: Props = $props();
 
-	let settings: AgentSettings = $state({ agency: 'conservative', muted: false, paused: false });
+	let settings: AgentSettings = $state({
+		agency: 'conservative',
+		muted: false,
+		paused: false,
+		intendedAudience: ''
+	});
 	let previewAgency: Agency | null = $state(null);
 	agentSettings.subscribe((v) => (settings = v));
 

--- a/src/lib/components/AudiencePanel.svelte
+++ b/src/lib/components/AudiencePanel.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	import { agentSettings } from '$lib/stores';
+	import type { AgentSettings } from '$lib/types';
+
+	interface Props {
+		onSave: (audience: string) => void | Promise<void>;
+	}
+	let { onSave }: Props = $props();
+
+	const PLACEHOLDER =
+		'Busy engineering managers who already know Kubernetes; skip basics, keep examples concrete and short.';
+
+	let settings: AgentSettings = $state({
+		agency: 'conservative',
+		muted: false,
+		paused: false,
+		intendedAudience: ''
+	});
+	let draft = $state('');
+	let dirty = $state(false);
+
+	agentSettings.subscribe((v) => {
+		settings = v;
+		// Keep the draft in sync when settings arrive from the server or
+		// another surface, but don't clobber in-progress typing.
+		if (!dirty) draft = v.intendedAudience ?? '';
+	});
+
+	const canSave = $derived(dirty && draft.trim() !== (settings.intendedAudience ?? '').trim());
+	const canClear = $derived((settings.intendedAudience ?? '').trim().length > 0 || draft.trim().length > 0);
+
+	function onInput(e: Event) {
+		draft = (e.target as HTMLTextAreaElement).value;
+		dirty = true;
+	}
+
+	async function save() {
+		const next = draft.trim();
+		dirty = false;
+		draft = next;
+		await onSave(next);
+	}
+
+	async function clear() {
+		draft = '';
+		dirty = false;
+		await onSave('');
+	}
+</script>
+
+<div class="audience-panel" role="dialog">
+	<span class="panel-title">Intended audience</span>
+	<div class="setting-label">Who are you writing for?</div>
+	<textarea
+		class="audience-input"
+		value={draft}
+		oninput={onInput}
+		placeholder={PLACEHOLDER}
+		rows="5"
+	></textarea>
+	<div class="panel-actions">
+		<button class="btn" type="button" onclick={() => void clear()} disabled={!canClear}>Clear</button>
+		<button class="btn primary" type="button" onclick={() => void save()} disabled={!canSave}>Save</button>
+	</div>
+</div>
+
+<style>
+	.audience-panel {
+		width: 340px;
+		max-width: calc(100vw - 32px);
+		box-sizing: border-box;
+		padding: 14px 16px 16px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 13px;
+		color: var(--text);
+	}
+	.panel-title {
+		display: block;
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		margin-bottom: 12px;
+	}
+	.setting-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text);
+		margin-bottom: 8px;
+	}
+	.audience-input {
+		width: 100%;
+		min-height: 110px;
+		resize: vertical;
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		background: var(--bg);
+		color: var(--text);
+		font: inherit;
+		font-size: 13px;
+		line-height: 1.5;
+		padding: 9px 10px;
+		outline: none;
+		box-sizing: border-box;
+	}
+	.audience-input:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 2px var(--accent-light);
+	}
+	.audience-input::placeholder {
+		color: var(--text-faint);
+	}
+	.panel-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 14px;
+	}
+	.btn {
+		font: inherit;
+		font-size: 12.5px;
+		font-weight: 500;
+		border-radius: 6px;
+		padding: 6px 11px;
+		border: 1px solid var(--border-light);
+		background: var(--bg-surface);
+		color: var(--text-secondary);
+		cursor: pointer;
+	}
+	.btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.btn.primary {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: white;
+	}
+	.btn.primary:disabled {
+		opacity: 0.45;
+	}
+</style>

--- a/src/lib/server/runtime-state.ts
+++ b/src/lib/server/runtime-state.ts
@@ -29,7 +29,8 @@ export type { AgentSettings, Rule };
  *   - Session resume for the Claude Agent SDK (`sessionId`)
  *   - The selection-feedback action toolbar (`recentActions`, `actionUsageCounts`)
  *   - Writing rules (`rules`) — consumed by `/api/render` when building the agent prompt
- *   - Agent behavior settings (`agentSettings`) — autonomy level and review-mode toggle
+ *   - Agent behavior settings (`agentSettings`) — autonomy level, intended
+ *     audience, and review-mode toggle
  *   - Open tab order + active tab
  *
  * `Rule`, `AgentSettings`, and `DEFAULT_AGENT_SETTINGS` are imported from

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -597,7 +597,8 @@ if (typeof window !== 'undefined') {
 export const agentSettings = writable<AgentSettings>({
 	agency: 'conservative',
 	muted: false,
-	paused: false
+	paused: false,
+	intendedAudience: ''
 });
 
 /** When the agent is muted, the editor's diff overlay stays hidden by

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -326,6 +326,9 @@ export interface AgentSettings {
 	 * Distinct from `muted` (which only hides the diff overlay). Toggled by
 	 * double-clicking the Agent pill. */
 	paused: boolean;
+	/** Free-text description of who the draft is for. Empty means no audience
+	 * bias. Injected into the agent prompt via session_state when it changes. */
+	intendedAudience: string;
 }
 
 /** Canonical default agent settings. Imported by the server runtime-state.
@@ -334,5 +337,6 @@ export interface AgentSettings {
 export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
 	agency: 'conservative',
 	muted: false,
-	paused: false
+	paused: false,
+	intendedAudience: ''
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,7 @@
 	import AgentModal from '$lib/components/AgentModal.svelte';
 	import Dialog from '$lib/components/Dialog.svelte';
 	import AgentSettingsPanel from '$lib/components/AgentSettingsPanel.svelte';
+	import AudiencePanel from '$lib/components/AudiencePanel.svelte';
 	import HooksPanel from '$lib/components/HooksPanel.svelte';
 	import SkillsPanel from '$lib/components/SkillsPanel.svelte';
 	import ApiKeysPanel from '$lib/components/ApiKeysPanel.svelte';
@@ -141,11 +142,17 @@
 	import type { AgentSettings, CommentThread, HistoryEntry, ImageAttachment, PendingReviewRound, ProposedRule, ProposedHook, Rule } from '$lib/types';
 	import type { MaterializedPendingReviewRound } from '$lib/review-rounds';
 
-	type AgentSettingsChange = {
-		type: 'agency';
-		from: AgentSettings['agency'];
-		to: AgentSettings['agency'];
-	};
+	type AgentSettingsChange =
+		| {
+				type: 'agency';
+				from: AgentSettings['agency'];
+				to: AgentSettings['agency'];
+		  }
+		| {
+				type: 'intendedAudience';
+				from: string;
+				to: string;
+		  };
 
 	type AgentSessionForSwitch = {
 		id: string;
@@ -928,7 +935,9 @@
 		aggressive: 2
 	};
 
-	function buildAutonomyChangeMessage(change: AgentSettingsChange): string {
+	function buildAutonomyChangeMessage(
+		change: Extract<AgentSettingsChange, { type: 'agency' }>
+	): string {
 		const copy = autonomyChangeCopy[change.to];
 		const wentUp = autonomyRank[change.to] > autonomyRank[change.from];
 		if (wentUp) {
@@ -937,11 +946,40 @@
 		return `Autonomy changed to ${copy.label}. ${copy.instruction} Use this policy from now on. Do not start new proactive work solely because autonomy was lowered.`;
 	}
 
+	function buildAudienceChangeMessage(audience: string): string {
+		if (!audience) {
+			return 'The user cleared the intended audience. Stop targeting a specific reader from now on.';
+		}
+		return (
+			`The user set the intended audience to: "${audience}". ` +
+			`Write for that reader from now on. Review the open documents with that audience in mind. ` +
+			`If a useful edit or comment follows, make it; otherwise keep the response brief.`
+		);
+	}
+
 	async function handleAgentSettingsChange(next: AgentSettings, change?: AgentSettingsChange) {
 		await persistAgentSettings(next);
 		if (change?.type === 'agency' && !next.paused) {
 			void submit(buildAutonomyChangeMessage(change));
+		} else if (change?.type === 'intendedAudience' && !next.paused) {
+			void submit(buildAudienceChangeMessage(change.to));
 		}
+	}
+
+	async function handleAudienceSave(audience: string) {
+		let prev = '';
+		let next: AgentSettings | null = null;
+		agentSettings.update((s) => {
+			prev = (s.intendedAudience ?? '').trim();
+			next = { ...s, intendedAudience: audience };
+			return next;
+		});
+		if (!next || prev === audience) return;
+		await handleAgentSettingsChange(next, {
+			type: 'intendedAudience',
+			from: prev,
+			to: audience
+		});
 	}
 
 	function isAcceptedEditsMessage(trigger?: string): boolean {
@@ -2214,6 +2252,7 @@
 					onClick: () => editorLineNumbers.update((v) => !v)
 				},
 				{ kind: 'panel', label: 'Writing references', panelKey: 'references' },
+				{ kind: 'panel', label: 'Intended audience', panelKey: 'audience' },
 				{ kind: 'panel', label: 'Skills', panelKey: 'skills' },
 				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' },
 				{ kind: 'divider' },
@@ -2980,6 +3019,7 @@
 					references: referencesPanelSnippet,
 					rules: rulesPanelSnippet,
 					agentSettings: agentSettingsSnippet,
+					audience: audiencePanelSnippet,
 					hooks: hooksPanelSnippet,
 					skills: skillsPanelSnippet,
 					apiKeys: apiKeysPanelSnippet
@@ -3010,6 +3050,10 @@
 
 	{#snippet agentSettingsSnippet()}
 		<AgentSettingsPanel onSettingsChange={handleAgentSettingsChange} />
+	{/snippet}
+
+	{#snippet audiencePanelSnippet()}
+		<AudiencePanel onSave={(audience) => void handleAudienceSave(audience)} />
 	{/snippet}
 
 	{#snippet hooksPanelSnippet()}

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -128,6 +128,7 @@ interface ImageAttachmentPayload {
 const KV_LAST_RULES = 'last_render:rules';
 const KV_LAST_REFS = 'last_render:refs';
 const KV_LAST_AGENCY = 'last_render:agency';
+const KV_LAST_AUDIENCE = 'last_render:audience';
 
 function normalizeToolPath(pathLike: string): string {
 	return normalize(resolve(WORKSPACE_ROOT, pathLike));
@@ -330,7 +331,7 @@ Every edit proposal needs a comment thread that says what is about to happen, so
 Each turn may contain these blocks, in this order.
 
 - <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and open comment threads as one-line stubs. Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(file_path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
-- <session_state>: rules, style references, and the agency level. Sent in full on the first turn, then only when something changed. If the block is absent, nothing changed.
+- <session_state>: rules, style references, the agency level, and the intended audience. Sent in full on the first turn, then only when something changed. If the block is absent, nothing changed.
 - <mode>: present only in special modes, such as plan-first.
 - <user_message>: the user's words, verbatim.
 - <user_feedback thread="..." mode="...">: the user's reply on a comment thread, verbatim, with the thread id and routing mode as attributes.
@@ -389,7 +390,11 @@ The agency level arrives in session_state when it changes.
 
 - Low: no edits, no new comments. Act only on an inline directive, a diff that needs a specific fix, or an explicit request. When in doubt, do nothing.
 - Medium: you have Low's edit permissions, and you may also open a comment thread when one would help. Open at most one per turn.
-- High: propose an edit or comment when you can name the specific defect: an unclear antecedent, a repeated point, a buried verb, a broken transition. Name the defect in the proposal. If you cannot name a defect, do not edit. Tighten, but do not rewrite.`;
+- High: propose an edit or comment when you can name the specific defect: an unclear antecedent, a repeated point, a buried verb, a broken transition. Name the defect in the proposal. If you cannot name a defect, do not edit. Tighten, but do not rewrite.
+
+## Intended audience
+
+When set, the intended reader arrives in session_state. Write for that audience: assume their background, match their jargon, and do not explain what they already know. If the block is absent, the audience is unchanged. If cleared, stop targeting a specific audience.`;
 }
 
 /** Build the per-render user prompt. Only the DYNAMIC content goes here —
@@ -502,12 +507,14 @@ function buildMultiTabPrompt(
 	const meta = readMeta();
 	const currentRuleTexts = meta.rules.map((r) => r.text);
 	const currentAgency = meta.agentSettings.agency;
+	const currentAudience = (meta.agentSettings.intendedAudience ?? '').trim();
 
 	// Read prior snapshots so we can emit only the deltas. First render of a
 	// session (snapshot absent) shows the full state — agent needs it once.
 	const priorRulesJson = kvGet(KV_LAST_RULES);
 	const priorRefsJson = kvGet(KV_LAST_REFS);
 	const priorAgency = kvGet(KV_LAST_AGENCY);
+	const priorAudience = kvGet(KV_LAST_AUDIENCE);
 
 	const currentRulesJson = snapshotRules(meta.rules);
 	const currentRefsJson = snapshotRefs();
@@ -548,6 +555,13 @@ function buildMultiTabPrompt(
 	if (currentAgency !== priorAgency) {
 		sessionParts.push(`Agency: ${currentAgency}`);
 	}
+	if (currentAudience !== (priorAudience ?? '')) {
+		sessionParts.push(
+			currentAudience
+				? `Intended audience: ${currentAudience}`
+				: 'Intended audience: (cleared — no specific audience set.)'
+		);
+	}
 	if (sessionParts.length > 0) {
 		sections.push(`<session_state>\n${sessionParts.join('\n\n')}\n</session_state>`);
 	}
@@ -574,6 +588,7 @@ function buildMultiTabPrompt(
 		kvSet(KV_LAST_RULES, currentRulesJson);
 		kvSet(KV_LAST_REFS, currentRefsJson);
 		kvSet(KV_LAST_AGENCY, currentAgency);
+		kvSet(KV_LAST_AUDIENCE, currentAudience);
 	} catch (err) {
 		console.error('[render] failed to persist prompt-state snapshot:', err);
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Settings → **Intended audience** flyout where writers describe who the draft is for.

- Free-text only (no presets): “Who are you writing for?” with a detailed placeholder example
- Persists on `agentSettings.intendedAudience` (SQLite kv, same path as autonomy)
- Injected into agent `<session_state>` when it changes; system prompt has a short audience section
- Save / Clear wakes the agent so it can recalibrate (skipped when paused)

## UI

Matches existing Settings panel flyouts (Writing references / Agent behavior): uppercase title, label, textarea, Clear / Save.

[Settings → Intended audience](https://cursor.com/agents/bc-4b26651f-0cc5-4538-9c66-7e7ee4e5cea4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintended-audience-live-proof.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b26651f-0cc5-4538-9c66-7e7ee4e5cea4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b26651f-0cc5-4538-9c66-7e7ee4e5cea4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/c35fd50e-6183-43fa-a4df-dd8841b3c7bc" />


