### PR TITLE
Save style skill globally for Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,7 @@ vite.config.ts.timestamp-*
 # Agent worktrees and locks
 .agents/
 /.codex/
-.claude/skills/*/.docwriter-bundled-skill
-.claude/skills/plain-writing/
-.claude/skills/docwriter-style-generator
+.claude/skills/*/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ vite.config.ts.timestamp-*
 /.codex/
 .claude/skills/*/.docwriter-bundled-skill
 .claude/skills/plain-writing/
+.claude/skills/docwriter-style-generator
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 

--- a/src/lib/components/ReferenceCalibrationDialog.svelte
+++ b/src/lib/components/ReferenceCalibrationDialog.svelte
@@ -89,6 +89,7 @@
 	let calibrationSessionIds = $state<string[]>([]);
 	let uploadingSkill = $state(false);
 	let finalizing = $state(false);
+	let startingAnalysis = $state(false);
 
 	const pendingTrials = $derived((summary?.profile?.calibrations ?? [])
 		.filter((trial) => calibrationSessionIds.includes(trial.id) && ['pending', 'generated', 'error'].includes(trial.status)));
@@ -400,6 +401,7 @@
 
 	async function startAnalysis() {
 		errorMessage = '';
+		startingAnalysis = true;
 		try {
 			const data = await requestJson('/api/style-profile/runs', {
 				method: 'POST',
@@ -410,6 +412,8 @@
 			connectRun(run!.id);
 		} catch (cause) {
 			errorMessage = cause instanceof Error ? cause.message : 'Could not start style analysis.';
+		} finally {
+			startingAnalysis = false;
 		}
 	}
 
@@ -567,12 +571,26 @@
 		}
 	}
 
+	let showGlobalPrompt = $state(false);
+	let pendingFinalizeResolve: ((saveToGlobal: boolean) => void) | null = null;
+
 	async function finalizeStyle() {
 		if (!canFinalize || finalizing) return;
 		finalizing = true;
 		errorMessage = '';
 		try {
-			const data = await requestJson('/api/style-profile/finalize', { method: 'POST' });
+			const saveToGlobal = await new Promise<boolean>((resolve) => {
+				pendingFinalizeResolve = resolve;
+				showGlobalPrompt = true;
+			});
+			showGlobalPrompt = false;
+			pendingFinalizeResolve = null;
+
+			const data = await requestJson('/api/style-profile/finalize', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ saveToGlobal })
+			});
 			await loadAll();
 			step = 'active';
 			onChanged?.();
@@ -581,6 +599,8 @@
 			errorMessage = cause instanceof Error ? cause.message : 'Could not finalize the style.';
 		} finally {
 			finalizing = false;
+			showGlobalPrompt = false;
+			pendingFinalizeResolve = null;
 		}
 	}
 
@@ -652,6 +672,16 @@
 						{#if activePropositions.length > 0}<span class="count-chip">{activePropositions.length}</span>{/if}
 					</button>
 				</nav>
+			{/if}
+
+			{#if showGlobalPrompt}
+				<div class="global-prompt">
+					<p>Save this style to your global Claude Code skills (<code>~/.claude/skills/</code>) so it works in every project?</p>
+					<div class="global-prompt-actions">
+						<button class="btn" onclick={() => pendingFinalizeResolve?.(false)}>Just this project</button>
+						<button class="btn primary" onclick={() => pendingFinalizeResolve?.(true)}>Save globally</button>
+					</div>
+				</div>
 			{/if}
 
 			{#if errorMessage}
@@ -783,8 +813,12 @@
 								<div class="head-copy">
 									<h3>Style analysis</h3>
 								</div>
-								{#if analysisRunning}
-									<button class="btn" onclick={cancelAnalysis}>Cancel</button>
+								{#if analysisRunning || startingAnalysis}
+									{#if analysisRunning}
+										<button class="btn" onclick={cancelAnalysis}>Cancel</button>
+									{:else}
+										<button class="btn" disabled>Starting…</button>
+									{/if}
 								{:else}
 									{#if run}
 										<button class="btn" onclick={resetAnalysis}>Start over</button>
@@ -799,7 +833,17 @@
 								so feel free to keep writing or do other things in the meantime.
 							</p>
 
-							{#if run}
+							{#if startingAnalysis && !run}
+								<div class="progress-summary">
+									<div class="progress-top">
+										<strong>Starting…</strong>
+										<span>Setting up the analysis</span>
+									</div>
+									<div class="progress-track" aria-label="Starting analysis">
+										<div class="progress-fill running" style:width="0%"></div>
+									</div>
+								</div>
+							{:else if run}
 								<div class="progress-summary">
 									<div class="progress-top">
 										<strong>{Math.round(run.progress)}% complete</strong>
@@ -1454,6 +1498,27 @@
 	}
 	.status-chip.error .chip-dot {
 		background: var(--diff-removed-color);
+	}
+
+	.global-prompt {
+		margin: 10px 16px 0;
+		padding: 12px 14px;
+		border: 1px solid var(--border-light);
+		border-radius: 7px;
+		background: var(--bg-elevated);
+		font-size: 13px;
+	}
+	.global-prompt p { margin: 0 0 10px; }
+	.global-prompt code {
+		font-size: 11.5px;
+		padding: 1px 5px;
+		background: var(--bg-inset);
+		border-radius: 3px;
+	}
+	.global-prompt-actions {
+		display: flex;
+		gap: 8px;
+		justify-content: flex-end;
 	}
 
 	.error-box {

--- a/src/lib/server/style-analysis/profile-store.ts
+++ b/src/lib/server/style-analysis/profile-store.ts
@@ -88,7 +88,6 @@ export function writeStyleProfile(profile: StyleProfile): StyleProfile {
 	ensureStyleAnalysisDir();
 	const next = StyleProfileSchema.parse({ ...profile, updatedAt: Date.now() }) as StyleProfile;
 	writePersistedStyleProfile(next);
-	writeJsonAtomic(STYLE_PROFILE_FILE, next);
 	return next;
 }
 

--- a/src/lib/server/style-analysis/profile-store.ts
+++ b/src/lib/server/style-analysis/profile-store.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type {
 	CalibrationTrial,
@@ -31,6 +32,8 @@ import {
 export const STYLE_PROFILE_FILE = join(DOCWRITER_DIR, 'style-profile.json');
 export const STYLE_ANALYSIS_DIR = join(DOCWRITER_DIR, 'style-analysis');
 export const STYLE_REPORT_FILE = join(STYLE_ANALYSIS_DIR, 'report.json');
+
+export const GLOBAL_STYLE_SKILL_DIR = join(homedir(), '.claude', 'skills', 'my-writing-style');
 
 function migrateStoredProfile(value: unknown): unknown {
 	if (!value || typeof value !== 'object') return value;
@@ -235,6 +238,11 @@ export function propositionFromDraft(
 		createdAt: now,
 		updatedAt: now
 	};
+}
+
+export function checkGlobalStyleSkill(): { available: boolean; path: string } {
+	const available = existsSync(join(GLOBAL_STYLE_SKILL_DIR, 'references', 'propositions.json'));
+	return { available, path: GLOBAL_STYLE_SKILL_DIR };
 }
 
 export function styleProfileSummary(): StyleProfileSummary {

--- a/src/routes/api/files/+server.ts
+++ b/src/routes/api/files/+server.ts
@@ -68,7 +68,9 @@ export const GET: RequestHandler = async ({ url }) => {
 			kind,
 			path: childRel,
 			watched: childRel === 'notes' || childRel.startsWith('notes/'),
-			internal: childRel === '.docwriter' || childRel.startsWith('.docwriter/')
+			internal: ['.docwriter', '.agents', '.claude'].some(
+				(prefix) => childRel === prefix || childRel.startsWith(prefix + '/')
+			)
 		});
 	}
 

--- a/src/routes/api/style-profile/finalize/+server.ts
+++ b/src/routes/api/style-profile/finalize/+server.ts
@@ -1,12 +1,27 @@
 import { error, json } from '@sveltejs/kit';
+import { cpSync, mkdirSync } from 'node:fs';
 import type { RequestHandler } from './$types';
 import { finalizeStyleProfile } from '$lib/server/style-analysis/finalize';
-import { styleProfileForClient } from '$lib/server/style-analysis/profile-store';
+import { GLOBAL_STYLE_SKILL_DIR, styleProfileForClient } from '$lib/server/style-analysis/profile-store';
 
-export const POST: RequestHandler = async () => {
+export const POST: RequestHandler = async ({ request }) => {
 	try {
+		const body = await request.json().catch(() => ({}));
+		const saveToGlobal = body?.saveToGlobal === true;
+
 		const profile = finalizeStyleProfile();
-		return json({ profile: styleProfileForClient(profile) });
+
+		let savedGlobally = false;
+		if (saveToGlobal && profile.skillPath) {
+			mkdirSync(GLOBAL_STYLE_SKILL_DIR, { recursive: true });
+			cpSync(profile.skillPath, GLOBAL_STYLE_SKILL_DIR, { recursive: true });
+			savedGlobally = true;
+		}
+
+		return json({
+			profile: styleProfileForClient(profile),
+			savedGlobally
+		});
 	} catch (cause) {
 		throw error(400, cause instanceof Error ? cause.message : 'Could not finalize the style');
 	}

--- a/src/routes/api/style-profile/user-skill/+server.ts
+++ b/src/routes/api/style-profile/user-skill/+server.ts
@@ -1,0 +1,10 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { checkGlobalStyleSkill } from '$lib/server/style-analysis/profile-store';
+
+/**
+ * Check whether a generated style skill exists at ~/.claude/skills/my-writing-style/.
+ * Called only when the user explicitly asks — DocWriter does not scan the home
+ * directory without permission.
+ */
+export const GET: RequestHandler = async () => json(checkGlobalStyleSkill());


