### PR TITLE
docs: Compass-style sliding TOC scroll animation

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,88 @@
+/* Compass-style "On this page" TOC: muted tree track + sliding primary thumb. */
+
+#table-of-contents-content.toc.dw-toc-clerk {
+	position: relative;
+	padding-inline-start: 0;
+	list-style: none;
+	margin: 0;
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .toc-item {
+	list-style: none;
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .toc-item > a {
+	position: relative;
+	display: block;
+	padding-block: 0.375rem;
+	padding-inline-start: var(--dw-toc-item-pad, 1.25rem);
+	transition: color 180ms ease;
+}
+
+/* Soft hierarchical connectors behind each entry. */
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch {
+	position: absolute;
+	inset-inline-start: 0;
+	top: -0.375rem;
+	bottom: 0;
+	height: calc(100% + 0.375rem);
+	pointer-events: none;
+	z-index: 0;
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch line,
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch path {
+	stroke: currentColor;
+	stroke-width: 1;
+	fill: none;
+	opacity: 0.12;
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .toc-item > a > :not(.dw-toc-branch) {
+	position: relative;
+	z-index: 1;
+}
+
+/* Sliding primary highlight clipped over the full tree path. */
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb {
+	position: absolute;
+	inset-inline-start: 0;
+	top: 0;
+	pointer-events: none;
+	z-index: 1;
+	transform-origin: center;
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb svg {
+	position: absolute;
+	inset-inline-start: 0;
+	top: 0;
+	overflow: visible;
+	transition: clip-path 280ms cubic-bezier(0.22, 1, 0.36, 1);
+	clip-path: polygon(
+		0 var(--dw-track-top, 0px),
+		100% var(--dw-track-top, 0px),
+		100% var(--dw-track-bottom, 0px),
+		0 var(--dw-track-bottom, 0px)
+	);
+}
+
+#table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path {
+	stroke: var(--primary, #7c3aed);
+	stroke-width: 1.5;
+	fill: none;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+html.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path,
+.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path {
+	stroke: var(--primary-light, #a78bfa);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#table-of-contents-content.toc.dw-toc-clerk .toc-item > a,
+	#table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb svg {
+		transition: none;
+	}
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -7,15 +7,18 @@
 	margin: 0;
 }
 
-#table-of-contents-content.toc.dw-toc-clerk .toc-item {
+#table-of-contents-content.toc.dw-toc-clerk .toc-item,
+#table-of-contents-content.toc.dw-toc-clerk ul {
 	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 #table-of-contents-content.toc.dw-toc-clerk .toc-item > a {
 	position: relative;
 	display: block;
 	padding-block: 0.375rem;
-	padding-inline-start: var(--dw-toc-item-pad, 1.25rem);
+	padding-inline-start: var(--dw-toc-item-pad, 1.25rem) !important;
 	transition: color 180ms ease;
 }
 
@@ -28,6 +31,7 @@
 	height: calc(100% + 0.375rem);
 	pointer-events: none;
 	z-index: 0;
+	color: #64748b;
 }
 
 #table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch line,
@@ -35,12 +39,12 @@
 	stroke: currentColor;
 	stroke-width: 1;
 	fill: none;
-	opacity: 0.12;
+	opacity: 0.35;
 }
 
-#table-of-contents-content.toc.dw-toc-clerk .toc-item > a > :not(.dw-toc-branch) {
-	position: relative;
-	z-index: 1;
+html.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch,
+.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-branch {
+	color: #94a3b8;
 }
 
 /* Sliding primary highlight clipped over the full tree path. */
@@ -51,6 +55,12 @@
 	pointer-events: none;
 	z-index: 1;
 	transform-origin: center;
+	color: #7c3aed;
+}
+
+html.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb,
+.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb {
+	color: #a78bfa;
 }
 
 #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb svg {
@@ -58,6 +68,7 @@
 	inset-inline-start: 0;
 	top: 0;
 	overflow: visible;
+	color: inherit;
 	transition: clip-path 280ms cubic-bezier(0.22, 1, 0.36, 1);
 	clip-path: polygon(
 		0 var(--dw-track-top, 0px),
@@ -68,16 +79,11 @@
 }
 
 #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path {
-	stroke: var(--primary, #7c3aed);
+	stroke: currentColor;
 	stroke-width: 1.5;
 	fill: none;
 	stroke-linecap: round;
 	stroke-linejoin: round;
-}
-
-html.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path,
-.dark #table-of-contents-content.toc.dw-toc-clerk .dw-toc-thumb path {
-	stroke: var(--primary-light, #a78bfa);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/toc-clerk.js
+++ b/docs/toc-clerk.js
@@ -7,7 +7,6 @@
  */
 (() => {
 	const TOC_SELECTOR = '#table-of-contents-content.toc';
-	const ITEM_SELECTOR = ':scope > .toc-item';
 	const BASE = 8;
 
 	/** @type {WeakMap<Element, { disconnect: () => void }>} */
@@ -36,10 +35,29 @@
 	}
 
 	/**
+	 * Anchor offsetTop is relative to the nearest positioned ancestor. Mintlify
+	 * marks each `.toc-item` as `relative`, so we measure against the list box.
+	 * @param {HTMLElement} list
+	 * @param {HTMLElement} anchor
+	 */
+	function measureAnchor(list, anchor) {
+		const listRect = list.getBoundingClientRect();
+		const rect = anchor.getBoundingClientRect();
+		const styles = getComputedStyle(anchor);
+		const padTop = parseFloat(styles.paddingTop) || 0;
+		const padBottom = parseFloat(styles.paddingBottom) || 0;
+		const top = rect.top - listRect.top + list.scrollTop + padTop;
+		const bottom = rect.bottom - listRect.top + list.scrollTop - padBottom;
+		return { top, bottom };
+	}
+
+	/**
 	 * @param {HTMLElement} list
 	 */
 	function build(list) {
-		const items = Array.from(list.querySelectorAll(ITEM_SELECTOR));
+		// Mintlify nests h3+ items under their parent <li>, so collect every
+		// .toc-item in document order rather than only direct children.
+		const items = Array.from(list.querySelectorAll('.toc-item'));
 		if (items.length === 0) return null;
 
 		clearBranches(list);
@@ -56,6 +74,9 @@
 			const depth = readDepth(item);
 			const pad = getItemPad(depth);
 			anchor.style.setProperty('--dw-toc-item-pad', `${pad}px`);
+			// Nested Mintlify items also set --toc-padding-left; keep both in sync
+			// so utility padding and our override agree.
+			anchor.style.setProperty('--toc-padding-left', `${Math.max(0, pad - BASE)}px`);
 
 			const l1 = getLineOffset(depth);
 			const prevDepth = i === 0 ? depth : readDepth(items[i - 1]);
@@ -74,12 +95,12 @@
 			}
 
 			if (l0 !== l1) {
-				const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-				path.setAttribute(
+				const bend = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+				bend.setAttribute(
 					'd',
 					`M ${l0 + 0.5} 0 C ${l0 + 0.5} 8 ${l1 + 0.5} 4 ${l1 + 0.5} 12`,
 				);
-				svg.appendChild(path);
+				svg.appendChild(bend);
 			}
 
 			const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
@@ -95,21 +116,15 @@
 
 		if (entries.length === 0) return null;
 
-		// Measure after branches are in the DOM so padding/offset are final.
 		let pathD = '';
 		let maxW = 0;
 		let maxH = 0;
+		/** @type {[number, number, number][]} */
 		const positions = [];
 
 		for (let i = 0; i < entries.length; i++) {
 			const entry = entries[i];
-			const styles = getComputedStyle(entry.anchor);
-			const top =
-				entry.anchor.offsetTop + (parseFloat(styles.paddingTop) || 0);
-			const bottom =
-				entry.anchor.offsetTop +
-				entry.anchor.clientHeight -
-				(parseFloat(styles.paddingBottom) || 0);
+			const { top, bottom } = measureAnchor(list, entry.anchor);
 			const x = entry.x;
 
 			entry.top = top;
@@ -139,6 +154,13 @@
 
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 		path.setAttribute('d', pathD);
+		path.setAttribute('fill', 'none');
+		path.setAttribute('stroke-width', '1.5');
+		path.setAttribute('stroke-linecap', 'round');
+		path.setAttribute('stroke-linejoin', 'round');
+		// Presentation attribute so stroke stays visible even if theme tokens
+		// are space-separated RGB components that invalidate CSS `stroke: var(--primary)`.
+		path.setAttribute('stroke', 'currentColor');
 		thumbSvg.appendChild(path);
 		thumb.appendChild(thumbSvg);
 		list.prepend(thumb);
@@ -149,7 +171,6 @@
 				if (entries[i].item.hasAttribute('data-active')) activeIdx.push(i);
 			}
 			if (activeIdx.length === 0) {
-				// Fall back to deepest-active only, or hide the thumb.
 				for (let i = 0; i < entries.length; i++) {
 					if (entries[i].item.hasAttribute('data-active-deepest')) {
 						activeIdx.push(i);
@@ -196,10 +217,6 @@
 				for (const entry of entries) {
 					entry.anchor.style.removeProperty('--dw-toc-item-pad');
 				}
-			},
-			rebuild: () => {
-				attrObserver.disconnect();
-				return build(list);
 			},
 		};
 	}
@@ -252,11 +269,9 @@
 			subtree: true,
 		});
 
-		// Rebuild after layout settles (fonts / sticky TOC mount).
 		window.addEventListener('resize', scheduleScan, { passive: true });
 		window.addEventListener('load', scheduleScan);
 
-		// Mintlify client navigations change the path without a full reload.
 		const pushState = history.pushState;
 		history.pushState = function (...args) {
 			const result = pushState.apply(this, args);

--- a/docs/toc-clerk.js
+++ b/docs/toc-clerk.js
@@ -1,0 +1,280 @@
+/**
+ * Compass / Fumadocs-clerk style TOC: hierarchical SVG connectors plus a
+ * primary-colored path whose clip-path slides with the active heading(s).
+ *
+ * Mintlify already marks `.toc-item[data-active]` / `[data-active-deepest]`.
+ * This script only adds the visual track + thumb animation.
+ */
+(() => {
+	const TOC_SELECTOR = '#table-of-contents-content.toc';
+	const ITEM_SELECTOR = ':scope > .toc-item';
+	const BASE = 8;
+
+	/** @type {WeakMap<Element, { disconnect: () => void }>} */
+	const enhanced = new WeakMap();
+
+	function getLineOffset(depth) {
+		if (depth <= 0) return BASE;
+		if (depth === 1) return 12 + BASE;
+		return 24 + BASE;
+	}
+
+	function getItemPad(depth) {
+		if (depth <= 0) return 12 + BASE;
+		if (depth === 1) return 24 + BASE;
+		return 36 + BASE;
+	}
+
+	function readDepth(item) {
+		const raw = item.getAttribute('data-depth');
+		const n = raw == null ? 0 : Number(raw);
+		return Number.isFinite(n) ? n : 0;
+	}
+
+	function clearBranches(list) {
+		list.querySelectorAll('.dw-toc-branch, .dw-toc-thumb').forEach((el) => el.remove());
+	}
+
+	/**
+	 * @param {HTMLElement} list
+	 */
+	function build(list) {
+		const items = Array.from(list.querySelectorAll(ITEM_SELECTOR));
+		if (items.length === 0) return null;
+
+		clearBranches(list);
+		list.classList.add('dw-toc-clerk');
+
+		/** @type {{ item: HTMLElement, anchor: HTMLElement, depth: number, top: number, bottom: number, x: number }[]} */
+		const entries = [];
+
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			const anchor = item.querySelector(':scope > a');
+			if (!(anchor instanceof HTMLElement)) continue;
+
+			const depth = readDepth(item);
+			const pad = getItemPad(depth);
+			anchor.style.setProperty('--dw-toc-item-pad', `${pad}px`);
+
+			const l1 = getLineOffset(depth);
+			const prevDepth = i === 0 ? depth : readDepth(items[i - 1]);
+			const nextDepth = i === items.length - 1 ? depth : readDepth(items[i + 1]);
+			const l0 = i === 0 ? l1 : getLineOffset(prevDepth);
+			const l2 = i === items.length - 1 ? l1 : getLineOffset(nextDepth);
+			const width = Math.max(l0, l1) + 9;
+
+			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+			svg.setAttribute('aria-hidden', 'true');
+			svg.classList.add('dw-toc-branch');
+			svg.style.width = `${width}px`;
+			if (l1 !== l2) {
+				svg.style.height = '100%';
+				svg.style.bottom = '0.375rem';
+			}
+
+			if (l0 !== l1) {
+				const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+				path.setAttribute(
+					'd',
+					`M ${l0 + 0.5} 0 C ${l0 + 0.5} 8 ${l1 + 0.5} 4 ${l1 + 0.5} 12`,
+				);
+				svg.appendChild(path);
+			}
+
+			const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+			line.setAttribute('x1', String(l1 + 0.5));
+			line.setAttribute('y1', l0 === l1 ? '6' : '12');
+			line.setAttribute('x2', String(l1 + 0.5));
+			line.setAttribute('y2', '100%');
+			svg.appendChild(line);
+
+			anchor.prepend(svg);
+			entries.push({ item, anchor, depth, top: 0, bottom: 0, x: l1 + 0.5 });
+		}
+
+		if (entries.length === 0) return null;
+
+		// Measure after branches are in the DOM so padding/offset are final.
+		let pathD = '';
+		let maxW = 0;
+		let maxH = 0;
+		const positions = [];
+
+		for (let i = 0; i < entries.length; i++) {
+			const entry = entries[i];
+			const styles = getComputedStyle(entry.anchor);
+			const top =
+				entry.anchor.offsetTop + (parseFloat(styles.paddingTop) || 0);
+			const bottom =
+				entry.anchor.offsetTop +
+				entry.anchor.clientHeight -
+				(parseFloat(styles.paddingBottom) || 0);
+			const x = entry.x;
+
+			entry.top = top;
+			entry.bottom = bottom;
+			positions.push([top, bottom, x]);
+			maxW = Math.max(maxW, x + 8);
+			maxH = Math.max(maxH, bottom);
+
+			if (i === 0) {
+				pathD += `M${x} ${top} L${x} ${bottom}`;
+			} else {
+				const [, upperBottom, upperX] = positions[i - 1];
+				pathD += ` L${upperX} ${upperBottom} ${x} ${top} L${x} ${bottom}`;
+			}
+		}
+
+		const thumb = document.createElement('div');
+		thumb.className = 'dw-toc-thumb';
+		thumb.setAttribute('aria-hidden', 'true');
+		thumb.style.width = `${maxW}px`;
+		thumb.style.height = `${maxH}px`;
+
+		const thumbSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		thumbSvg.setAttribute('viewBox', `0 0 ${maxW} ${maxH}`);
+		thumbSvg.setAttribute('width', String(maxW));
+		thumbSvg.setAttribute('height', String(maxH));
+
+		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+		path.setAttribute('d', pathD);
+		thumbSvg.appendChild(path);
+		thumb.appendChild(thumbSvg);
+		list.prepend(thumb);
+
+		function applyThumb() {
+			const activeIdx = [];
+			for (let i = 0; i < entries.length; i++) {
+				if (entries[i].item.hasAttribute('data-active')) activeIdx.push(i);
+			}
+			if (activeIdx.length === 0) {
+				// Fall back to deepest-active only, or hide the thumb.
+				for (let i = 0; i < entries.length; i++) {
+					if (entries[i].item.hasAttribute('data-active-deepest')) {
+						activeIdx.push(i);
+					}
+				}
+			}
+			if (activeIdx.length === 0) {
+				thumb.style.setProperty('--dw-track-top', '0px');
+				thumb.style.setProperty('--dw-track-bottom', '0px');
+				return;
+			}
+			const start = activeIdx[0];
+			const end = activeIdx[activeIdx.length - 1];
+			thumb.style.setProperty('--dw-track-top', `${positions[start][0]}px`);
+			thumb.style.setProperty('--dw-track-bottom', `${positions[end][1]}px`);
+		}
+
+		applyThumb();
+
+		const attrObserver = new MutationObserver((mutations) => {
+			for (const m of mutations) {
+				if (
+					m.type === 'attributes' &&
+					(m.attributeName === 'data-active' ||
+						m.attributeName === 'data-active-deepest')
+				) {
+					applyThumb();
+					return;
+				}
+			}
+		});
+		for (const entry of entries) {
+			attrObserver.observe(entry.item, {
+				attributes: true,
+				attributeFilter: ['data-active', 'data-active-deepest'],
+			});
+		}
+
+		return {
+			disconnect() {
+				attrObserver.disconnect();
+				clearBranches(list);
+				list.classList.remove('dw-toc-clerk');
+				for (const entry of entries) {
+					entry.anchor.style.removeProperty('--dw-toc-item-pad');
+				}
+			},
+			rebuild: () => {
+				attrObserver.disconnect();
+				return build(list);
+			},
+		};
+	}
+
+	function enhance(list) {
+		const prev = enhanced.get(list);
+		if (prev) prev.disconnect();
+		const handle = build(list);
+		if (handle) enhanced.set(list, handle);
+	}
+
+	function scan() {
+		document.querySelectorAll(TOC_SELECTOR).forEach((list) => {
+			if (!(list instanceof HTMLElement)) return;
+			enhance(list);
+		});
+	}
+
+	let scanScheduled = false;
+	function scheduleScan() {
+		if (scanScheduled) return;
+		scanScheduled = true;
+		requestAnimationFrame(() => {
+			scanScheduled = false;
+			scan();
+		});
+	}
+
+	function boot() {
+		scan();
+
+		const rootObserver = new MutationObserver((mutations) => {
+			for (const m of mutations) {
+				if (m.type !== 'childList') continue;
+				for (const node of m.addedNodes) {
+					if (!(node instanceof Element)) continue;
+					if (
+						node.matches?.(TOC_SELECTOR) ||
+						node.querySelector?.(TOC_SELECTOR) ||
+						node.classList?.contains('toc-item')
+					) {
+						scheduleScan();
+						return;
+					}
+				}
+			}
+		});
+		rootObserver.observe(document.documentElement, {
+			childList: true,
+			subtree: true,
+		});
+
+		// Rebuild after layout settles (fonts / sticky TOC mount).
+		window.addEventListener('resize', scheduleScan, { passive: true });
+		window.addEventListener('load', scheduleScan);
+
+		// Mintlify client navigations change the path without a full reload.
+		const pushState = history.pushState;
+		history.pushState = function (...args) {
+			const result = pushState.apply(this, args);
+			scheduleScan();
+			setTimeout(scheduleScan, 50);
+			setTimeout(scheduleScan, 250);
+			return result;
+		};
+		window.addEventListener('popstate', () => {
+			scheduleScan();
+			setTimeout(scheduleScan, 50);
+			setTimeout(scheduleScan, 250);
+		});
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', boot, { once: true });
+	} else {
+		boot();
+	}
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Compass / Fumadocs-clerk style **On this page** animation to the Mintlify docs:

- Soft hierarchical SVG connectors beside each TOC entry
- A primary-colored tree path whose `clip-path` smoothly slides and resizes with the active heading(s) as you scroll — including doglegs into nested h3 items

Implemented with Mintlify’s auto-loaded custom assets (`docs/style.css`, `docs/toc-clerk.js`) so it applies site-wide without forking the theme. Uses Mintlify’s existing `toc-item[data-active]` / `[data-active-deepest]` markers.

## Preview

[TOC thumb on nested headings](https://cursor.com/agents/bc-d47d1dd4-edb3-47f2-a345-f51ceae5b65f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftoc-nested-thumb.png)

[TOC thumb mid-scroll on Quickstart](https://cursor.com/agents/bc-d47d1dd4-edb3-47f2-a345-f51ceae5b65f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftoc-scroll-2.png)

## How to verify

1. `npm run docs` → open a longer page (e.g. `/quickstart` or `/connect-provider`)
2. Scroll the main content and watch the right-hand TOC: the purple track segment should glide between headings
3. On `/connect-provider`, scroll into **Add credentials → Claude** and confirm the thumb doglegs into the nested items
4. Confirm `prefers-reduced-motion: reduce` disables the transition

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d47d1dd4-edb3-47f2-a345-f51ceae5b65f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d47d1dd4-edb3-47f2-a345-f51ceae5b65f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

