### PR TITLE
Add welcome step and file upload to style calibration dialog

### DIFF
--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -716,7 +716,7 @@
 									class="canvas-text"
 									bind:value={sampleText}
 									onkeydown={onComposerKeydown}
-									placeholder="Paste your writing here — aim for 3–5 samples"
+									placeholder="Paste the writing here"
 									aria-label="Passage text"
 								></textarea>
 								<div class="canvas-foot">
@@ -744,7 +744,7 @@
 							</div>
 							<div class="rail-list">
 								{#if references.length === 0}
-									<p class="panel-empty">Nothing added yet.</p>
+									<p class="panel-empty">Nothing added yet. Aim for 3 - 5 samples.</p>
 								{:else}
 									{#each references as reference (reference.id)}
 										<div

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -87,12 +87,8 @@
 	let busyId = $state<string | null>(null);
 	let neitherEdits = $state<Record<string, string>>({});
 	let calibrationSessionIds = $state<string[]>([]);
-	let importOpen = $state(false);
-	let importPath = $state('');
-	let importing = $state(false);
 	let uploadingSkill = $state(false);
 	let finalizing = $state(false);
-	let skillVersions = $state<Array<{ version: number; createdAt: number; propositionCount: number }>>([]);
 
 	const pendingTrials = $derived((summary?.profile?.calibrations ?? [])
 		.filter((trial) => calibrationSessionIds.includes(trial.id) && ['pending', 'generated', 'error'].includes(trial.status)));
@@ -241,7 +237,6 @@
 				if (run?.id) void loadStoredTraces(run.id);
 				if (run?.id && ['queued', 'running'].includes(run.status)) connectRun(run.id);
 			});
-			void loadSkillVersions();
 		}
 		else eventSource?.close();
 	});
@@ -433,38 +428,6 @@
 		}
 	}
 
