### PR TITLE
Simplify PR #77 author-style code and fix selected-source bugs

### DIFF
--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -286,12 +286,6 @@
 		}
 	}
 
-	function formatToolInput(input: Record<string, unknown>): string {
-		return Object.entries(input)
-			.map(([key, value]) => `${key}: ${typeof value === 'string' ? value : JSON.stringify(value)}`)
-			.join('\n');
-	}
-
 	function onComposerKeydown(event: KeyboardEvent) {
 		if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
 			event.preventDefault();

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -23,23 +23,25 @@
 	import type {
 		CalibrationChoice,
 		CalibrationTrial,
+		MaterializationStatus,
+		PropositionStatus,
 		SpecialistRunState,
 		StyleAnalysisRun,
 		StyleProfileSummary,
 		StyleProposition,
 		StyleReferenceRole
 	} from '$lib/style-profile';
+	import { isActiveProposition } from '$lib/style-profile';
 
-	type ReferenceType = 'workspace-file' | 'stored-sample' | 'url';
 	interface ReferenceItem {
 		id: string;
 		label: string;
-		type: ReferenceType;
+		type: 'stored-sample';
 		target: string;
 		role: StyleReferenceRole;
 		format?: string;
 		contentHash?: string;
-		materializationStatus: 'pending' | 'ready' | 'stale' | 'error';
+		materializationStatus: MaterializationStatus;
 		extractedAt?: number;
 		error?: string;
 		description?: string;
@@ -93,19 +95,17 @@
 
 	const pendingTrials = $derived((summary?.profile?.calibrations ?? [])
 		.filter((trial) => calibrationSessionIds.includes(trial.id) && ['pending', 'generated', 'error'].includes(trial.status)));
-	const activePropositions = $derived((summary?.profile?.propositions ?? [])
-		.filter((proposition) => ['active', 'confirmed'].includes(proposition.status)));
+	const activePropositions = $derived((summary?.profile?.propositions ?? []).filter(isActiveProposition));
 	const allPropositions = $derived(summary?.profile?.propositions ?? []);
-	const inactivePropositions = $derived(allPropositions
-		.filter((proposition) => !['active', 'confirmed'].includes(proposition.status)));
+	const inactivePropositions = $derived(allPropositions.filter((proposition) => !isActiveProposition(proposition)));
 
 	/** Why a proposition is not in the skill, in the reader's terms rather than
 	 *  the status name stored on it. */
-	function inactiveReason(status: string): string {
+	function inactiveReason(status: PropositionStatus): string {
 		if (status === 'pending') return 'Waiting on your pick';
 		if (status === 'disabled') return 'You removed it';
 		if (status === 'not-actionable') return 'Too vague to act on';
-		if (status === 'rejected') return 'You rejected it';
+		if (status === 'skipped') return 'You skipped it';
 		return titleCase(status);
 	}
 	const analysisRunning = $derived(Boolean(run && ['queued', 'running'].includes(run.status)));
@@ -257,30 +257,8 @@
 	const canAddSample = $derived(
 		!addingSample && sampleDescription.trim().length > 0 && sampleText.trim().length > 0
 	);
-	const selectedCount = $derived(references.length);
+	const selectedCount = $derived(references.filter((reference) => reference.selected !== false).length);
 	const previewReference = $derived(references.find((item) => item.id === previewId) ?? null);
-
-	async function setSelected(reference: ReferenceItem, selected: boolean) {
-		busyId = reference.id;
-		// Reflect the choice straight away; the reload confirms it.
-		references = references.map((item) =>
-			item.id === reference.id ? { ...item, selected } : item
-		);
-		try {
-			await requestJson(`/api/references/${encodeURIComponent(reference.id)}`, {
-				method: 'PATCH',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ selected })
-			});
-			await loadAll();
-			onChanged?.();
-		} catch (cause) {
-			errorMessage = cause instanceof Error ? cause.message : 'Could not update the source.';
-			await loadAll();
-		} finally {
-			busyId = null;
-		}
-	}
 
 	/** One pasted passage plus the writer's description of what it is. */
 	async function addSample() {
@@ -609,10 +587,7 @@
 	}
 
 	function sourceKindLabel(reference: ReferenceItem): string {
-		const kind = reference.type === 'workspace-file' ? 'Workspace file'
-			: reference.type === 'stored-sample' ? 'Pasted sample'
-			: 'Link';
-		return reference.format ? `${kind} · ${reference.format}` : kind;
+		return reference.format ? `Pasted sample · ${reference.format}` : 'Pasted sample';
 	}
 
 	function closeOnBackdrop(event: MouseEvent) {

--- a/src/lib/components/ReferenceStatusPill.svelte
+++ b/src/lib/components/ReferenceStatusPill.svelte
@@ -15,11 +15,11 @@
 	const label = $derived.by(() => {
 		if (loading && !summary) return 'Checking references';
 		if (!summary || summary.status === 'empty') return 'References not provided';
-		if (summary.status === 'ready-to-analyze') return 'Calibrate references';
+		if (summary.status === 'ready-to-analyze') return 'Analyze references';
 		if (summary.status === 'analyzing') return 'Analyzing references';
 		if (summary.status === 'stale') return 'Update style';
 		if (summary.status === 'error') return 'Analysis failed';
-		if (summary.activeCount === 0 && summary.unresolvedCount > 0) return 'Calibrate references';
+		if (summary.status === 'needs-calibration' || summary.unresolvedCount > 0) return 'Calibrate references';
 		// Outstanding choices are the dialog's business; the pill only reports
 		// that a style is in force.
 		return 'Style uploaded';
@@ -28,7 +28,9 @@
 	const tone = $derived.by(() => {
 		if (!summary || ['empty', 'ready-to-analyze'].includes(summary.status)) return 'warning';
 		if (summary.status === 'error') return 'error';
-		if (summary.status === 'stale' || summary.unresolvedCount > 0) return 'pending';
+		if (summary.status === 'stale' || summary.status === 'needs-calibration' || summary.unresolvedCount > 0) {
+			return 'pending';
+		}
 		if (summary.status === 'analyzing') return 'working';
 		return 'active';
 	});
@@ -43,6 +45,9 @@
 		if (summary.status === 'analyzing') return 'Measuring your references and drafting style guidance.';
 		if (summary.status === 'error') return 'The last style analysis failed.\nClick to see what went wrong.';
 		if (summary.status === 'stale') return 'Your references changed since the last analysis.\nClick to re-run it.';
+		if (summary.status === 'needs-calibration' || summary.unresolvedCount > 0) {
+			return 'A few style habits still need your pick between close passages.\nClick to finish calibrating.';
+		}
 		return 'Your author style is active and guiding the writing agent.';
 	});
 

--- a/src/lib/server/style-analysis/analyze-style.mjs
+++ b/src/lib/server/style-analysis/analyze-style.mjs
@@ -32,7 +32,8 @@ function hash(value) {
 }
 
 function id(prefix, value) {
-	return `${prefix}_${hash(value).slice(0, 12)}`;
+	// Structural ids only need uniqueness within a report — avoid SHA-256 per token.
+	return `${prefix}:${value}`;
 }
 
 function round(value, digits = 4) {
@@ -50,9 +51,8 @@ function words(text) {
 	}));
 }
 