### PR DESCRIPTION
## Summary
- When finalizing a style profile, a prompt asks whether to also save it to `~/.claude/skills/my-writing-style/` so Claude Code auto-loads it in every project
- Copies the complete generated skill (SKILL.md + references/) — same format the `docwriter-style-generator` plugin produces
- Adds `GET /api/style-profile/user-skill` to check for an existing global skill (only on explicit user action, no silent home-dir scanning)
- Adds instant "Starting…" feedback when clicking "Run analysis" (the button was unresponsive while the POST was in flight)
- Stops writing `style-profile.json` mirror — SQLite is the sole store now (read-fallback kept for migrating old installs)
- Marks `.agents/` and `.claude/` as internal in the file tree (greyed out like `.docwriter/`)
- Gitignores all `.claude/skills/*/` since they are generated at runtime by `syncSkillInstallations`

## Test plan
- [ ] Run style analysis, finalize, click "Save globally" — verify `~/.claude/skills/my-writing-style/` contains SKILL.md + references/
- [ ] Click "Just this project" — verify nothing written to `~/.claude/skills/`
- [ ] New Claude Code session in another project — verify `my-writing-style` skill loads
- [ ] Click "Run analysis" — verify "Starting…" appears immediately
- [ ] `.agents/` and `.claude/` appear greyed out in file tree
- [ ] No `style-profile.json` written after finalizing (only SQLite)