### PR TITLE
Point quickstart at style guidance

### DIFF
--- a/docs/agent/customize.mdx
+++ b/docs/agent/customize.mdx
@@ -8,8 +8,8 @@ You can give the agent guidance that lasts beyond one request.
   <Card title="Writing rules" icon="list-check" href="/customize/rules">
     Save a short instruction that the agent should follow across requests, such as a required term or heading style.
   </Card>
-  <Card title="Writing references" icon="book-open" href="/customize/references">
-    Give the agent a writing sample, source file, or URL to consult when a request needs that material.
+  <Card title="Style guidance" icon="book-open" href="/customize/references">
+    Paste your writing, run the style analysis, and finalize a skill the agent follows for your voice.
   </Card>
   <Card title="Skills" icon="puzzle" href="/customize/skills">
     Add a reusable procedure that explains how to complete a specific kind of work with several steps.
@@ -20,7 +20,7 @@ You can give the agent guidance that lasts beyond one request.
 
 - Use a **rule** for a short instruction, such as a required term or citation format. Enabled rules apply to your later requests.
 - Use an **intended audience** when you want to name the reader, such as busy managers or first-year students.
-- Use a **reference** when the agent should learn from an example or consult source material. You can enable or disable the saved material and name it in a request.
+- Use **style guidance** when you want the agent to learn your voice from several of your passages and follow that skill on later requests.
 - Use a **skill** for a task with a reusable procedure, such as reviewing prose or building a preview. You can run the skill directly or ask for it in Chat.
 
 You can use more than one type in the same project. For example, a rule can require plain headings while an intended audience names the reader, a reference shows the voice you want, and a skill describes the review process.
@@ -51,10 +51,10 @@ You can find writing rules in the toolbar above the editor.
   ![The writing rules panel above the editor](/images/writing-rules-panel.png)
 </Frame>
 
-Writing references and skills are under **Settings**.
+Style guidance and skills are under **Settings**. Open **Writing references** to calibrate your style.
 
 <Frame>
-  ![The Writing references panel open from Settings](/images/writing-references-panel.png)
+  ![The Calibrate your style dialog with pasted sources](/images/style-guidance-sources.png)
 </Frame>
 
 <Frame>

--- a/docs/customize/references.mdx
+++ b/docs/customize/references.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Writing references"
+title: "Style guidance"
 ---
 
 Here, we will walk through how to calibrate your writing agent with your style. You paste a few passages of your own writing, DocWriter works out how you write, and the agent follows that voice when you ask it to help. Expect this to take about **ten minutes**.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -41,7 +41,7 @@ DocWriter reimagines AI-assisted writing to let you:
     Choose a provider, sign in, and select a model.
   </Card>
   <Card title="Your first writing workflow" icon="play" href="/quickstart">
-    Add references, draft, save rules, and run final critique passes.
+    Add style guidance, draft, save rules, and run final critique passes.
   </Card>
   <Card title="Tour the interface" icon="window" href="/tour/interface">
     Learn where files, reviews, and agent activity appear.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -2,20 +2,20 @@
 title: "Your first writing workflow"
 ---
 
-Use this walkthrough for a complete writing project. You will give the agent examples before you write, leave instructions in the draft while you keep typing, give feedback on highlighted passages, discuss those threads in place, and ask several reviewer agents to critique the finished draft.
+Use this walkthrough for a complete writing project. You will calibrate the agent's style before you write, leave instructions in the draft while you keep typing, give feedback on highlighted passages, discuss those threads in place, and ask several reviewer agents to critique the finished draft.
 
 ## Connect a provider
 
 Before you start, follow the steps in [Connect a provider](/connect-provider). Continue after your provider and model appear in the header and the test request succeeds.
 
-## Add writing references
+## Add style guidance
 
-Before you ask the agent to help with the draft, you should give it examples of your writing. Click the references pill in the header, or open **Settings**, then **Writing references**. Paste three of your passages, run the analysis, pick between close passages when asked, and finalize the skill.
+Before you ask the agent to help with the draft, calibrate it on your writing voice. Open the references pill in the header, or **Settings**, then **Writing references**. Paste three of your passages, run the analysis, pick which close passages sound like you, and finalize the skill.
 
-You can follow the full screenshot walkthrough in [Writing references](/customize/references).
+Follow the full walkthrough in [Style guidance](/customize/references). Expect about ten minutes.
 
-<Frame caption="Writing references are available under Settings.">
-  ![The Writing references panel with options for adding source material](/images/writing-references-panel.png)
+<Frame caption="Paste three of your passages, then run the style analysis.">
+  ![The Calibrate your style dialog with three pasted sources ready to analyze](/images/style-guidance-sources.png)
 </Frame>
 
 ## Set the intended audience
@@ -133,4 +133,4 @@ Reply when a finding needs discussion. Accept a linked edit when the wording imp
 
 Open the project file in another editor to confirm that the accepted text is plain Markdown. Your comments and pending suggestions stay in DocWriter until you resolve the comments and accept or reject the suggestions.
 
-Read [Writing references](/customize/references), [Selected text and directives](/agent/selected-text-and-directives), [Intended audience](/agent/customize#set-the-intended-audience), [Writing rules](/customize/rules), and [Comments and critique](/agent/comments-and-critique) for the full controls. Read [Recovery](/help/recovery) if the editor, provider, or proposal does not behave as described.
+Read [Style guidance](/customize/references), [Selected text and directives](/agent/selected-text-and-directives), [Intended audience](/agent/customize#set-the-intended-audience), [Writing rules](/customize/rules), and [Comments and critique](/agent/comments-and-critique) for the full controls. Read [Recovery](/help/recovery) if the editor, provider, or proposal does not behave as described.


### PR DESCRIPTION
## Summary
- Rename the quickstart section from "Add writing references" to "Add style guidance" and link to `/customize/references`.
- Retitle that page to **Style guidance** and update the customize hub card so it no longer describes the old file/URL reference flow.
- Use the style-calibration sources screenshot instead of the old references panel image.

## Test plan
- [ ] Open `/quickstart` and confirm **Add style guidance** links to `/customize/references`
- [ ] Confirm `/customize/references` page title is **Style guidance** in the nav
- [ ] Confirm `/agent/customize` card copy matches the style-analysis flow
- [ ] Confirm `style-guidance-sources.png` renders on quickstart and customize pages


Made with [Cursor](https://cursor.com)