### PR TITLE
Clarify Claude Code /login in auth UI and docs

### DIFF
--- a/docs/connect-provider.mdx
+++ b/docs/connect-provider.mdx
@@ -6,8 +6,6 @@ You can use the editor without an AI account. Connect one provider when you want
 
 DocWriter supports Claude, OpenAI, Codex, Cursor, and Pi. You choose the provider and model from pills in the page header.
 
-For Claude, DocWriter can reuse your existing Claude Code terminal login (`claude`, then `/login`) so agent calls use your Claude.ai / Claude Code subscription. An Anthropic API key is optional and bills API usage instead.
-
 ## Choose a provider
 
 Click the provider pill in the header and choose one provider where you already have an account or API key. Click the model pill beside it to search the available models or add a custom model identifier.
@@ -38,24 +36,16 @@ Saved keys live in `~/.docwriter/keys.env`. A process environment variable or pr
 
 ### Claude
 
-Prefer your Claude Code / Claude.ai subscription when you already use Claude Code on this computer. DocWriter reuses that login. You do not paste anything in the DocWriter UI for this path.
+DocWriter can use your Claude Code login on this computer. You do not need to paste a key in DocWriter for that.
 
-1. Open a terminal **on the same computer that runs DocWriter**.
-2. Run `claude` to open Claude Code.
-3. Type `/login` (a Claude Code slash command — not a DocWriter menu) and finish the browser sign-in.
-4. In DocWriter, open **Settings**, then **API keys**. Claude should show **Using login**.
+1. Open a terminal on the same computer that runs DocWriter.
+2. Enter `claude` and press Enter. Wait until the Claude Code session is running.
+3. Type `/login` and press Enter. Finish the browser sign-in when it opens.
+4. In DocWriter, open **Settings → API keys**. Claude should show **Using login**.
 
-Leave the Anthropic API key field empty. Pasting an `ANTHROPIC_API_KEY` works, but agent calls then bill Anthropic **API** usage instead of your Claude Code subscription.
+Leave the Anthropic key field empty. If you paste an `ANTHROPIC_API_KEY` (or set it in the environment), agent calls bill Anthropic API usage instead of your Claude Code subscription. Remove the stored key and unset the env var to go back to login.
 