-	async function loadSkillVersions() {
-		try {
-			const data = await requestJson('/api/style-profile/versions');
-			skillVersions = Array.isArray(data.versions) ? data.versions : [];
-		} catch {
-			skillVersions = [];
-		}
-	}
-
-	/** Put a saved version or a downloaded bundle back in place. */
-	async function restoreSkill(source: { version: number } | { path: string }) {
-		const path = 'path' in source ? source.path.trim() : '';
-		if ('path' in source && !path) return;
-		importing = true;
-		errorMessage = '';
-		try {
-			await requestJson('/api/style-profile/import', {
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify('version' in source ? { version: source.version } : { path })
-			});
-			importPath = '';
-			importOpen = false;
-			await loadAll();
-			await loadSkillVersions();
-			onChanged?.();
-		} catch (cause) {
-			errorMessage = cause instanceof Error ? cause.message : 'Could not restore that skill.';
-		} finally {
-			importing = false;
-		}
-	}
 
 	async function handleSkillUpload(event: Event) {
 		const input = event.target as HTMLInputElement;
@@ -482,7 +445,6 @@
 			const data = await response.json().catch(() => ({}));
 			if (!response.ok) throw new Error(messageFromResponse(data, `HTTP ${response.status}`));
 			await loadAll();
-			await loadSkillVersions();
 			step = 'active';
 			onChanged?.();
 		} catch (cause) {
@@ -612,7 +574,6 @@
 		try {
 			const data = await requestJson('/api/style-profile/finalize', { method: 'POST' });
 			await loadAll();
-			await loadSkillVersions();
 			step = 'active';
 			onChanged?.();
 			onFinalized?.(data?.profile?.skillId ?? 'author-style');
@@ -668,49 +629,12 @@
 				{:else}
 					<span id="reference-dialog-title">Calibrate your style</span>
 					<div class="header-actions">
-						<button class="btn" onclick={() => (importOpen = !importOpen)}>
-							<Upload size={13} /> Upload skill
-						</button>
 						<button class="icon-btn" onclick={onClose} aria-label="Close style calibration"><X size={14} /></button>
 					</div>
 				{/if}
 			</div>
 
 			{#if step !== 'welcome'}
-				{#if importOpen}
-					<div class="import-panel">
-						<div class="import-upload-row">
-							<label class="btn primary upload-file-btn" class:disabled={importing || uploadingSkill}>
-								{#if uploadingSkill}<LoaderCircle size={13} class="spinner" />{/if}
-								<Upload size={13} /> Upload .zip
-								<input type="file" accept=".zip" hidden onchange={handleSkillUpload} disabled={importing || uploadingSkill} />
-							</label>
-						</div>
-
-						{#if skillVersions.length > 0}
-							<div class="version-list">
-								{#each skillVersions as entry (entry.version)}
-									<div class="version-row">
-										<div class="version-main">
-											<strong>Version {entry.version}</strong>
-											<span class="source-meta">
-												{entry.propositionCount} instruction{entry.propositionCount === 1 ? '' : 's'}
-												· {new Date(entry.createdAt).toLocaleString()}
-											</span>
-										</div>
-										<button
-											class="btn"
-											disabled={importing}
-											onclick={() => restoreSkill({ version: entry.version })}
-										>Restore</button>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
-					</div>
-				{/if}
-
 				<nav class="steps" aria-label="Reference setup steps">
 					<button class:current={step === 'sources'} onclick={() => (step = 'sources')}>
 						<span class="step-num">1</span>
@@ -1666,13 +1590,6 @@
 		opacity: 0.45;
 		cursor: default;
 	}
-	.import-upload-row {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		padding-bottom: 10px;
-		border-bottom: 1px solid var(--border-light);
-	}
 	@media (max-width: 580px) {
 		.welcome-cards {
 			grid-template-columns: 1fr;
@@ -2218,59 +2135,6 @@
 		display: flex;
 		align-items: center;
 		gap: 10px;
-	}
-	/* Drops out of the dialog header, so it sits above the tabs rather than
-	 * inside whichever step happens to be open. */
-	.import-panel {
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-		margin: 12px 24px 0;
-		padding: 12px;
-		border: 1px solid var(--border-light);
-		border-radius: 10px;
-		background: var(--bg-surface);
-	}
-	.version-list {
-		display: flex;
-		flex-direction: column;
-	}
-	.version-row {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 12px;
-		padding: 7px 0;
-	}
-	.version-row + .version-row {
-		border-top: 1px solid var(--border-light);
-	}
-	.version-main {
-		display: flex;
-		min-width: 0;
-		flex-direction: column;
-		gap: 2px;
-		font-size: 12.5px;
-	}
-	.import-row {
-		display: flex;
-		gap: 8px;
-	}
-	.import-row input {
-		box-sizing: border-box;
-		width: 100%;
-		flex: 1;
-		padding: 7px 10px;
-		border: 1px solid var(--border-light);
-		border-radius: 7px;
-		background: var(--bg);
-		color: var(--text);
-		font: inherit;
-		font-size: 12.5px;
-	}
-	.import-row input:focus {
-		outline: none;
-		border-color: var(--accent);
 	}
 	.proposition-list {
 		display: flex;

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -716,7 +716,7 @@
 									class="canvas-text"
 									bind:value={sampleText}
 									onkeydown={onComposerKeydown}
-									placeholder="Paste the writing here"
+									placeholder="Paste your writing here — aim for 3–5 samples"
 									aria-label="Passage text"
 								></textarea>
 								<div class="canvas-foot">

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -65,7 +65,7 @@
 	}
 
 	let { open, provider, model, onClose, onChanged, onFinalized }: Props = $props();
-	let step = $state<'sources' | 'review' | 'active'>('sources');
+	let step = $state<'welcome' | 'sources' | 'review' | 'active'>('sources');
 	let references = $state<ReferenceItem[]>([]);
 	let summary = $state<StyleProfileSummary | null>(null);
 	let loading = $state(false);
@@ -90,6 +90,7 @@
 	let importOpen = $state(false);
 	let importPath = $state('');
 	let importing = $state(false);
+	let uploadingSkill = $state(false);
 	let finalizing = $state(false);
 	let skillVersions = $state<Array<{ version: number; createdAt: number; propositionCount: number }>>([]);
 
@@ -234,6 +235,9 @@
 			calibrationSessionIds = [];
 			tracesLoadedFor = null;
 			void loadAll().then(() => {
+				if (references.length === 0 && (!summary || summary.status === 'empty') && !summary?.profile?.publishedAt) {
+					step = 'welcome';
+				}
 				if (run?.id) void loadStoredTraces(run.id);
 				if (run?.id && ['queued', 'running'].includes(run.status)) connectRun(run.id);
 			});
@@ -462,6 +466,33 @@
 		}
 	}
 
+	async function handleSkillUpload(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		uploadingSkill = true;
+		errorMessage = '';
+		try {
+			const formData = new FormData();
+			formData.append('file', file);
+			const response = await fetch('/api/style-profile/import', {
+				method: 'POST',
+				body: formData
+			});
+			const data = await response.json().catch(() => ({}));
+			if (!response.ok) throw new Error(messageFromResponse(data, `HTTP ${response.status}`));
+			await loadAll();
+			await loadSkillVersions();
+			step = 'active';
+			onChanged?.();
+		} catch (cause) {
+			errorMessage = cause instanceof Error ? cause.message : 'Could not upload the skill.';
+		} finally {
+			uploadingSkill = false;
+			input.value = '';
+		}
+	}
+
 	async function cancelAnalysis() {
 		if (!run) return;
 		await requestJson(`/api/style-profile/runs/${encodeURIComponent(run.id)}`, { method: 'DELETE' });
@@ -629,94 +660,127 @@
 			transition:fly={{ y: 14, duration: 180, easing: cubicOut }}
 		>
 			<div class="dialog-header">
-				<span id="reference-dialog-title">Calibrate your style</span>
-				<div class="header-actions">
-					<!-- Lives here rather than on the Active skill tab: the writer who
-					     wants this has no profile yet, so they are on the first tab. -->
-					<button class="btn" onclick={() => (importOpen = !importOpen)}>
-						<Upload size={13} /> Restore from a skill
-					</button>
-					<button class="icon-btn" onclick={onClose} aria-label="Close style calibration"><X size={14} /></button>
-				</div>
+				{#if step === 'welcome'}
+					<span id="reference-dialog-title">Get started</span>
+					<div class="header-actions">
+						<button class="icon-btn" onclick={onClose} aria-label="Close"><X size={14} /></button>
+					</div>
+				{:else}
+					<span id="reference-dialog-title">Calibrate your style</span>
+					<div class="header-actions">
+						<button class="btn" onclick={() => (importOpen = !importOpen)}>
+							<Upload size={13} /> Upload skill
+						</button>
+						<button class="icon-btn" onclick={onClose} aria-label="Close style calibration"><X size={14} /></button>
+					</div>
+				{/if}
 			</div>
 
-			{#if importOpen}
-				<div class="import-panel">
-					{#if skillVersions.length > 0}
-						<div class="version-list">
-							{#each skillVersions as entry (entry.version)}
-								<div class="version-row">
-									<div class="version-main">
-										<strong>Version {entry.version}</strong>
-										<span class="source-meta">
-											{entry.propositionCount} instruction{entry.propositionCount === 1 ? '' : 's'}
-											· {new Date(entry.createdAt).toLocaleString()}
-										</span>
-									</div>
-									<button
-										class="btn"
-										disabled={importing}
-										onclick={() => restoreSkill({ version: entry.version })}
-									>Restore</button>
-								</div>
-							{/each}
+			{#if step !== 'welcome'}
+				{#if importOpen}
+					<div class="import-panel">
+						<div class="import-upload-row">
+							<label class="btn primary upload-file-btn" class:disabled={importing || uploadingSkill}>
+								{#if uploadingSkill}<LoaderCircle size={13} class="spinner" />{/if}
+								<Upload size={13} /> Choose .zip file
+								<input type="file" accept=".zip" hidden onchange={handleSkillUpload} disabled={importing || uploadingSkill} />
+							</label>
 						</div>
-					{:else}
-						<p class="hint">No saved versions yet. One is kept every time the skill is built.</p>
-					{/if}
 
-					<div class="import-row">
-						<input
-							bind:value={importPath}
-							placeholder="…or a path to a skill folder or .zip"
-							aria-label="Path to a skill folder or zip"
-							onkeydown={(event) => {
-								if (event.key === 'Enter') void restoreSkill({ path: importPath });
-							}}
-						/>
-						<button
-							class="btn"
-							disabled={!importPath.trim() || importing}
-							onclick={() => restoreSkill({ path: importPath })}
-						>
-							{#if importing}<LoaderCircle size={13} class="spinner" />{/if}
-							Restore
-						</button>
+						{#if skillVersions.length > 0}
+							<div class="version-list">
+								{#each skillVersions as entry (entry.version)}
+									<div class="version-row">
+										<div class="version-main">
+											<strong>Version {entry.version}</strong>
+											<span class="source-meta">
+												{entry.propositionCount} instruction{entry.propositionCount === 1 ? '' : 's'}
+												· {new Date(entry.createdAt).toLocaleString()}
+											</span>
+										</div>
+										<button
+											class="btn"
+											disabled={importing}
+											onclick={() => restoreSkill({ version: entry.version })}
+										>Restore</button>
+									</div>
+								{/each}
+							</div>
+						{/if}
+
+						<div class="import-row">
+							<input
+								bind:value={importPath}
+								placeholder="Path to a skill folder or .zip"
+								aria-label="Path to a skill folder or zip"
+								onkeydown={(event) => {
+									if (event.key === 'Enter') void restoreSkill({ path: importPath });
+								}}
+							/>
+							<button
+								class="btn"
+								disabled={!importPath.trim() || importing}
+								onclick={() => restoreSkill({ path: importPath })}
+							>
+								{#if importing}<LoaderCircle size={13} class="spinner" />{/if}
+								Import
+							</button>
+						</div>
 					</div>
-					<p class="hint">
-						Restoring installs that whole skill folder and replaces your guidance. Your sources and
-						measurements are untouched.
-					</p>
-				</div>
-			{/if}
+				{/if}
 
-			<!-- Numbered because the tabs are the flow: add sources, analyze,
-			     review the draft. The visible sequence replaces a "next" button
-			     on each step. -->
-			<nav class="steps" aria-label="Reference setup steps">
-				<button class:current={step === 'sources'} onclick={() => (step = 'sources')}>
-					<span class="step-num">1</span>
-					Sources
-					{#if references.length > 0}<span class="count-chip">{references.length}</span>{/if}
-				</button>
-				<button class:current={step === 'review'} onclick={() => (step = 'review')}>
-					<span class="step-num">2</span>
-					Analyze
-					{#if pendingTrials.length > 0}<span class="count-chip">{pendingTrials.length}</span>{/if}
-				</button>
-				<button class:current={step === 'active'} onclick={() => (step = 'active')}>
-					<span class="step-num">3</span>
-					{summary?.hasUnpublishedChanges ? 'Style draft' : 'Active skill'}
-					{#if activePropositions.length > 0}<span class="count-chip">{activePropositions.length}</span>{/if}
-				</button>
-			</nav>
+				<nav class="steps" aria-label="Reference setup steps">
+					<button class:current={step === 'sources'} onclick={() => (step = 'sources')}>
+						<span class="step-num">1</span>
+						Sources
+						{#if references.length > 0}<span class="count-chip">{references.length}</span>{/if}
+					</button>
+					<button class:current={step === 'review'} onclick={() => (step = 'review')}>
+						<span class="step-num">2</span>
+						Analyze
+						{#if pendingTrials.length > 0}<span class="count-chip">{pendingTrials.length}</span>{/if}
+					</button>
+					<button class:current={step === 'active'} onclick={() => (step = 'active')}>
+						<span class="step-num">3</span>
+						{summary?.hasUnpublishedChanges ? 'Style draft' : 'Active skill'}
+						{#if activePropositions.length > 0}<span class="count-chip">{activePropositions.length}</span>{/if}
+					</button>
+				</nav>
+			{/if}
 
 			{#if errorMessage}
 				<div class="error-box"><TriangleAlert size={13} /><span>{errorMessage}</span></div>
 			{/if}
 
 			<div class="dialog-body">
-				{#if step === 'sources'}
+				{#if step === 'welcome'}
+					<div class="step step-welcome">
+						<div class="welcome-inner">
+							<div class="welcome-hero">
+								<h2>Learn your writing style</h2>
+								<p>Paste a few samples of your writing and DocWriter will build a skill that matches your voice.</p>
+							</div>
+							<div class="welcome-cards">
+								<button class="welcome-card" onclick={() => (step = 'sources')}>
+									<span class="welcome-card-icon"><FileStack size={22} /></span>
+									<h3>Add writing samples</h3>
+									<p>Paste 3–5 passages from your own writing. DocWriter will analyze your style and generate a skill for you.</p>
+									<span class="welcome-card-cta">Get started <span aria-hidden="true">&rarr;</span></span>
+								</button>
+								<div class="welcome-card">
+									<span class="welcome-card-icon"><Upload size={22} /></span>
+									<h3>Upload a skill</h3>
+									<p>Have a .zip skill file from a previous session? Upload it to skip the analysis.</p>
+									<label class="btn primary welcome-upload-btn" class:disabled={uploadingSkill}>
+										{#if uploadingSkill}<LoaderCircle size={13} class="spinner" />{/if}
+										Choose .zip file
+										<input type="file" accept=".zip" hidden onchange={handleSkillUpload} disabled={uploadingSkill} />
+									</label>
+								</div>
+							</div>
+						</div>
+					</div>
+				{:else if step === 'sources'}
 					<!-- A writing surface, not a form: the canvas is the page you are
 					     pasting onto, and the rail on the right holds what you have. -->
 					<div class="step step-sources">
@@ -1523,6 +1587,114 @@
 		max-width: 320px;
 		font-size: 12px;
 		line-height: 1.55;
+	}
+
+	/* ---- welcome step ------------------------------------------------- */
+	.step-welcome {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: auto;
+	}
+	.welcome-inner {
+		max-width: 640px;
+		padding: 40px 24px 48px;
+		text-align: center;
+	}
+	.welcome-hero {
+		margin-bottom: 32px;
+	}
+	.welcome-hero h2 {
+		margin: 0 0 8px;
+		font-size: 22px;
+		font-weight: 700;
+		letter-spacing: -0.015em;
+		color: var(--text);
+	}
+	.welcome-hero p {
+		margin: 0 auto;
+		max-width: 420px;
+		font-size: 13.5px;
+		line-height: 1.55;
+		color: var(--text-muted);
+	}
+	.welcome-cards {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 16px;
+	}
+	.welcome-card {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+		padding: 24px 22px;
+		border: 1px solid var(--border-light);
+		border-radius: 10px;
+		background: var(--bg-surface);
+		text-align: left;
+		font: inherit;
+		color: inherit;
+		cursor: pointer;
+		transition: border-color 0.12s;
+	}
+	button.welcome-card:hover {
+		border-color: var(--accent);
+		background: var(--bg-hover);
+	}
+	.welcome-card h3 {
+		margin: 4px 0 0;
+		font-size: 14px;
+		font-weight: 600;
+	}
+	.welcome-card p {
+		margin: 0;
+		font-size: 12.5px;
+		line-height: 1.55;
+		color: var(--text-muted);
+	}
+	.welcome-card-icon {
+		display: grid;
+		place-items: center;
+		width: 40px;
+		height: 40px;
+		border-radius: 9px;
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+	.welcome-card-cta {
+		margin-top: auto;
+		padding-top: 4px;
+		color: var(--accent);
+		font-size: 13px;
+		font-weight: 500;
+	}
+	.welcome-upload-btn {
+		margin-top: auto;
+		cursor: pointer;
+	}
+	.welcome-upload-btn.disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.upload-file-btn {
+		cursor: pointer;
+	}
+	.upload-file-btn.disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.import-upload-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding-bottom: 10px;
+		border-bottom: 1px solid var(--border-light);
+	}
+	@media (max-width: 580px) {
+		.welcome-cards {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	/* ---- step 1: sources ---------------------------------------------- */

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -682,7 +682,7 @@
 						<div class="import-upload-row">
 							<label class="btn primary upload-file-btn" class:disabled={importing || uploadingSkill}>
 								{#if uploadingSkill}<LoaderCircle size={13} class="spinner" />{/if}
-								<Upload size={13} /> Choose .zip file
+								<Upload size={13} /> Upload .zip
 								<input type="file" accept=".zip" hidden onchange={handleSkillUpload} disabled={importing || uploadingSkill} />
 							</label>
 						</div>
@@ -708,24 +708,6 @@
 							</div>
 						{/if}
 
-						<div class="import-row">
-							<input
-								bind:value={importPath}
-								placeholder="Path to a skill folder or .zip"
-								aria-label="Path to a skill folder or zip"
-								onkeydown={(event) => {
-									if (event.key === 'Enter') void restoreSkill({ path: importPath });
-								}}
-							/>
-							<button
-								class="btn"
-								disabled={!importPath.trim() || importing}
-								onclick={() => restoreSkill({ path: importPath })}
-							>
-								{#if importing}<LoaderCircle size={13} class="spinner" />{/if}
-								Import
-							</button>
-						</div>
 					</div>
 				{/if}
 
@@ -765,15 +747,15 @@
 									<span class="welcome-card-icon"><FileStack size={22} /></span>
 									<h3>Add writing samples</h3>
 									<p>Paste 3–5 passages from your own writing. DocWriter will analyze your style and generate a skill for you.</p>
-									<span class="welcome-card-cta">Get started <span aria-hidden="true">&rarr;</span></span>
+									<span class="welcome-card-cta">Get started</span>
 								</button>
 								<div class="welcome-card">
 									<span class="welcome-card-icon"><Upload size={22} /></span>
-									<h3>Upload a skill</h3>
-									<p>Have a .zip skill file from a previous session? Upload it to skip the analysis.</p>
+									<h3>Upload a style skill</h3>
+									<p>Have a previously generated style skill? Upload the .zip to skip the analysis.</p>
 									<label class="btn primary welcome-upload-btn" class:disabled={uploadingSkill}>
 										{#if uploadingSkill}<LoaderCircle size={13} class="spinner" />{/if}
-										Choose .zip file
+										Upload .zip
 										<input type="file" accept=".zip" hidden onchange={handleSkillUpload} disabled={uploadingSkill} />
 									</label>
 								</div>

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -305,6 +305,8 @@ Voice belongs to the user. Match their cadence, vocabulary, sentence length, cap
 
 Every file is raw text, including .md. The editor renders markdown source literally, so preserve whatever syntax the file uses. Keep JSON, YAML, and code valid. Do not add or strip formatting unless asked.
 
+Before your first edit in a session, list the files in the workspace directory with Glob and read nearby files for context. Understanding the project layout — sibling files, naming conventions, and existing structure — helps you make edits that fit the rest of the project.
+
 ## Editing tools
 
 - For any workspace file, open tab or not, use edit_doc, write_doc, and read_doc. The path argument is the tab id (e.g. "drafts/chapter-1.md") or the file's absolute path. The built-in Edit and Write tools only work in your scratch space.

--- a/src/routes/api/style-profile/import/+server.ts
+++ b/src/routes/api/style-profile/import/+server.ts
@@ -1,5 +1,7 @@
 import { error, json } from '@sveltejs/kit';
-import { isAbsolute, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import type { RequestHandler } from './$types';
 import {
 	profileFromSkillFolder,
@@ -14,19 +16,37 @@ import { replacePublishedStylePropositions } from '$lib/server/style-analysis/pr
 
 /**
  * Restore an author-style skill instead of running the pass: either a version
- * from this workspace's history, or a folder / zip from Download skill.
- *
- * The whole folder is installed, not regenerated, so an older skill comes back
- * exactly as it was rather than rebuilt in today's format. The profile is
- * rebuilt alongside it so the UI and the turn prompt agree with the files.
- * Everything is validated before anything is written.
+ * from this workspace's history, a folder / zip from Download skill, or a
+ * .zip file uploaded via multipart form data.
  */
 export const POST: RequestHandler = async ({ request }) => {
-	const body = await request.json().catch(() => ({}));
-	const version = typeof body.version === 'number' ? body.version : null;
-	const path = typeof body.path === 'string' ? body.path.trim() : '';
+	const contentType = request.headers.get('content-type') ?? '';
+
+	let version: number | null = null;
+	let path = '';
+
+	if (contentType.includes('multipart/form-data')) {
+		const formData = await request.formData();
+		const file = formData.get('file');
+		if (!file || !(file instanceof File)) {
+			throw error(400, 'No file provided');
+		}
+		if (!file.name.toLowerCase().endsWith('.zip')) {
+			throw error(400, 'Only .zip skill files are accepted');
+		}
+		const uploadDir = mkdtempSync(join(tmpdir(), 'docwriter-upload-'));
+		const uploadPath = join(uploadDir, file.name);
+		const buffer = Buffer.from(await file.arrayBuffer());
+		writeFileSync(uploadPath, buffer);
+		path = uploadPath;
+	} else {
+		const body = await request.json().catch(() => ({}));
+		version = typeof body.version === 'number' ? body.version : null;
+		path = typeof body.path === 'string' ? body.path.trim() : '';
+	}
+
 	if (version === null && !path) {
-		throw error(400, 'Give a version number or the path to a skill folder or .zip');
+		throw error(400, 'Give a version number, a path, or upload a .zip file');
 	}
 
 	let sourceDir: string;


### PR DESCRIPTION
## Summary

Refactors the reference calibration dialog to introduce a new "welcome" onboarding step and replaces the path-based skill restoration UI with direct .zip file upload via multipart form data.

## Key Changes

- **New welcome step:** Added a `'welcome'` step to the calibration flow that appears when a user has no references, empty profile, and no published skill. The welcome screen presents two options: add writing samples or upload a previously generated skill .zip file.

- **File upload instead of path input:** Replaced the import panel's path-based restoration (which required users to provide filesystem paths) with a file input that accepts .zip files. The upload handler now sends multipart form data to `/api/style-profile/import`.

- **Removed version history UI:** Deleted the `loadSkillVersions()` function and the version list UI that displayed saved skill versions with restore buttons. The `skillVersions` state and related imports/exports have been removed.

- **Simplified state management:** Removed `importOpen`, `importPath`, `importing`, and `skillVersions` state variables. Replaced with a single `uploadingSkill` boolean for the new file upload flow.

- **Updated API endpoint:** Modified `/api/style-profile/import` to handle both multipart form data (new file uploads) and JSON payloads (existing version/path restoration). File uploads are written to a temporary directory before processing.

- **Conditional header and navigation:** The dialog header and step navigation now conditionally render based on whether the user is on the welcome step, with different titles and button layouts.

- **UX improvements:** Added hint text to the sources panel ("Aim for 3 - 5 samples"), styled the welcome cards with icons and descriptions, and made the upload button a labeled file input for better accessibility.

## Implementation Details

- The welcome step is triggered automatically when `loadAll()` completes and detects an empty profile with no references or published skill.
- File uploads create a temporary directory using `mkdtempSync` and write the uploaded buffer to disk before the existing skill restoration logic processes it.
- The welcome cards use a two-column grid layout that collapses to single column on screens ≤580px wide.
- Step navigation is hidden on the welcome step to keep the onboarding focused.

https://claude.ai/code/session_01Gif7FHMCCXQp8cW5Vh2fXy