-function percentile(values, fraction) {
-	if (!values.length) return 0;
-	const sorted = [...values].sort((a, b) => a - b);
+function percentileSorted(sorted, fraction) {
+	if (!sorted.length) return 0;
 	const position = (sorted.length - 1) * fraction;
 	const lower = Math.floor(position);
 	const upper = Math.ceil(position);
@@ -60,19 +60,26 @@ function percentile(values, fraction) {
 	return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
 }
 
+function percentile(values, fraction) {
+	if (!values.length) return 0;
+	return percentileSorted([...values].sort((a, b) => a - b), fraction);
+}
+
 function distribution(values) {
 	if (!values.length) {
 		return { min: 0, p10: 0, median: 0, p90: 0, max: 0, mean: 0, mad: 0 };
 	}
-	const median = percentile(values, 0.5);
+	const sorted = [...values].sort((a, b) => a - b);
+	const median = percentileSorted(sorted, 0.5);
+	const deviations = sorted.map((value) => Math.abs(value - median)).sort((a, b) => a - b);
 	return {
-		min: round(Math.min(...values)),
-		p10: round(percentile(values, 0.1)),
+		min: round(sorted[0]),
+		p10: round(percentileSorted(sorted, 0.1)),
 		median: round(median),
-		p90: round(percentile(values, 0.9)),
-		max: round(Math.max(...values)),
+		p90: round(percentileSorted(sorted, 0.9)),
+		max: round(sorted[sorted.length - 1]),
 		mean: round(values.reduce((sum, value) => sum + value, 0) / values.length),
-		mad: round(percentile(values.map((value) => Math.abs(value - median)), 0.5))
+		mad: round(percentileSorted(deviations, 0.5))
 	};
 }
 
@@ -414,27 +421,34 @@ function containingSentence(document, start) {
 	return document.sentences.find((sentence) => sentence.start <= start && sentence.end >= start);
 }
 
+function nestingDepthSeries(text) {
+	const depths = new Uint16Array(text.length + 1);
+	const stack = [];
+	let straightDoubleQuoteOpen = false;
+	let straightSingleQuoteOpen = false;
+	for (let cursor = 0; cursor < text.length; cursor += 1) {
+		depths[cursor] = stack.length + Number(straightDoubleQuoteOpen) + Number(straightSingleQuoteOpen);
+		const character = text[cursor];
+		if (character === '(' || character === '[') stack.push(character);
+		else if (character === ')' && stack.at(-1) === '(') stack.pop();
+		else if (character === ']' && stack.at(-1) === '[') stack.pop();
+		else if (character === '“') stack.push(character);
+		else if (character === '”' && stack.at(-1) === '“') stack.pop();
+		else if (character === '‘') stack.push(character);
+		else if (character === '’' && stack.at(-1) === '‘') stack.pop();
+		else if (character === '"') straightDoubleQuoteOpen = !straightDoubleQuoteOpen;
+		else if (character === "'" && !(/[\p{L}]/u.test(text[cursor - 1] ?? '') && /[\p{L}]/u.test(text[cursor + 1] ?? ''))) {
+			straightSingleQuoteOpen = !straightSingleQuoteOpen;
+		}
+	}
+	depths[text.length] = stack.length + Number(straightDoubleQuoteOpen) + Number(straightSingleQuoteOpen);
+	return depths;
+}
+
 function punctuationOccurrences(document) {
 	const occurrences = [];
 	const consumed = new Set();
-	const nestingDepthAt = (text, index) => {
-		const stack = [];
-		let straightDoubleQuoteOpen = false;
-		let straightSingleQuoteOpen = false;
-		for (let cursor = 0; cursor < index; cursor += 1) {
-			const character = text[cursor];
-			if (character === '(' || character === '[') stack.push(character);
-			else if (character === ')' && stack.at(-1) === '(') stack.pop();
-			else if (character === ']' && stack.at(-1) === '[') stack.pop();
-			else if (character === '“') stack.push(character);
-			else if (character === '”' && stack.at(-1) === '“') stack.pop();
-			else if (character === '‘') stack.push(character);
-			else if (character === '’' && stack.at(-1) === '‘') stack.pop();
-			else if (character === '"') straightDoubleQuoteOpen = !straightDoubleQuoteOpen;
-			else if (character === "'" && !(/[\p{L}]/u.test(text[cursor - 1] ?? '') && /[\p{L}]/u.test(text[cursor + 1] ?? ''))) straightSingleQuoteOpen = !straightSingleQuoteOpen;
-		}
-		return stack.length + Number(straightDoubleQuoteOpen) + Number(straightSingleQuoteOpen);
-	};
+	const nestingDepths = nestingDepthSeries(document.text);
 	const isFalsePeriod = (text, index) => {
 		if (/\d/.test(text[index - 1] ?? '') && /\d/.test(text[index + 1] ?? '')) return true;
 		const whitespaceStart = Math.max(text.lastIndexOf(' ', index), text.lastIndexOf('\n', index), text.lastIndexOf('\t', index)) + 1;
@@ -487,7 +501,7 @@ function punctuationOccurrences(document) {
 				rightClauseWords: words(rightText.slice(0, rightBoundary)).length,
 				normalizedPosition: sentence ? round(local / Math.max(1, sentence.text.length)) : 0,
 				followingConjunction: after && CONJUNCTIONS.has(after) ? after : null,
-				nestingDepth: nestingDepthAt(document.text, start),
+				nestingDepth: nestingDepths[start],
 				likelyFunction,
 				sentenceText: sentence?.text ?? '',
 				...extra
@@ -745,7 +759,7 @@ const FAMILY_LABELS = {
 };
 
 function metricFamily(metricId) {
-	return metricId.split('.').slice(0, metricId.startsWith('punctuation.') ? 1 : 1)[0];
+	return metricId.split('.')[0];
 }
 
 function metricUnit(metricId) {

--- a/src/lib/server/style-analysis/calibration.test.ts
+++ b/src/lib/server/style-analysis/calibration.test.ts
@@ -8,8 +8,7 @@ import { analyzeDocuments, normalizeText } from './analyze-style.mjs';
 vi.mock('./run-manager', () => ({
 	runStructuredStyleAgent: vi.fn(async () => ({
 		statement: 'The user confirmed the revised direction.',
-		instruction: 'Use the user confirmed form.',
-		scope: ['prose']
+		instruction: 'Use the user confirmed form.'
 	}))
 }));
 

--- a/src/lib/server/style-analysis/calibration.ts
+++ b/src/lib/server/style-analysis/calibration.ts
@@ -31,11 +31,10 @@ const VARIANT_SCHEMA = {
 const REVISION_SCHEMA = {
 	type: 'object',
 	additionalProperties: false,
-	required: ['statement', 'instruction', 'scope'],
+	required: ['statement', 'instruction'],
 	properties: {
 		statement: { type: 'string' },
-		instruction: { type: 'string' },
-		scope: { type: 'array', items: { type: 'string' } }
+		instruction: { type: 'string' }
 	}
 };
 
@@ -98,7 +97,6 @@ export async function generateCalibrationTrial(input: {
 	id: string;
 	provider: ProviderId;
 	model?: string;
-	contentBrief?: string;
 }): Promise<CalibrationTrial> {
 	let profile = readStyleProfile();
 	const report = readStyleReport();
@@ -138,8 +136,7 @@ Call submit_style_variant once.`,
 					variant: rewritten,
 					targetExplanation: typeof parsed.targetExplanation === 'string' ? parsed.targetExplanation : ''
 				};
-			},
-			abortSignal: new AbortController().signal
+			}
 		});
 		original = fallbackPassage;
 		variant = generated.variant;
@@ -178,7 +175,7 @@ async function reviseFromChoice(input: {
 	proposition: StyleProposition;
 	chosenText: string;
 	reason: string;
-}): Promise<{ statement: string; instruction: string; scope: string[] }> {
+}): Promise<{ statement: string; instruction: string }> {
 	return runStructuredStyleAgent({
 		providerId: input.provider,
 		model: input.model,
@@ -187,8 +184,7 @@ async function reviseFromChoice(input: {
 		toolName: 'submit_calibration_revision',
 		toolDescription: 'Submit the revised user confirmed style proposition.',
 		inputSchema: REVISION_SCHEMA,
-		parse: (value) => CalibrationRevisionSchema.parse(value),
-		abortSignal: new AbortController().signal
+		parse: (value) => CalibrationRevisionSchema.parse(value)
 	});
 }
 
@@ -229,7 +225,11 @@ export async function answerCalibrationTrial(input: {
 				chosenText,
 				reason: input.choice === 'neither' ? 'The user rejected both generated passages and wrote an acceptable version.' : 'The user preferred the close variant that did not support the previous proposition.'
 			});
-			nextProposition = { ...nextProposition, ...revision };
+			nextProposition = {
+				...nextProposition,
+				statement: revision.statement,
+				instruction: revision.instruction
+			};
 		}
 		nextProposition.status = 'confirmed';
 		nextProposition.confidence = 1;

--- a/src/lib/server/style-analysis/calibration.ts
+++ b/src/lib/server/style-analysis/calibration.ts
@@ -1,9 +1,13 @@
 import type { CalibrationChoice, CalibrationTrial, StyleAnalysisReport, StyleProfile, StyleProposition } from '$lib/style-profile';
-import { isActiveProposition } from '$lib/style-profile';
 import type { ProviderId } from '$lib/server/providers/types';
 import { compileAuthorStyleSkill } from './skill-compiler';
 import { CalibrationRevisionSchema } from './schemas';
-import { readStyleProfile, readStyleReport, writeStyleProfile } from './profile-store';
+import {
+	persistProfileAfterPropositionChange,
+	readStyleProfile,
+	readStyleReport,
+	writeStyleProfile
+} from './profile-store';
 import { runStructuredStyleAgent } from './run-manager';
 import { appendStyleStudyEvent } from './study-log';
 import { STYLE_FEATURE_REGISTRY } from './feature-registry';
@@ -241,15 +245,7 @@ export async function answerCalibrationTrial(input: {
 	};
 	profile.propositions = profile.propositions.map((candidate) => candidate.id === proposition.id ? nextProposition : candidate);
 	profile.calibrations = profile.calibrations.map((candidate) => candidate.id === trial.id ? nextTrial : candidate);
-	const unresolved = profile.propositions.filter((candidate) => candidate.status === 'pending').length;
-	const active = profile.propositions.filter(isActiveProposition);
-	profile.status = unresolved ? 'needs-calibration' : active.length ? 'active' : 'ready-to-analyze';
-	if (active.length) {
-		const skill = compileAuthorStyleSkill(profile, report);
-		profile.skillId = skill.skillId;
-		profile.skillPath = skill.skillPath;
-	}
-	profile = writeStyleProfile(profile);
+	profile = persistProfileAfterPropositionChange(profile, report, compileAuthorStyleSkill);
 	appendStyleStudyEvent('calibration_answered', {
 		calibrationId: trial.id,
 		propositionId: proposition.id,

--- a/src/lib/server/style-analysis/profile-store.ts
+++ b/src/lib/server/style-analysis/profile-store.ts
@@ -2,19 +2,23 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type {
-	FeatureMeasurement,
+	CalibrationTrial,
 	StyleAnalysisReport,
 	StyleProfile,
 	StyleProfileSummary,
 	StyleProposition
 } from '$lib/style-profile';
-import { isActiveProposition, STYLE_ANALYZER_VERSION, STYLE_PROFILE_SCHEMA_VERSION } from '$lib/style-profile';
+import {
+	deriveStyleProfileStatus,
+	isActiveProposition,
+	STYLE_ANALYZER_VERSION,
+	STYLE_PROFILE_SCHEMA_VERSION
+} from '$lib/style-profile';
 import { DOCWRITER_DIR, ensureDocWriterDir } from '$lib/server/document-files';
 import { writeJsonAtomic } from '$lib/server/file-utils';
-import { listStyleReferences } from '$lib/server/references';
+import { isSelected, listStyleReferences } from '$lib/server/references';
 import { referenceIsStale } from './materialize';
 import type { PropositionDraft } from './schemas';
-import { propositionTypeIsAllowed } from './feature-registry';
 import { StyleAnalysisReportSchema, StyleProfileSchema } from './schemas';
 
 export const STYLE_PROFILE_FILE = join(DOCWRITER_DIR, 'style-profile.json');
@@ -44,11 +48,26 @@ export function writeStyleProfile(profile: StyleProfile): StyleProfile {
 	return next;
 }
 
+/** Strip the answer key before any calibration trial leaves the server. */
+export function publicCalibrationTrial(trial: CalibrationTrial): Omit<CalibrationTrial, 'targetCandidate'> {
+	const { targetCandidate: _targetCandidate, ...publicTrial } = trial;
+	return publicTrial;
+}
+
 export function styleProfileForClient(profile: StyleProfile): StyleProfile {
 	return {
 		...profile,
-		calibrations: profile.calibrations.map(({ targetCandidate: _targetCandidate, ...trial }) => trial)
+		calibrations: profile.calibrations.map((trial) => publicCalibrationTrial(trial))
 	};
+}
+
+/** Hash of the selected sources that feed analysis — must match analyzeDocuments. */
+export function referencesSnapshotHash(
+	references: Array<{ id: string; role: string; contentHash?: string }>
+): string {
+	return createHash('sha256')
+		.update(references.map((reference) => `${reference.id}:${reference.role}:${reference.contentHash ?? ''}`).sort().join('|'))
+		.digest('hex');
 }
 
 export function createStyleProfile(sourceSnapshotHash: string): StyleProfile {
@@ -79,23 +98,6 @@ export function writeStyleReport(report: StyleAnalysisReport): StyleAnalysisRepo
 	const validated = StyleAnalysisReportSchema.parse(report) as StyleAnalysisReport;
 	writeJsonAtomic(STYLE_REPORT_FILE, validated);
 	return validated;
-}
-
-function average(values: number[]): number {
-	return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
-}
-
-function agreementForMeasurement(measurement: FeatureMeasurement): number {
-	const median = Math.abs(measurement.distribution?.median ?? measurement.value);
-	const mad = measurement.distribution?.mad ?? 0;
-	return Math.max(0, 1 - Math.min(1, mad / Math.max(0.01, median)));
-}
-
-function roleAgreement(measurement: FeatureMeasurement): number {
-	const authored = measurement.roleValues.authored;
-	const inspiration = measurement.roleValues.inspiration;
-	if (authored === undefined || inspiration === undefined) return 1;
-	return Math.max(0, 1 - Math.min(1, Math.abs(authored - inspiration) / Math.max(0.01, Math.abs(authored) + Math.abs(inspiration))));
 }
 
 /** Quotes drift in punctuation and spacing; match on the shape of the words.
@@ -194,7 +196,7 @@ export function propositionFromDraft(
 }
 
 export function styleProfileSummary(): StyleProfileSummary {
-	const references = listStyleReferences();
+	const references = listStyleReferences().filter(isSelected);
 	const profile = readStyleProfile();
 	if (!references.length) {
 		return { status: 'empty', referenceCount: 0, activeCount: 0, unresolvedCount: 0, stale: false, profile: profile ? styleProfileForClient(profile) : null };
@@ -204,11 +206,24 @@ export function styleProfileSummary(): StyleProfileSummary {
 	}
 	const stale = references.some(referenceIsStale)
 		|| references.some((reference) => reference.materializationStatus !== 'ready')
-		|| createHash('sha256')
-			.update(references.map((reference) => `${reference.id}:${reference.role}:${reference.contentHash ?? ''}`).sort().join('|'))
-			.digest('hex') !== profile.sourceSnapshotHash;
+		|| referencesSnapshotHash(references) !== profile.sourceSnapshotHash;
 	const activeCount = profile.propositions.filter(isActiveProposition).length;
 	const unresolvedCount = profile.propositions.filter((proposition) => proposition.status === 'pending').length;
 	const status = stale && profile.status !== 'analyzing' ? 'stale' : profile.status;
 	return { status, referenceCount: references.length, activeCount, unresolvedCount, stale, profile: styleProfileForClient({ ...profile, status }) };
+}
+
+/** Recompute status, compile the skill when anything is active, and persist. */
+export function persistProfileAfterPropositionChange(
+	profile: StyleProfile,
+	report: StyleAnalysisReport,
+	compile: (profile: StyleProfile, report: StyleAnalysisReport) => { skillId: string; skillPath: string }
+): StyleProfile {
+	profile.status = deriveStyleProfileStatus(profile.propositions);
+	if (profile.propositions.some(isActiveProposition)) {
+		const skill = compile(profile, report);
+		profile.skillId = skill.skillId;
+		profile.skillPath = skill.skillPath;
+	}
+	return writeStyleProfile(profile);
 }

--- a/src/lib/server/style-analysis/run-log-store.ts
+++ b/src/lib/server/style-analysis/run-log-store.ts
@@ -17,6 +17,19 @@ import type { SpecialistLogEntry } from './run-manager';
 /** Belt and braces against a runaway agent filling the database. */
 const MAX_LINES_PER_RUN = 2000;
 
+/** Per-run insert counts so we do not COUNT(*) on every closed line. */
+const lineCounts = new Map<string, number>();
+
+function countedLines(runId: string): number {
+	const cached = lineCounts.get(runId);
+	if (cached !== undefined) return cached;
+	const { count } = getDb()
+		.prepare('SELECT COUNT(*) AS count FROM style_run_logs WHERE run_id = ?')
+		.get(runId) as { count: number };
+	lineCounts.set(runId, count);
+	return count;
+}
+
 /** Never throws: a trace is for looking at, and losing a line must not fail a
  *  run. Callers can append without guarding. */
 export function appendRunLog(runId: string, entry: SpecialistLogEntry) {
@@ -28,12 +41,9 @@ export function appendRunLog(runId: string, entry: SpecialistLogEntry) {
 }
 
 function appendRunLogOrThrow(runId: string, entry: SpecialistLogEntry) {
-	const db = getDb();
-	const { count } = db
-		.prepare('SELECT COUNT(*) AS count FROM style_run_logs WHERE run_id = ?')
-		.get(runId) as { count: number };
+	const count = countedLines(runId);
 	if (count >= MAX_LINES_PER_RUN) return;
-	db.prepare(
+	getDb().prepare(
 		`INSERT INTO style_run_logs (run_id, specialist_id, kind, text, tool_name, created)
 		 VALUES (?, ?, ?, ?, ?, ?)`
 	).run(
@@ -44,6 +54,7 @@ function appendRunLogOrThrow(runId: string, entry: SpecialistLogEntry) {
 		entry.toolName ?? null,
 		Date.now()
 	);
+	lineCounts.set(runId, count + 1);
 }
 
 /** Every stored line for a run, in the order it happened, keyed by specialist. */
@@ -74,4 +85,5 @@ export function readRunLogs(runId: string): Record<string, SpecialistLogEntry[]>
 
 export function deleteRunLogs(runId: string) {
 	getDb().prepare('DELETE FROM style_run_logs WHERE run_id = ?').run(runId);
+	lineCounts.delete(runId);
 }

--- a/src/lib/server/style-analysis/run-manager.ts
+++ b/src/lib/server/style-analysis/run-manager.ts
@@ -48,7 +48,8 @@ export interface SpecialistLogEntry {
 
 export interface StyleRunEvent {
 	type: 'snapshot' | 'progress' | 'specialist' | 'specialist_log' | 'completed' | 'error' | 'cancelled';
-	run: StyleAnalysisRun;
+	/** Omitted on high-volume `specialist_log` lines — clients keep their last run snapshot. */
+	run?: StyleAnalysisRun;
 	message?: string;
 	log?: SpecialistLogEntry;
 }
@@ -95,20 +96,20 @@ function emit(run: ManagedRun, type: StyleRunEvent['type'], message?: string) {
 	const snapshot = publicRun(run);
 	if (run.profile) {
 		run.profile.lastRun = snapshot;
-		// Progress ticks are frequent; persist durable outcomes and specialist
-		// transitions so a reload mid-run is accurate without rewriting on every tick.
-		if (type !== 'progress') {
+		// Specialists run in parallel; persisting on every status tick races the
+		// same JSON file. Keep lastRun in memory and write only at terminal events
+		// (executeRun also writes explicitly at phase boundaries).
+		if (type === 'completed' || type === 'error' || type === 'cancelled') {
 			run.profile = writeStyleProfile(run.profile);
 		}
 	}
 	run.emitter.emit('event', { type, run: snapshot, message } satisfies StyleRunEvent);
 }
 
-/** Trace lines are high-volume: skip profile writes and deep-clones. */
+/** Trace lines are high-volume: no profile write, no run clone/payload. */
 function emitLog(run: ManagedRun, log: SpecialistLogEntry) {
 	run.emitter.emit('event', {
 		type: 'specialist_log',
-		run: run.state,
 		log
 	} satisfies StyleRunEvent);
 }
@@ -306,11 +307,10 @@ function sourceExcerpts(
 
 function specialistPrompt(
 	report: StyleAnalysisReport,
-	documents: NormalizedDocument[],
-	descriptions: Record<string, string>,
-	families: StyleFamily[]
+	families: StyleFamily[],
+	vocabulary: string[],
+	excerpts: string
 ): string {
-	const vocabulary = characteristicVocabulary(documents);
 	return [
 		'Measurements that fired for your families (zeros already removed — treat these as hints, not the answer):',
 		JSON.stringify(reportSlice(report, families)),
@@ -320,7 +320,7 @@ function specialistPrompt(
 		'The writing. Each source is labeled with what the author says it is.',
 		'Read it, then write ghostwriter instructions in plain language:',
 		'',
-		sourceExcerpts(documents, descriptions)
+		excerpts
 	].join('\n');
 }
 
@@ -465,7 +465,9 @@ async function runSpecialist(
 	run: ManagedRun,
 	report: StyleAnalysisReport,
 	documents: NormalizedDocument[],
-	descriptions: Record<string, string>,
+	corpus: string,
+	vocabulary: string[],
+	excerpts: string,
 	specialist: (typeof SPECIALISTS)[number]
 ): Promise<PropositionDraft[]> {
 	updateSpecialist(run, specialist.id, { status: 'running', startedAt: now(), error: undefined });
@@ -473,14 +475,13 @@ async function runSpecialist(
 		providerId: run.state.provider as ProviderId,
 		model: run.state.model,
 		systemPrompt: specialistSystemPrompt(specialist.families),
-		prompt: specialistPrompt(report, documents, descriptions, specialist.families),
+		prompt: specialistPrompt(report, specialist.families, vocabulary, excerpts),
 		toolName: 'submit_style_families',
 		toolDescription: 'Submit all grounded style propositions for the assigned feature families.',
 		inputSchema: draftJsonSchema(),
 		onEvent: (event) => forwardSpecialistEvent(run, specialist.id, event),
 		parse: (value) => {
 			const parsed = SpecialistSubmissionSchema.parse(value);
-			const corpus = corpusText(documents);
 			for (const draft of parsed.propositions) {
 				if (!specialist.families.includes(draft.family)) throw new Error(`Family ${draft.family} is outside this specialist assignment`);
 				validateDraftGrounding(draft, corpus);
@@ -596,8 +597,13 @@ async function executeRun(run: ManagedRun, force: boolean) {
 		run.state.phase = 'reflecting';
 		run.state.progress = 35;
 		emit(run, 'progress', 'Running three style specialists');
+		const corpus = corpusText(documents);
+		const vocabulary = characteristicVocabulary(documents);
+		const excerpts = sourceExcerpts(documents, descriptions);
 		const specialistResults = await Promise.all(
-			SPECIALISTS.map((specialist) => runSpecialist(run, report, documents, descriptions, specialist))
+			SPECIALISTS.map((specialist) =>
+				runSpecialist(run, report, documents, corpus, vocabulary, excerpts, specialist)
+			)
 		);
 		if (run.abortController.signal.aborted) throw new Error('Style analysis was cancelled');
 		const drafts = specialistResults.flat();
@@ -605,8 +611,7 @@ async function executeRun(run: ManagedRun, force: boolean) {
 		run.state.phase = 'synthesizing';
 		run.state.progress = 75;
 		emit(run, 'progress', 'Merging grounded propositions');
-		const synthesized = drafts.length ? await runSynthesis(run, corpusText(documents), drafts) : [];
-		const corpus = corpusText(documents);
+		const synthesized = drafts.length ? await runSynthesis(run, corpus, drafts) : [];
 		const grounded: StyleProposition[] = [];
 		let droppedUngrounded = 0;
 		synthesized.forEach((draft, index) => {

--- a/src/lib/server/style-analysis/run-manager.ts
+++ b/src/lib/server/style-analysis/run-manager.ts
@@ -104,11 +104,11 @@ function emit(run: ManagedRun, type: StyleRunEvent['type'], message?: string) {
 	run.emitter.emit('event', { type, run: snapshot, message } satisfies StyleRunEvent);
 }
 
-/** Trace lines are high-volume, so they skip the profile write that emit() does. */
+/** Trace lines are high-volume: skip profile writes and deep-clones. */
 function emitLog(run: ManagedRun, log: SpecialistLogEntry) {
 	run.emitter.emit('event', {
 		type: 'specialist_log',
-		run: publicRun(run),
+		run: run.state,
 		log
 	} satisfies StyleRunEvent);
 }
@@ -352,7 +352,8 @@ export async function runStructuredStyleAgent<T>(input: {
 	toolDescription: string;
 	inputSchema: Record<string, unknown>;
 	parse: (value: unknown) => T;
-	abortSignal: AbortSignal;
+	/** Optional — calibration calls are uncancellable today. */
+	abortSignal?: AbortSignal;
 	/** Observe the agent's working trace. Purely for display. */
 	onEvent?: (event: ProviderEvent) => void;
 }): Promise<T> {
@@ -384,7 +385,7 @@ export async function runStructuredStyleAgent<T>(input: {
 		input.onEvent?.(event);
 		if (event.type === 'error') providerError = event.error;
 	}
-	if (input.abortSignal.aborted) throw new Error('Style analysis was cancelled');
+	if (input.abortSignal?.aborted) throw new Error('Style analysis was cancelled');
 	if (!submission) throw new Error(providerError || `Agent did not call ${input.toolName}`);
 	return submission;
 }
@@ -492,7 +493,9 @@ async function runSpecialist(
 		let result: SpecialistSubmission;
 		try {
 			result = await execute();
-		} catch {
+		} catch (error) {
+			// One retry for transient provider failures — never after cancel.
+			if (run.abortController.signal.aborted) throw error;
 			result = await execute();
 		}
 		updateSpecialist(run, specialist.id, { status: 'completed', completedAt: now() });
@@ -567,6 +570,7 @@ async function executeRun(run: ManagedRun, force: boolean) {
 		run.state.progress = 5;
 		emit(run, 'progress', 'Reading reference sources');
 		const materialized = await materializeAllReferences(force);
+		if (!materialized.length) throw new Error('Add at least one writing reference before analysis');
 		if (run.abortController.signal.aborted) throw new Error('Style analysis was cancelled');
 
 		run.state.phase = 'measuring';
@@ -578,8 +582,15 @@ async function executeRun(run: ManagedRun, force: boolean) {
 			materialized.map((item) => [item.reference.id, item.reference.description ?? item.reference.label])
 		);
 		const report = writeStyleReport(analyzeDocuments(documents) as StyleAnalysisReport);
-		run.profile = createStyleProfile(report.sourceSnapshotHash);
-		run.profile.lastRun = publicRun(run);
+		// Keep prior propositions on disk until synthesis finishes so a crash
+		// mid-run does not wipe confirmed guidance.
+		const base = run.profile ?? createStyleProfile(report.sourceSnapshotHash);
+		run.profile = {
+			...base,
+			status: 'analyzing',
+			sourceSnapshotHash: report.sourceSnapshotHash,
+			lastRun: publicRun(run)
+		};
 		writeStyleProfile(run.profile);
 
 		run.state.phase = 'reflecting';
@@ -597,16 +608,24 @@ async function executeRun(run: ManagedRun, force: boolean) {
 		const synthesized = drafts.length ? await runSynthesis(run, corpusText(documents), drafts) : [];
 		const corpus = corpusText(documents);
 		const grounded: StyleProposition[] = [];
+		let droppedUngrounded = 0;
 		synthesized.forEach((draft, index) => {
 			// A proposition whose examples are not in the sources is dropped, not
 			// surfaced — the writer should never be shown invented evidence.
 			try {
 				grounded.push(propositionFromDraft(draft, corpus, index));
 			} catch {
-				// Skip it.
+				droppedUngrounded += 1;
 			}
 		});
 		const propositions = carryConfirmed(previous, grounded);
+		if (!propositions.length) {
+			throw new Error(
+				droppedUngrounded
+					? `Style analysis produced no grounded propositions (${droppedUngrounded} dropped: examples not in sources)`
+					: 'Style analysis produced no grounded propositions'
+			);
+		}
 		const pending = propositions.filter((proposition) => proposition.status === 'pending');
 		const active = propositions.filter(isActiveProposition);
 		run.profile.propositions = propositions;
@@ -615,8 +634,7 @@ async function executeRun(run: ManagedRun, force: boolean) {
 			propositionId: proposition.id,
 			status: 'pending'
 		}));
-		// Nothing grounded at all is a failed analysis; otherwise derive from the set.
-		run.profile.status = propositions.length ? deriveStyleProfileStatus(propositions) : 'error';
+		run.profile.status = deriveStyleProfileStatus(propositions);
 
 		run.state.phase = 'compiling';
 		run.state.progress = 90;
@@ -639,6 +657,7 @@ async function executeRun(run: ManagedRun, force: boolean) {
 			model: run.state.model,
 			activeCount: active.length,
 			pendingCount: pending.length,
+			droppedUngrounded,
 			referenceCount: report.documents.length,
 			authoredReferenceCount: report.documents.filter((document) => document.role === 'authored').length,
 			inspirationReferenceCount: report.documents.filter((document) => document.role === 'inspiration').length,

--- a/src/lib/server/style-analysis/run-manager.ts
+++ b/src/lib/server/style-analysis/run-manager.ts
@@ -9,7 +9,7 @@ import type {
 	StyleProfile,
 	StyleProposition
 } from '$lib/style-profile';
-import { isActiveProposition } from '$lib/style-profile';
+import { deriveStyleProfileStatus, isActiveProposition } from '$lib/style-profile';
 import type { ProviderEvent, ProviderId, ToolDefinition } from '$lib/server/providers/types';
 import { getProvider } from '$lib/server/providers';
 import { analyzeDocuments } from './analyze-style.mjs';
@@ -36,7 +36,7 @@ import { compileAuthorStyleSkill } from './skill-compiler';
 import { appendStyleStudyEvent } from './study-log';
 import { appendRunLog } from './run-log-store';
 import { STYLE_FEATURE_REGISTRY } from './feature-registry';
-import { listStyleReferences } from '$lib/server/references';
+import { isSelected, listStyleReferences } from '$lib/server/references';
 
 /** One line of a specialist's working trace, streamed as it happens. */
 export interface SpecialistLogEntry {
@@ -92,11 +92,16 @@ function publicRun(run: ManagedRun): StyleAnalysisRun {
 
 function emit(run: ManagedRun, type: StyleRunEvent['type'], message?: string) {
 	run.state.updatedAt = now();
+	const snapshot = publicRun(run);
 	if (run.profile) {
-		run.profile.lastRun = publicRun(run);
-		run.profile = writeStyleProfile(run.profile);
+		run.profile.lastRun = snapshot;
+		// Progress ticks are frequent; persist durable outcomes and specialist
+		// transitions so a reload mid-run is accurate without rewriting on every tick.
+		if (type !== 'progress') {
+			run.profile = writeStyleProfile(run.profile);
+		}
 	}
-	run.emitter.emit('event', { type, run: publicRun(run), message } satisfies StyleRunEvent);
+	run.emitter.emit('event', { type, run: snapshot, message } satisfies StyleRunEvent);
 }
 
 /** Trace lines are high-volume, so they skip the profile write that emit() does. */
@@ -610,7 +615,8 @@ async function executeRun(run: ManagedRun, force: boolean) {
 			propositionId: proposition.id,
 			status: 'pending'
 		}));
-		run.profile.status = pending.length ? 'needs-calibration' : active.length ? 'active' : 'error';
+		// Nothing grounded at all is a failed analysis; otherwise derive from the set.
+		run.profile.status = propositions.length ? deriveStyleProfileStatus(propositions) : 'error';
 
 		run.state.phase = 'compiling';
 		run.state.progress = 90;
@@ -669,7 +675,9 @@ async function executeRun(run: ManagedRun, force: boolean) {
 }
 
 export function startStyleAnalysisRun(input: { provider: ProviderId; model?: string; force?: boolean }): StyleAnalysisRun {
-	if (listStyleReferences().length === 0) throw new Error('Add at least one writing reference before analysis');
+	if (!listStyleReferences().some(isSelected)) {
+		throw new Error('Add at least one writing reference before analysis');
+	}
 	if (activeRunId) {
 		const active = jobs.get(activeRunId);
 		if (active && ['queued', 'running'].includes(active.state.status)) throw new Error('A style analysis is already running');

--- a/src/lib/server/style-analysis/schemas.ts
+++ b/src/lib/server/style-analysis/schemas.ts
@@ -48,8 +48,7 @@ export const SynthesisSubmissionSchema = z.object({
 
 export const CalibrationRevisionSchema = z.object({
 	statement: z.string().trim().min(1).max(1000),
-	instruction: z.string().trim().min(1).max(1000),
-	scope: z.array(z.string().trim().min(1).max(160)).max(12).default([])
+	instruction: z.string().trim().min(1).max(1000)
 });
 
 export const FeatureMeasurementSchema = z.object({

--- a/src/lib/server/style-analysis/schemas.ts
+++ b/src/lib/server/style-analysis/schemas.ts
@@ -46,13 +46,6 @@ export const SynthesisSubmissionSchema = z.object({
 	summary: z.string().trim().min(1).max(6000).default('Generated author style profile')
 });
 
-export const CalibrationCandidatesSchema = z.object({
-	candidateA: z.string().trim().min(20).max(4000),
-	candidateB: z.string().trim().min(20).max(4000),
-	supportsProposition: z.enum(['a', 'b']),
-	targetExplanation: z.string().trim().min(1).max(1000)
-});
-
 export const CalibrationRevisionSchema = z.object({
 	statement: z.string().trim().min(1).max(1000),
 	instruction: z.string().trim().min(1).max(1000),
@@ -162,4 +155,3 @@ export const StyleProfileSchema = z.object({
 export type PropositionDraft = z.infer<typeof PropositionDraftSchema>;
 export type SpecialistSubmission = z.infer<typeof SpecialistSubmissionSchema>;
 export type SynthesisSubmission = z.infer<typeof SynthesisSubmissionSchema>;
-export type CalibrationCandidates = z.infer<typeof CalibrationCandidatesSchema>;

--- a/src/lib/server/style-analysis/skill-compiler.ts
+++ b/src/lib/server/style-analysis/skill-compiler.ts
@@ -5,7 +5,7 @@ import { isActiveProposition } from '$lib/style-profile';
 import { DOCWRITER_DIR } from '$lib/server/document-files';
 import { readSkillsConfig, upsertManagedSkill } from '$lib/server/skills-config';
 import { writeJsonAtomic, writeTextAtomic } from '$lib/server/file-utils';
-import { listStyleReferences, REFERENCES_CACHE_DIR } from '$lib/server/references';
+import { isSelected, listStyleReferences, REFERENCES_CACHE_DIR } from '$lib/server/references';
 import { skillVersionFor, snapshotSkillVersion } from './skill-versions';
 import { normalizeForMatch } from './profile-store';
 import analyzerScript from './analyze-style.mjs?raw';
@@ -54,10 +54,10 @@ function activePropositions(profile: StyleProfile): StyleProposition[] {
 	return profile.propositions.filter(isActiveProposition);
 }
 
-/** The author's sources as one blob, for widening quoted examples. */
+/** The author's selected sources as one blob, for widening quoted examples. */
 function sourceCorpus(): string {
 	const texts: string[] = [];
-	for (const reference of listStyleReferences()) {
+	for (const reference of listStyleReferences().filter(isSelected)) {
 		const path = join(REFERENCES_CACHE_DIR, `${reference.id}.txt`);
 		if (!existsSync(path)) continue;
 		try {

--- a/src/lib/style-profile.ts
+++ b/src/lib/style-profile.ts
@@ -176,6 +176,17 @@ export function isActiveProposition(proposition: { status: PropositionStatus }):
 	return proposition.status === 'active' || proposition.status === 'confirmed';
 }
 
+/** Profile status from the current proposition set (pending beats active). */
+export function deriveStyleProfileStatus(
+	propositions: Array<{ status: PropositionStatus }>
+): Exclude<StyleProfileStatus, 'empty' | 'analyzing' | 'stale' | 'error'> {
+	if (propositions.some((proposition) => proposition.status === 'pending')) {
+		return 'needs-calibration';
+	}
+	if (propositions.some(isActiveProposition)) return 'active';
+	return 'ready-to-analyze';
+}
+
 export type CalibrationChoice = 'a' | 'b' | 'same' | 'neither' | 'skip';
 
 export interface CalibrationTrial {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import ModelPicker from '$lib/components/ModelPicker.svelte';
 	import ReferenceStatusPill from '$lib/components/ReferenceStatusPill.svelte';
 	import ReferenceCalibrationDialog from '$lib/components/ReferenceCalibrationDialog.svelte';
+	import { isActiveProposition } from '$lib/style-profile';
 	import OutlinePane from '$lib/components/OutlinePane.svelte';
 	import FileTree from '$lib/components/FileTree.svelte';
 	import type { FileEntry } from '$lib/components/FileTree.svelte';
@@ -2205,7 +2206,7 @@
 			if (!response.ok) return null;
 			const summary = await response.json();
 			const active = (summary?.profile?.propositions ?? [])
-				.filter((p: { status: string }) => p.status === 'active' || p.status === 'confirmed')
+				.filter(isActiveProposition)
 				.map((p: { id: string; instruction: string }) => `${p.id}:${p.instruction}`)
 				.sort();
 			return JSON.stringify(active);

--- a/src/routes/api/references/[id]/+server.ts
+++ b/src/routes/api/references/[id]/+server.ts
@@ -2,7 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
 	deleteStyleReference,
-	listStyleReferences,
+	getStyleReference,
 	updateStyleReference
 } from '$lib/server/references';
 import { updateMaterializedReferenceText } from '$lib/server/style-analysis/materialize';
@@ -17,7 +17,7 @@ function decodeId(raw: string): string {
 
 export const GET: RequestHandler = async ({ params }) => {
 	const id = decodeId(params.id);
-	const reference = listStyleReferences().find((ref) => ref.id === id);
+	const reference = getStyleReference(id);
 	if (!reference) throw error(404, 'Reference not found');
 	return json({ reference });
 };
@@ -37,8 +37,10 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	try {
 		if (typeof body?.text === 'string') {
 			const materialized = updateMaterializedReferenceText(id, body.text);
-			if (body.role) updateStyleReference(id, { role: body.role });
-			return json({ reference: listStyleReferences().find((reference) => reference.id === id), materialized: { text: materialized.text } });
+			const reference = body.role
+				? updateStyleReference(id, { role: body.role })
+				: getStyleReference(id);
+			return json({ reference, materialized: { text: materialized.text } });
 		}
 		const reference = updateStyleReference(id, {
 			...(body.role ? { role: body.role } : {}),

--- a/src/routes/api/style-profile/calibrations/[id]/+server.ts
+++ b/src/routes/api/style-profile/calibrations/[id]/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import type { CalibrationChoice } from '$lib/style-profile';
 import type { ProviderId } from '$lib/server/providers/types';
 import { answerCalibrationTrial, generateCalibrationTrial } from '$lib/server/style-analysis/calibration';
-import { styleProfileForClient } from '$lib/server/style-analysis/profile-store';
+import { publicCalibrationTrial, styleProfileForClient } from '$lib/server/style-analysis/profile-store';
 
 const PROVIDERS = new Set<ProviderId>(['claude', 'openai', 'codex', 'cursor', 'pi']);
 const CHOICES = new Set<CalibrationChoice>(['a', 'b', 'same', 'neither', 'skip']);
@@ -22,8 +22,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 			model: typeof body.model === 'string' && body.model ? body.model : undefined,
 			contentBrief: typeof body.contentBrief === 'string' ? body.contentBrief : undefined
 		});
-		const { targetCandidate: _targetCandidate, ...publicTrial } = trial;
-		return json({ trial: publicTrial });
+		return json({ trial: publicCalibrationTrial(trial) });
 	} catch (cause) {
 		throw error(400, cause instanceof Error ? cause.message : String(cause));
 	}
@@ -40,8 +39,10 @@ export const PUT: RequestHandler = async ({ params, request }) => {
 			provider: providerFrom(body.provider),
 			model: typeof body.model === 'string' && body.model ? body.model : undefined
 		});
-		const { targetCandidate: _targetCandidate, ...publicTrial } = result.trial;
-		return json({ profile: styleProfileForClient(result.profile), trial: publicTrial });
+		return json({
+			profile: styleProfileForClient(result.profile),
+			trial: publicCalibrationTrial(result.trial)
+		});
 	} catch (cause) {
 		throw error(400, cause instanceof Error ? cause.message : String(cause));
 	}

--- a/src/routes/api/style-profile/calibrations/[id]/+server.ts
+++ b/src/routes/api/style-profile/calibrations/[id]/+server.ts
@@ -19,8 +19,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 		const trial = await generateCalibrationTrial({
 			id: params.id,
 			provider: providerFrom(body.provider),
-			model: typeof body.model === 'string' && body.model ? body.model : undefined,
-			contentBrief: typeof body.contentBrief === 'string' ? body.contentBrief : undefined
+			model: typeof body.model === 'string' && body.model ? body.model : undefined
 		});
 		return json({ trial: publicCalibrationTrial(trial) });
 	} catch (cause) {

--- a/src/routes/api/style-profile/propositions/[id]/+server.ts
+++ b/src/routes/api/style-profile/propositions/[id]/+server.ts
@@ -1,8 +1,12 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { compileAuthorStyleSkill } from '$lib/server/style-analysis/skill-compiler';
-import { readStyleProfile, readStyleReport, styleProfileForClient, writeStyleProfile } from '$lib/server/style-analysis/profile-store';
-import { isActiveProposition } from '$lib/style-profile';
+import {
+	persistProfileAfterPropositionChange,
+	readStyleProfile,
+	readStyleReport,
+	styleProfileForClient
+} from '$lib/server/style-analysis/profile-store';
 
 export const PATCH: RequestHandler = async ({ params, request }) => {
 	let profile = readStyleProfile();
@@ -23,12 +27,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		updatedAt: Date.now()
 	};
 	profile.propositions = profile.propositions.map((proposition) => proposition.id === params.id ? next : proposition);
-	const unresolved = profile.propositions.some((proposition) => proposition.status === 'pending');
-	const hasActive = profile.propositions.some(isActiveProposition);
-	profile.status = unresolved ? 'needs-calibration' : hasActive ? 'active' : 'ready-to-analyze';
-	const skill = compileAuthorStyleSkill(profile, report);
-	profile.skillId = skill.skillId;
-	profile.skillPath = skill.skillPath;
-	profile = writeStyleProfile(profile);
+	profile = persistProfileAfterPropositionChange(profile, report, compileAuthorStyleSkill);
 	return json({ profile: styleProfileForClient(profile), proposition: next });
 };

--- a/src/routes/api/style-profile/propositions/[id]/+server.ts
+++ b/src/routes/api/style-profile/propositions/[id]/+server.ts
@@ -22,7 +22,6 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		...existing,
 		...(typeof body.instruction === 'string' && body.instruction.trim() ? { instruction: body.instruction.trim() } : {}),
 		...(typeof body.statement === 'string' && body.statement.trim() ? { statement: body.statement.trim() } : {}),
-		...(Array.isArray(body.scope) ? { scope: body.scope.filter((item: unknown): item is string => typeof item === 'string' && Boolean(item.trim())).map((item: string) => item.trim()) } : {}),
 		...(body.status ? { status: body.status } : {}),
 		updatedAt: Date.now()
 	};

--- a/src/routes/api/style-profile/reset/+server.ts
+++ b/src/routes/api/style-profile/reset/+server.ts
@@ -1,20 +1,24 @@
 import { json } from '@sveltejs/kit';
 import { existsSync, rmSync } from 'fs';
 import type { RequestHandler } from './$types';
-import { STYLE_ANALYSIS_DIR, STYLE_PROFILE_FILE } from '$lib/server/style-analysis/profile-store';
-import { readStyleProfile } from '$lib/server/style-analysis/profile-store';
+import {
+	STYLE_PROFILE_FILE,
+	STYLE_REPORT_FILE,
+	readStyleProfile
+} from '$lib/server/style-analysis/profile-store';
 import { deleteRunLogs } from '$lib/server/style-analysis/run-log-store';
 
 /**
  * Throw away every learned proposition and the measurement report behind them,
- * so the next run starts from nothing. Sources are left alone — starting over
- * on the analysis should not mean re-collecting the writing.
+ * so the next run starts from nothing. Sources and their materialized cache are
+ * left alone — starting over on the analysis should not mean re-collecting or
+ * re-extracting the writing.
  */
 export const POST: RequestHandler = async () => {
 	// The traces belong to the run being thrown away, so they go with it.
 	const lastRunId = readStyleProfile()?.lastRun?.id;
 	if (lastRunId) deleteRunLogs(lastRunId);
 	if (existsSync(STYLE_PROFILE_FILE)) rmSync(STYLE_PROFILE_FILE, { force: true });
-	if (existsSync(STYLE_ANALYSIS_DIR)) rmSync(STYLE_ANALYSIS_DIR, { recursive: true, force: true });
+	if (existsSync(STYLE_REPORT_FILE)) rmSync(STYLE_REPORT_FILE, { force: true });
 	return json({ ok: true });
 };

--- a/src/routes/api/style-profile/runs/[id]/events/+server.ts
+++ b/src/routes/api/style-profile/runs/[id]/events/+server.ts
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async ({ params }) => {
 			const send = (event: StyleRunEvent) => {
 				controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
 				if (['completed', 'error', 'cancelled'].includes(event.type)
-					|| ['completed', 'error', 'cancelled'].includes(event.run.status)) {
+					|| (event.run && ['completed', 'error', 'cancelled'].includes(event.run.status))) {
 					unsubscribe?.();
 					controller.close();
 				}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cleanup pass on #77 (`feat/writing-references-author-style`), from parallel quality / performance / reuse reviews.

## Bugs fixed

- Stale snapshot/hash ignored `isSelected`; analysis could start with no selected sources
- Mid-run `createStyleProfile` wiped confirmed propositions on disk
- Empty / fully-failed analysis could still mark the run `completed`
- Blind specialist retry after cancel; parallel `writeStyleProfile` races under `Promise.all`
- Reset deleted `source-cache` while references stayed `ready`
- Pill hint claimed style was active during `needs-calibration`
- Silent discarded `scope` on revisions/PATCH; dead `rejected` status label
- Skill compile corpus included deselected sources

## Simplify / reuse

- Shared `deriveStyleProfileStatus`, `persistProfileAfterPropositionChange`, `publicCalibrationTrial`, `referencesSnapshotHash`
- Clients reuse `isActiveProposition`
- Removed dead helpers/schema/`setSelected`/`formatToolInput`/`contentBrief`/fake abort controllers/obsolete reference kinds

## Performance

- O(n) nesting-depth series; cheap structural ids (no per-token SHA-256)
- `distribution` sorts once; specialist vocabulary/excerpts computed once
- Persist profile only on terminal run events; `specialist_log` SSE omits `run`
- In-memory per-run log line counter instead of `COUNT(*)` per append

## Verification

`npm run test:unit` — 24/24  
`npm run check` — clean

## Skipped (larger)

- Split the 2k-line dialog; shared client style-profile store
- Slim/pretty-print-less report persistence; debounce skill compile
- Rhetoric marker single-pass / Aho–Corasick; binary-search sentence lookup
- Poll-only-while-analyzing / fingerprint-only stale checks
- Pasted page-chrome stripping (known gap in #77)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-349ed894-8d0e-49df-820b-4b6cd0a6dedf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-349ed894-8d0e-49df-820b-4b6cd0a6dedf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