-If the agent toast says authentication failed and mentions `/login`, it means those terminal steps above — refresh the Claude Code login, then retry in DocWriter. See [Provider errors](/help/provider-errors#claude-code-login-expired).
-
-To use an API key instead:
-
-```sh
-export ANTHROPIC_API_KEY=sk-ant-...
-```
-
-Or paste the key under **Settings → API keys**. Remove the stored key (and clear any shell `ANTHROPIC_API_KEY`) when you want to return to Claude Code login.
+If auth fails later, repeat steps 1–3, then retry in DocWriter. See [Provider errors](/help/provider-errors#claude-code-login-expired).
 
 ### OpenAI and Codex
 

--- a/docs/connect-provider.mdx
+++ b/docs/connect-provider.mdx
@@ -6,6 +6,8 @@ You can use the editor without an AI account. Connect one provider when you want
 
 DocWriter supports Claude, OpenAI, Codex, Cursor, and Pi. You choose the provider and model from pills in the page header.
 
+For Claude, DocWriter can reuse your existing Claude Code terminal login (`claude`, then `/login`) so agent calls use your Claude.ai / Claude Code subscription. An Anthropic API key is optional and bills API usage instead.
+
 ## Choose a provider
 
 Click the provider pill in the header and choose one provider where you already have an account or API key. Click the model pill beside it to search the available models or add a custom model identifier.
@@ -36,13 +38,24 @@ Saved keys live in `~/.docwriter/keys.env`. A process environment variable or pr
 
 ### Claude
 
-Use an Anthropic key or an existing Claude login:
+Prefer your Claude Code / Claude.ai subscription when you already use Claude Code on this computer. DocWriter reuses that login. You do not paste anything in the DocWriter UI for this path.
+
+1. Open a terminal **on the same computer that runs DocWriter**.
+2. Run `claude` to open Claude Code.
+3. Type `/login` (a Claude Code slash command — not a DocWriter menu) and finish the browser sign-in.
+4. In DocWriter, open **Settings**, then **API keys**. Claude should show **Using login**.
+
+Leave the Anthropic API key field empty. Pasting an `ANTHROPIC_API_KEY` works, but agent calls then bill Anthropic **API** usage instead of your Claude Code subscription.
+
+If the agent toast says authentication failed and mentions `/login`, it means those terminal steps above — refresh the Claude Code login, then retry in DocWriter. See [Provider errors](/help/provider-errors#claude-code-login-expired).
+
+To use an API key instead:
 
 ```sh
 export ANTHROPIC_API_KEY=sk-ant-...
-# or
-claude login
 ```
+
+Or paste the key under **Settings → API keys**. Remove the stored key (and clear any shell `ANTHROPIC_API_KEY`) when you want to return to Claude Code login.
 
 ### OpenAI and Codex
 

--- a/docs/feature-catalog.json
+++ b/docs/feature-catalog.json
@@ -41,7 +41,7 @@
     {
       "id": "connect-provider-04",
       "area": "Models",
-      "feature": "Use Claude or Codex login instead of an API key",
+      "feature": "Use Claude Code terminal login (/login) instead of an API key",
       "targetPage": "connect-provider"
     },
     {
@@ -353,7 +353,7 @@
     {
       "id": "agent-ask-and-steer-09",
       "area": "Agent",
-      "feature": "See failed run toasts with authentication recovery hints",
+      "feature": "See auth failure toasts with Claude Code /login steps",
       "targetPage": "agent/ask-and-steer"
     },
     {

--- a/docs/help/provider-errors.mdx
+++ b/docs/help/provider-errors.mdx
@@ -16,11 +16,25 @@ Adding a key allows future requests to use that provider. When you enter a key i
 
 Process environment variables and project `.env` files take precedence over `~/.docwriter/keys.env`. Restart DocWriter after changing a shell environment variable. A wrong value in the environment can continue to override a correct value saved in the panel.
 
-## A command line login expired
+## Claude Code login expired
 
-Run the provider login command again. Claude and Codex can use existing command line logins.
+`/login` is a **Claude Code terminal** command, not a DocWriter control.
 
-Choose **New session** if the provider still tries to resume the expired conversation. New session clears the saved provider conversation, agent activity for the current session, temporary scratch files, and pending proposals. It keeps workspace files, comments, rules, hooks, and settings. Copy any proposal text you need before choosing it.
+1. On the same computer that runs DocWriter, open a terminal.
+2. Run `claude`.
+3. Type `/login` and finish the browser sign-in.
+4. In DocWriter, open **Settings**, then **API keys**. Claude should show **Using login**.
+5. Retry the agent request.
+
+Leave the Anthropic API key empty to keep using your Claude Code / Claude.ai subscription. If a key is saved (or `ANTHROPIC_API_KEY` is set in the environment), DocWriter uses API billing instead. Choose **Remove stored key** and clear the env var when you want subscription login again.
+
+Choose **New session** if the provider still tries to resume an expired conversation. New session clears the saved provider conversation, agent activity for the current session, temporary scratch files, and pending proposals. It keeps workspace files, comments, rules, hooks, and settings. Copy any proposal text you need before choosing it.
+
+## Other command line logins expired
+
+Codex can also use an existing command line login. Run that provider's login again in a terminal on this computer, then retry.
+
+Choose **New session** if the provider still tries to resume the expired conversation.
 
 ## The selected model does not exist
 

--- a/docs/help/provider-errors.mdx
+++ b/docs/help/provider-errors.mdx
@@ -18,15 +18,15 @@ Process environment variables and project `.env` files take precedence over `~/.
 
 ## Claude Code login expired
 
-`/login` is a **Claude Code terminal** command, not a DocWriter control.
+`/login` is typed inside Claude Code in a terminal — not in the DocWriter UI.
 
-1. On the same computer that runs DocWriter, open a terminal.
-2. Run `claude`.
-3. Type `/login` and finish the browser sign-in.
-4. In DocWriter, open **Settings**, then **API keys**. Claude should show **Using login**.
+1. Open a terminal on the same computer that runs DocWriter.
+2. Enter `claude` and press Enter. Wait until the session is running.
+3. Type `/login` and press Enter. Finish the browser sign-in.
+4. In DocWriter, open **Settings → API keys**. Claude should show **Using login**.
 5. Retry the agent request.
 
-Leave the Anthropic API key empty to keep using your Claude Code / Claude.ai subscription. If a key is saved (or `ANTHROPIC_API_KEY` is set in the environment), DocWriter uses API billing instead. Choose **Remove stored key** and clear the env var when you want subscription login again.
+Keep the Anthropic key field empty for subscription login. If a key is set in the panel or as `ANTHROPIC_API_KEY`, DocWriter bills API usage instead — remove the stored key and unset the env var to use login again.
 
 Choose **New session** if the provider still tries to resume an expired conversation. New session clears the saved provider conversation, agent activity for the current session, temporary scratch files, and pending proposals. It keeps workspace files, comments, rules, hooks, and settings. Copy any proposal text you need before choosing it.
 

--- a/src/lib/components/ApiKeysPanel.svelte
+++ b/src/lib/components/ApiKeysPanel.svelte
@@ -246,9 +246,6 @@
 		padding: 1px 4px;
 		border-radius: 4px;
 	}
-	.alt-note.refresh {
-		margin-top: -2px;
-	}
 	.key-input {
 		display: flex;
 		gap: 6px;

--- a/src/lib/components/ApiKeysPanel.svelte
+++ b/src/lib/components/ApiKeysPanel.svelte
@@ -95,7 +95,6 @@
 	<div class="intro">
 		Stored in <code>~/.docwriter/keys.env</code> and shared across all workspaces.
 		Environment variables (and the repo <code>.env</code>) override these.
-		Claude and Codex can also reuse a terminal login — see each provider note below.
 	</div>
 
 	{#if error}
@@ -112,20 +111,11 @@
 					<span class="badge {statusClass(p)}">{statusLabel(p)}</span>
 				</div>
 				<div class="env-var"><code>{p.envVar}</code></div>
-				{#if p.altAuthNote && (!p.present || p.source === 'login')}
+				{#if !p.present && p.altAuthNote}
 					<div class="alt-note">{p.altAuthNote}</div>
 				{/if}
-				{#if p.id === 'claude' && p.source === 'login'}
-					<div class="alt-note refresh">
-						If the agent still fails with auth errors, refresh the login in a terminal:
-						run <code>claude</code>, type <code>/login</code>, finish the browser sign-in, then retry.
-					</div>
-				{/if}
 				{#if p.id === 'claude' && p.present}
-					<div class="alt-note refresh">
-						An Anthropic API key is set, so agent calls bill API usage (not your Claude Code subscription).
-						Choose <strong>Remove stored key</strong> below (and clear any shell <code>ANTHROPIC_API_KEY</code>) to reuse Claude Code login instead.
-					</div>
+					<div class="alt-note">Key set — API billing. Remove it to use Claude Code login instead.</div>
 				{/if}
 				<div class="key-input">
 					<input

--- a/src/lib/components/ApiKeysPanel.svelte
+++ b/src/lib/components/ApiKeysPanel.svelte
@@ -95,6 +95,7 @@
 	<div class="intro">
 		Stored in <code>~/.docwriter/keys.env</code> and shared across all workspaces.
 		Environment variables (and the repo <code>.env</code>) override these.
+		Claude and Codex can also reuse a terminal login — see each provider note below.
 	</div>
 
 	{#if error}
@@ -111,8 +112,20 @@
 					<span class="badge {statusClass(p)}">{statusLabel(p)}</span>
 				</div>
 				<div class="env-var"><code>{p.envVar}</code></div>
-				{#if !p.present && p.usable && p.altAuthNote}
+				{#if p.altAuthNote && (!p.present || p.source === 'login')}
 					<div class="alt-note">{p.altAuthNote}</div>
+				{/if}
+				{#if p.id === 'claude' && p.source === 'login'}
+					<div class="alt-note refresh">
+						If the agent still fails with auth errors, refresh the login in a terminal:
+						run <code>claude</code>, type <code>/login</code>, finish the browser sign-in, then retry.
+					</div>
+				{/if}
+				{#if p.id === 'claude' && p.present}
+					<div class="alt-note refresh">
+						An Anthropic API key is set, so agent calls bill API usage (not your Claude Code subscription).
+						Choose <strong>Remove stored key</strong> below (and clear any shell <code>ANTHROPIC_API_KEY</code>) to reuse Claude Code login instead.
+					</div>
 				{/if}
 				<div class="key-input">
 					<input
@@ -235,6 +248,16 @@
 		color: var(--text-muted);
 		line-height: 1.45;
 		margin-bottom: 8px;
+	}
+	.alt-note code {
+		font-family: ui-monospace, monospace;
+		font-size: 11px;
+		background: var(--bg-surface);
+		padding: 1px 4px;
+		border-radius: 4px;
+	}
+	.alt-note.refresh {
+		margin-top: -2px;
 	}
 	.key-input {
 		display: flex;

--- a/src/lib/server/api-keys.ts
+++ b/src/lib/server/api-keys.ts
@@ -43,7 +43,8 @@ export const PROVIDER_KEYS: ProviderKeySpec[] = [
 		label: 'Claude',
 		envVar: 'ANTHROPIC_API_KEY',
 		required: false,
-		altAuthNote: 'Falls back to your `claude login` (Claude.ai subscription) if no key is set.'
+		altAuthNote:
+			'No key needed if Claude Code is logged in on this computer. In a terminal: run `claude`, type `/login`, finish the browser sign-in. DocWriter reuses that login (Claude.ai / Claude Code subscription). Pasting an Anthropic API key here bills API usage instead.'
 	},
 	{
 		id: 'openai',

--- a/src/lib/server/api-keys.ts
+++ b/src/lib/server/api-keys.ts
@@ -43,8 +43,7 @@ export const PROVIDER_KEYS: ProviderKeySpec[] = [
 		label: 'Claude',
 		envVar: 'ANTHROPIC_API_KEY',
 		required: false,
-		altAuthNote:
-			'No key needed if Claude Code is logged in on this computer. In a terminal: run `claude`, type `/login`, finish the browser sign-in. DocWriter reuses that login (Claude.ai / Claude Code subscription). Pasting an Anthropic API key here bills API usage instead.'
+		altAuthNote: 'Or skip the key: in a terminal run `claude`, then type `/login`.'
 	},
 	{
 		id: 'openai',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1025,6 +1025,36 @@
 
 	/** True when the dequeued message can be safely skipped because there's
 	 * a more specific user message right behind it. */
+	/** Plain-language recovery steps when the provider rejects auth.
+	 * `/login` is a Claude Code CLI slash command — not a DocWriter UI action. */
+	function authRecoveryHint(providerId: string): string {
+		if (providerId === 'claude') {
+			return [
+				'Claude Code login expired or is missing. This is not a DocWriter setting.',
+				'In a terminal on this computer:',
+				'1. Run: claude',
+				'2. Type: /login',
+				'3. Finish the browser sign-in, then return here and try again.',
+				'',
+				'In DocWriter: Settings → API keys — Claude should say "Using login".',
+				'Leave the Anthropic API key empty to keep using your Claude Code / Claude.ai subscription. Pasting a key bills Anthropic API usage instead.',
+				'',
+				'More detail: Settings → API keys, or docs.docwriter.org/connect-provider'
+			].join('\n');
+		}
+		if (providerId === 'codex') {
+			return [
+				'Codex login expired or is missing.',
+				'In a terminal on this computer, run your Codex CLI login again, then retry.',
+				'Or open Settings → API keys and paste a key for Codex / OpenAI.'
+			].join('\n');
+		}
+		return [
+			'Re-authenticate this provider, then try again.',
+			'Open Settings → API keys to see whether a login or API key is available.'
+		].join('\n');
+	}
+
 	function isSkippableWhenQueued(trigger?: string): boolean {
 		return isAcceptedEditsMessage(trigger) || isImplicitWakeupTrigger(trigger);
 	}
@@ -1548,7 +1578,7 @@
 							kind: 'error',
 							title: isAuthError ? 'Agent auth failed' : 'Agent run failed',
 							body: isAuthError
-								? `${errText}\n\nRe-authenticate your provider (e.g. run \`claude\` in a terminal and /login), then try again.`
+								? `${errText}\n\n${authRecoveryHint(provider)}`
 								: errText,
 							refId: String(renderStart)
 						});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1025,34 +1025,21 @@
 
 	/** True when the dequeued message can be safely skipped because there's
 	 * a more specific user message right behind it. */
-	/** Plain-language recovery steps when the provider rejects auth.
-	 * `/login` is a Claude Code CLI slash command — not a DocWriter UI action. */
+	/** Recovery steps when the provider rejects auth. `/login` is typed inside
+	 * a Claude Code terminal session — not in the DocWriter UI. */
 	function authRecoveryHint(providerId: string): string {
 		if (providerId === 'claude') {
 			return [
-				'Claude Code login expired or is missing. This is not a DocWriter setting.',
 				'In a terminal on this computer:',
-				'1. Run: claude',
-				'2. Type: /login',
-				'3. Finish the browser sign-in, then return here and try again.',
-				'',
-				'In DocWriter: Settings → API keys — Claude should say "Using login".',
-				'Leave the Anthropic API key empty to keep using your Claude Code / Claude.ai subscription. Pasting a key bills Anthropic API usage instead.',
-				'',
-				'More detail: Settings → API keys, or docs.docwriter.org/connect-provider'
+				'1. Enter claude and wait for the session to start',
+				'2. Type /login and finish the browser sign-in',
+				'3. Retry here (Settings → API keys should show Using login; leave the Anthropic key empty)'
 			].join('\n');
 		}
 		if (providerId === 'codex') {
-			return [
-				'Codex login expired or is missing.',
-				'In a terminal on this computer, run your Codex CLI login again, then retry.',
-				'Or open Settings → API keys and paste a key for Codex / OpenAI.'
-			].join('\n');
+			return 'Re-run your Codex CLI login in a terminal, or paste a key under Settings → API keys.';
 		}
-		return [
-			'Re-authenticate this provider, then try again.',
-			'Open Settings → API keys to see whether a login or API key is available.'
-		].join('\n');
+		return 'Re-authenticate this provider, then try again. See Settings → API keys.';
 	}
 
 	function isSkippableWhenQueued(trigger?: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Claude Code subscription login discoverable: concrete terminal steps in the docs, short notes in **Settings → API keys**, and a clearer auth-failure toast.

## Changes

- **Docs** (`connect-provider`, `provider-errors`): step-by-step — enter `claude` in a terminal, wait for the session, type `/login`, finish browser sign-in; leave the Anthropic key empty for subscription login.
- **API keys panel**: one short line for Claude (`Or skip the key: in a terminal run claude, then type /login.` / `Key set — API billing…`).
- Auth failure toast uses the same short terminal steps.

## Test plan

- [x] Open **Settings → API keys** and confirm Claude notes are one short line (no key / key set)
- [x] Skim Claude section in `docs/connect-provider.mdx` and `docs/help/provider-errors.mdx`
- [x] `npm run check` (earlier on this branch)

## Walkthrough

[Short Claude note when no key](https://cursor.com/agents/bc-01a04a44-f6cc-7ddd-b07a-39db13028d6e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_keys_claude_no_key_note.png)
[Short Claude note when key set](https://cursor.com/agents/bc-01a04a44-f6cc-7ddd-b07a-39db13028d6e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_keys_claude_key_set_note.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04a44-f6cc-7ddd-b07a-39db13028d6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04a44-f6cc-7ddd-b07a-39db13028d6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

