### PR TITLE
Relabel comment-thread Resolve button to Dismiss

### DIFF
--- a/src/lib/components/CommentGutter.svelte
+++ b/src/lib/components/CommentGutter.svelte
@@ -61,7 +61,7 @@
 		/** Accept / reject every pending round on this tab. */
 		onAcceptAll?: () => void;
 		onRejectAll?: () => void;
-		/** Resolve / reopen a thread (undoable; resolving also drops its edits). */
+		/** Dismiss / reopen a thread (undoable; dismissing also drops its edits). */
 		onResolveThread: (threadId: string, resolved: boolean) => void;
 		/** Pin/unpin a whole feedback thread's edits so their diffs stay shown
 		 * even when the card is collapsed. */
@@ -541,7 +541,7 @@
 
 	function toggleResolved(thread: CommentThread) {
 		const next = !thread.resolved;
-		// Resolving also drops the thread's pending edits, and the whole action
+		// Dismissing also drops the thread's pending edits, and the whole action
 		// is applied locally with USER_ORIGIN by the parent so ctrl+z reopens
 		// the thread and brings its edits back in one step.
 		onResolveThread(thread.id, next);
@@ -737,7 +737,7 @@
 										<Copy size={11} />
 									</button>
 									<!-- No per-edit reject on thread cards: the natural "no" is a
-									     follow-up reply asking for a revision (or Resolve, which
+									     follow-up reply asking for a revision (or Dismiss, which
 									     drops the thread's pending edits). Loose edit cards keep
 									     their X — they have no reply box. -->
 									<button
@@ -779,9 +779,9 @@
 						onclick={() => toggleResolved(thread)}
 						title={thread.resolved
 							? 'Re-open this thread (it will appear in the agent prompt again)'
-							: 'Mark this thread done. It stops being inlined into the agent prompt.'}
+							: 'Dismiss this thread. It hides from the gutter and the agent prompt. Unaccepted edits on this thread are discarded.'}
 					>
-						{thread.resolved ? 'Reopen' : 'Resolve'}
+						{thread.resolved ? 'Reopen' : 'Dismiss'}
 					</button>
 					<div class="card-actions-right">
 						<span class="kbd-hint">{modEnterToSend}</span>
@@ -1193,7 +1193,7 @@
 		align-items: center;
 		gap: 6px;
 	}
-	/* Text-style buttons for secondary actions (Resolve, Close) — no
+	/* Text-style buttons for secondary actions (Dismiss, Close) — no
 	 * border, just a link-y color. Keeps the card from stacking more
 	 * boxed UI. */
 	.resolve-link {

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -83,7 +83,7 @@
 		/** Accept / reject every pending round on this tab. */
 		onAcceptAllEdits?: () => void;
 		onRejectAllEdits?: () => void;
-		/** Resolve / reopen a thread (undoable; also drops its pending edits). */
+		/** Dismiss / reopen a thread (undoable; also drops its pending edits). */
 		onResolveThread?: (threadId: string, resolved: boolean) => void;
 		/** Open the resolved preview output beside the source editor
 		 * (used by "Locate in PDF" on the feedback popup). */

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -46,6 +46,7 @@ import type {
 	PendingReviewOperation,
 	PendingReviewRound
 } from '$lib/types';
+import { formatListedThreads } from '$lib/shared/list-threads';
 import { isValidTabId, tabFile, WORKSPACE_ROOT } from './document-files';
 import { resolveWorkspacePath } from './workspace-path';
 import { getRules, getTabsState, setTabsState } from './runtime-state';
@@ -1061,18 +1062,26 @@ const replyToCommentTool = tool(
 	}
 );
 
-/** Read all open (unresolved) comment threads for a tab. Threads are stored
- * in the Y.Doc and persisted to SQLite — not in the JSONL transcript — so the
- * prompt only carries stubs; call this tool to get the full conversations. */
+/** Read comment threads for a tab. Threads live on the Y.Doc (persisted via
+ * `yjs_updates`), so the prompt only carries stubs; call this for the full
+ * conversation. Dismissed threads stay on the map with `resolved: true` —
+ * pass include_dismissed to read them, then review_action(reopen_thread) to
+ * put one back in the gutter. */
 const listThreadsTool = tool(
 	'list_threads',
-	'Return all open comment threads for a workspace tab, with every message in each. The prompt shows only thread ids and anchor quotes. Call this to read the full conversation before replying.',
+	'Return comment threads for a workspace tab, with every message in each. Defaults to open (visible) threads. The prompt shows only stubs. Set include_dismissed=true to read threads the user dismissed — they stay on the document, hidden from the gutter. Then review_action({ action: "reopen_thread", thread_id }) brings one back.',
 	{
 		file_path: z
 			.string()
-			.describe('Workspace-relative tab id or absolute path to the tab file.')
+			.describe('Workspace-relative tab id or absolute path to the tab file.'),
+		include_dismissed: z
+			.boolean()
+			.optional()
+			.describe(
+				'If true, also return dismissed (hidden) threads so you can reopen one. Use when the user asks about a thread that disappeared or wants one brought back.'
+			)
 	},
-	async ({ file_path }) => {
+	async ({ file_path, include_dismissed }) => {
 		if (isScratchPath(file_path)) {
 			return toolError('list_threads cannot be used on scratch paths — only on workspace tab files.');
 		}
@@ -1090,25 +1099,8 @@ const listThreadsTool = tool(
 			await direct.transact((document) => {
 				const commentsMap = getCommentsMap(document as unknown as Y.Doc);
 				const threads: CommentThread[] = [];
-				commentsMap.forEach((t) => { if (!t.resolved) threads.push(t); });
-				threads.sort((a, b) => a.createdAt - b.createdAt);
-				if (threads.length === 0) {
-					result = `No open threads on ${file_path}.`;
-					return;
-				}
-				const lines: string[] = [`${threads.length} open thread${threads.length === 1 ? '' : 's'} on ${file_path}:\n`];
-				for (const thread of threads) {
-					lines.push(`Thread \`${thread.id}\` — anchor: "${thread.anchor.quote.slice(0, 120)}${thread.anchor.quote.length > 120 ? '…' : ''}"`);
-					for (const msg of thread.messages) {
-						const role = msg.author === 'agent' ? 'you' : 'user';
-						lines.push(`  [${role}] ${msg.text}`);
-						if (msg.proposedEdit) {
-							lines.push(`    proposed_edit: "${msg.proposedEdit.oldString}" → "${msg.proposedEdit.newString}"`);
-						}
-					}
-					lines.push('');
-				}
-				result = lines.join('\n');
+				commentsMap.forEach((t) => threads.push(t));
+				result = formatListedThreads(file_path, threads, include_dismissed === true);
 			});
 		} finally {
 			await direct.disconnect();

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -345,7 +345,7 @@ export function cryptoRandomId(): string {
 
 /** Open a comment thread anchored to the passage an agent edit replaces and
  * return its id, so a spontaneous edit renders as a thread card (with a
- * conversation + Resolve) instead of a bare standalone edit card. The anchor
+ * conversation + Dismiss) instead of a bare standalone edit card. The anchor
  * quote is the edit's `oldString`, which `edit_doc` already guaranteed
  * matches the live text exactly once, so the gutter can position the card and
  * the client backfills CRDT rel-positions on first render. The single agent

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -106,7 +106,7 @@ function buildDocwriterMcp() {
 		),
 		tool(
 			'review_action',
-			'Accept or reject pending edits, or resolve or reopen comment threads, only when the user\'s current message explicitly asks for that action. This mutates document review state.',
+			'Accept or reject pending edits, or dismiss or reopen comment threads, only when the user\'s current message explicitly asks. reopen_thread brings a dismissed thread back into the gutter — find its id with list_threads(include_dismissed=true).',
 			{
 				file_path: z.string().describe('Workspace-relative path or absolute path inside the workspace.'),
 				action: z.enum(['accept_round', 'accept_all', 'reject_round', 'reject_all', 'resolve_thread', 'reopen_thread']).describe('The explicit review action requested by the user.'),

--- a/src/lib/server/providers/tool-handlers.ts
+++ b/src/lib/server/providers/tool-handlers.ts
@@ -37,6 +37,7 @@ import type {
 	CommentMessage,
 	CommentThread
 } from '$lib/types';
+import { formatListedThreads } from '$lib/shared/list-threads';
 import { resolveWorkspacePath } from '$lib/server/workspace-path';
 import { addCustomSkill, readEnabledSkill } from '$lib/server/skills-config';
 import {
@@ -349,7 +350,7 @@ export function buildToolDefinitions(): ToolDefinition[] {
 		{
 			name: 'review_action',
 			description:
-				'Accept/reject pending review edits or resolve/reopen comment threads ONLY when the user explicitly asks you to do that action. This mutates document review state.',
+				'Accept/reject pending review edits, or dismiss/reopen comment threads, ONLY when the user explicitly asks. reopen_thread brings a dismissed thread back into the gutter — find its id with list_threads(include_dismissed=true).',
 			inputSchema: {
 				type: 'object',
 				properties: {
@@ -561,14 +562,25 @@ export function buildToolDefinitions(): ToolDefinition[] {
 		},
 		{
 			name: 'list_threads',
-			description: 'Return all open (unresolved) comment threads for a workspace tab.',
+			description:
+				'Return comment threads for a workspace tab, with every message in each. Defaults to open threads. Set include_dismissed=true to read threads the user dismissed (they stay on the document, hidden from the gutter). Then review_action({ action: "reopen_thread", thread_id }) brings one back.',
 			inputSchema: {
 				type: 'object',
-				properties: { file_path: { type: 'string' } },
+				properties: {
+					file_path: { type: 'string' },
+					include_dismissed: {
+						type: 'boolean',
+						description:
+							'If true, also return dismissed (hidden) threads so you can reopen one. Use when the user asks about a thread that disappeared or wants one brought back.'
+					}
+				},
 				required: ['file_path']
 			},
 			execute: async (input) => {
-				const { file_path: path } = input as { file_path: string };
+				const { file_path: path, include_dismissed } = input as {
+					file_path: string;
+					include_dismissed?: boolean;
+				};
 				if (!path) {
 					return { isError: true, content: [{ type: 'text' as const, text: 'list_threads requires `file_path`.' }] };
 				}
@@ -585,20 +597,8 @@ export function buildToolDefinitions(): ToolDefinition[] {
 					await direct.transact((document) => {
 						const commentsMap = getCommentsMap(document as unknown as Y.Doc);
 						const threads: CommentThread[] = [];
-						commentsMap.forEach((t) => { if (!t.resolved) threads.push(t); });
-						threads.sort((a, b) => a.createdAt - b.createdAt);
-						if (threads.length === 0) { result = `No open threads on ${path}.`; return; }
-						const lines: string[] = [`${threads.length} open thread${threads.length === 1 ? '' : 's'} on ${path}:\n`];
-						for (const thread of threads) {
-							lines.push(`Thread \`${thread.id}\` — anchor: "${thread.anchor.quote.slice(0, 120)}${thread.anchor.quote.length > 120 ? '…' : ''}"`);
-							for (const m of thread.messages) {
-								const role = m.author === 'agent' ? 'you' : 'user';
-								lines.push(`  [${role}] ${m.text}`);
-								if (m.proposedEdit) lines.push(`    proposed_edit: "${m.proposedEdit.oldString}" → "${m.proposedEdit.newString}"`);
-							}
-							lines.push('');
-						}
-						result = lines.join('\n');
+						commentsMap.forEach((t) => threads.push(t));
+						result = formatListedThreads(path, threads, include_dismissed === true);
 					});
 				} finally {
 					await direct.disconnect();

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -156,8 +156,8 @@ async function withLiveDoc<T>(
  * user message) — has nothing left to show once its edit is gone, so we
  * auto-resolve it (the card disappears). A thread with genuine back-and-
  * forth (any user message) is left open: the edit row clears but the
- * conversation stays, and the user resolves it manually via the card's
- * Resolve button. Runs inside the caller's transaction so the resolve
+ * conversation stays, and the user dismisses it manually via the card's
+ * Dismiss button. Runs inside the caller's transaction so the dismiss
  * lands in the same Yjs delta as the round removal.
  *
  * `threadIds` are the feedbackThreadIds of the just-removed rounds. */
@@ -365,9 +365,9 @@ export async function rejectTabRounds(
 	});
 }
 
-/** Resolve (or reopen) a comment thread. The thread is the PARENT of any
- * edits grouped under it, so resolving it also drops those pending edits —
- * a resolved thread carries no live proposals. Both the comments-map write
+/** Dismiss (or reopen) a comment thread. The thread is the PARENT of any
+ * edits grouped under it, so dismissing it also drops those pending edits —
+ * a dismissed thread carries no live proposals. Both the comments-map write
  * and the review-array deletes happen in ONE `USER_ORIGIN` transaction, so
  * the returned delta — applied on the client with `USER_ORIGIN` — lands as a
  * single undoable step: ctrl+z reopens the thread AND resurrects its edits

--- a/src/lib/shared/list-threads.test.ts
+++ b/src/lib/shared/list-threads.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { CommentThread } from '$lib/types';
+import { formatDismissedThreadsHint, formatListedThreads } from './list-threads';
+
+function thread(
+	id: string,
+	resolved: boolean,
+	quote: string,
+	userText: string
+): CommentThread {
+	return {
+		id,
+		resolved,
+		createdAt: Number(id.replace(/\D/g, '') || 0),
+		anchor: { quote, occurrenceIndex: 0 },
+		messages: [{ id: `msg_${id}`, author: 'user', text: userText, timestamp: 1 }]
+	};
+}
+
+describe('formatListedThreads', () => {
+	const open = thread('thread_1', false, 'Rayleigh scattering', 'explain this term');
+	const dismissed = thread('thread_2', true, 'At sunset', 'too abrupt');
+
+	it('lists only open threads by default and hints at dismissed ones', () => {
+		const text = formatListedThreads('document.md', [open, dismissed], false);
+		expect(text).toContain('1 open thread on document.md');
+		expect(text).toContain('thread_1');
+		expect(text).toContain('explain this term');
+		expect(text).not.toContain('too abrupt');
+		expect(text).toContain('1 dismissed thread');
+		expect(text).toContain('include_dismissed=true');
+		expect(text).toContain('reopen_thread');
+	});
+
+	it('includes dismissed thread bodies when asked', () => {
+		const text = formatListedThreads('document.md', [open, dismissed], true);
+		expect(text).toContain('[dismissed]');
+		expect(text).toContain('thread_2');
+		expect(text).toContain('too abrupt');
+		expect(text).toContain('reopen_thread');
+	});
+
+	it('says there are no threads when the map is empty', () => {
+		expect(formatListedThreads('document.md', [], false)).toBe(
+			'No comment threads on document.md.'
+		);
+	});
+
+	it('still reports dismissed-only tabs without include_dismissed', () => {
+		const text = formatListedThreads('document.md', [dismissed], false);
+		expect(text).toContain('No open threads on document.md.');
+		expect(text).toContain('1 dismissed thread');
+		expect(text).not.toContain('too abrupt');
+	});
+});
+
+describe('formatDismissedThreadsHint', () => {
+	it('is empty when nothing is dismissed', () => {
+		expect(formatDismissedThreadsHint(0)).toBe('');
+	});
+
+	it('pluralizes', () => {
+		expect(formatDismissedThreadsHint(2)).toContain('2 dismissed threads');
+	});
+});

--- a/src/lib/shared/list-threads.ts
+++ b/src/lib/shared/list-threads.ts
@@ -1,0 +1,73 @@
+import type { CommentThread } from '$lib/types';
+
+function formatOneThread(thread: CommentThread, dismissed: boolean): string {
+	const status = dismissed ? ' [dismissed]' : '';
+	const quote = thread.anchor.quote.slice(0, 120);
+	const ellipsis = thread.anchor.quote.length > 120 ? '…' : '';
+	const lines = [`Thread \`${thread.id}\`${status} — anchor: "${quote}${ellipsis}"`];
+	for (const msg of thread.messages) {
+		const role =
+			msg.author === 'agent'
+				? 'you'
+				: msg.author === 'external'
+					? (msg.externalAuthor ?? 'reviewer')
+					: 'user';
+		lines.push(`  [${role}] ${msg.text}`);
+		if (msg.proposedEdit) {
+			lines.push(
+				`    proposed_edit: "${msg.proposedEdit.oldString}" → "${msg.proposedEdit.newString}"`
+			);
+		}
+	}
+	return lines.join('\n');
+}
+
+/** Text the agent sees from `list_threads`. Open threads first; dismissed
+ * threads only when `includeDismissed` is set. If dismissed threads exist
+ * but were not requested, a one-line hint tells the agent how to read them
+ * and how to put one back in the gutter (`review_action reopen_thread`). */
+export function formatListedThreads(
+	filePath: string,
+	threads: CommentThread[],
+	includeDismissed: boolean
+): string {
+	const open = threads.filter((t) => !t.resolved).sort((a, b) => a.createdAt - b.createdAt);
+	const dismissed = threads.filter((t) => t.resolved).sort((a, b) => a.createdAt - b.createdAt);
+
+	if (open.length === 0 && dismissed.length === 0) {
+		return `No comment threads on ${filePath}.`;
+	}
+
+	const parts: string[] = [];
+	if (open.length > 0) {
+		parts.push(
+			`${open.length} open thread${open.length === 1 ? '' : 's'} on ${filePath}:\n`
+		);
+		for (const thread of open) {
+			parts.push(formatOneThread(thread, false));
+			parts.push('');
+		}
+	} else {
+		parts.push(`No open threads on ${filePath}.`);
+	}
+
+	if (includeDismissed && dismissed.length > 0) {
+		parts.push(
+			`${dismissed.length} dismissed thread${dismissed.length === 1 ? '' : 's'} on ${filePath} (hidden from the gutter; review_action reopen_thread brings one back):\n`
+		);
+		for (const thread of dismissed) {
+			parts.push(formatOneThread(thread, true));
+			parts.push('');
+		}
+	} else if (dismissed.length > 0) {
+		parts.push(formatDismissedThreadsHint(dismissed.length));
+	}
+
+	return parts.join('\n').replace(/\n+$/, '');
+}
+
+/** One-line breadcrumb for the per-turn workspace_state stub. */
+export function formatDismissedThreadsHint(dismissedCount: number): string {
+	if (dismissedCount <= 0) return '';
+	return `${dismissedCount} dismissed thread${dismissedCount === 1 ? '' : 's'}. Call list_threads with include_dismissed=true to read them; review_action(reopen_thread) to bring one back.`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1701,8 +1701,8 @@
 		}
 	}
 
-	/** Resolve / reopen a thread through the same undo-friendly transport as
-	 * Accept/Reject: pause sync, let the server resolve the thread AND drop its
+	/** Dismiss / reopen a thread through the same undo-friendly transport as
+	 * Accept/Reject: pause sync, let the server dismiss the thread AND drop its
 	 * pending edits in one transaction, apply the delta locally with
 	 * USER_ORIGIN. ctrl+z then reopens the thread and resurrects its edits in a
 	 * single step. */

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -22,6 +22,7 @@ import { readMeta } from '$lib/server/document-io';
 import { kvGet, kvSet, dbAppendConversationEvent } from '$lib/server/db-writes';
 import { readCommentThreads, readReviewRounds } from '$lib/shared/ydoc-codec';
 import type { CommentThread } from '$lib/types';
+import { formatDismissedThreadsHint } from '$lib/shared/list-threads';
 import { replayUpdatesInto } from '$lib/server/ydoc-persistence';
 import { registerPendingAskUser } from '$lib/server/ask-user-state';
 import { unifiedLineDiff } from '$lib/diff';
@@ -317,7 +318,7 @@ Before your first edit in a session, list the files in the workspace directory w
 - Your scratch space is ${AGENT_SCRATCH_DIR}/. Use it for drafts, outlines, and notes to yourself. The user never sees it. It persists across turns and is wiped on "New session".
 - Read anywhere in the workspace with the built-in Read, Glob, and Grep. For open tabs, use read_doc instead. The built-in Read can also read images.
 - For hooks call propose_hook. For rules call propose_rule. For skills call add_skill with a GitHub URL or local path. Do not edit .docwriter/hooks.json, .docwriter/skills.json, .claude/skills, or .agents/skills directly.
-- Call review_action to accept, reject, resolve, or reopen only when the user's current message explicitly asks for that action.
+- Call review_action to accept, reject, dismiss, or reopen only when the user's current message explicitly asks for that action. Dismissed threads stay on the document. list_threads(include_dismissed=true) reads them; review_action(reopen_thread) puts one back in the gutter.
 
 ## Announce edits on a thread
 
@@ -334,7 +335,7 @@ Every edit proposal needs a comment thread that says what is about to happen, so
 
 Each turn may contain these blocks, in this order.
 
-- <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and open comment threads as one-line stubs. Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(file_path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
+- <workspace_state>: the open tabs, a diff of what changed in each since your last turn, and comment-thread stubs (open threads plus a count of dismissed ones). Unchanged tabs say "Unchanged". Tab content is never inlined. Call read_doc(file_path) when you need it. Calls are cheap because the server holds the document in memory, so read what you need, not every tab.
 - <author_style>: how the user writes, learned from their own writing. Present on every turn once a style has been learned. Follow it whenever you draft or revise prose, unless the user asks for something different this turn.
 - <session_state>: rules, style references, the agency level, and the intended audience. Sent in full on the first turn, then only when something changed. If the block is absent, nothing changed.
 - <mode>: present only in special modes, such as plan-first.
@@ -440,15 +441,21 @@ function renderCommentThreadsBlock(
 	pendingEditThreadIds: string[] = []
 ): string {
 	const open = threads.filter((t) => !t.resolved);
-	if (open.length === 0) return '';
+	const dismissedCount = threads.filter((t) => t.resolved).length;
+	if (open.length === 0 && dismissedCount === 0) return '';
 	const pending = new Set(pendingEditThreadIds);
-	const lines: string[] = ['Open threads (route per "Where a response goes"):'];
-	for (const thread of open) {
-		const quote = thread.anchor.quote.replace(/\n+/g, ' ').slice(0, 120);
-		const ellipsis = thread.anchor.quote.length > 120 ? '…' : '';
-		const pendingNote = pending.has(thread.id) ? ' (pending edit)' : '';
-		lines.push(`- ${thread.id}${pendingNote} anchored to: "${quote}${ellipsis}"`);
+	const lines: string[] = [];
+	if (open.length > 0) {
+		lines.push('Open threads (route per "Where a response goes"):');
+		for (const thread of open) {
+			const quote = thread.anchor.quote.replace(/\n+/g, ' ').slice(0, 120);
+			const ellipsis = thread.anchor.quote.length > 120 ? '…' : '';
+			const pendingNote = pending.has(thread.id) ? ' (pending edit)' : '';
+			lines.push(`- ${thread.id}${pendingNote} anchored to: "${quote}${ellipsis}"`);
+		}
 	}
+	const dismissedHint = formatDismissedThreadsHint(dismissedCount);
+	if (dismissedHint) lines.push(dismissedHint);
 	return '\n' + lines.join('\n');
 }
 

--- a/src/routes/welcome/+page.svelte
+++ b/src/routes/welcome/+page.svelte
@@ -233,7 +233,7 @@
 						</div>
 						<input class="rp-reply" type="text" placeholder="Reply..." disabled />
 						<div class="rp-footer">
-							<span class="rp-resolve">Resolve</span>
+							<span class="rp-resolve">Dismiss</span>
 							<button class="rp-send">Send</button>
 						</div>
 					</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The comment-card action that hides a thread and drops its unaccepted edits is now labeled **Dismiss** instead of **Resolve**. The tooltip says the thread hides from the gutter and the agent prompt, and that unaccepted edits are discarded.

Dismissed threads were already still on the live Y.Doc (`Y.Map('comments')`, `resolved: true`). The agent just could not see them: `list_threads` filtered them out, and there is no SQL `threads` table / no useful `SELECT` on `yjs_updates` (binary CRDT blobs).

This follow-up gives the agent a real recovery path:

1. `list_threads` defaults to open threads, but reports how many are dismissed.
2. `list_threads(include_dismissed=true)` returns the full dismissed conversations, marked `[dismissed]`.
3. `review_action({ action: "reopen_thread", thread_id })` clears the flag so the card returns to the gutter. A `reply_to_comment` on that id also reopens it.

The per-turn workspace stub includes the dismissed count so the agent knows to look.

Internal APIs (`resolved`, `setThreadResolution`) are unchanged. Persistence is still the Y.Doc comments map + `yjs_updates`, not a relational threads table.

## Testing

- Unit tests for `formatListedThreads` (open-only, include_dismissed, dismissed-only, empty).
- Live tab: created a thread, dismissed it, replayed the Y.Doc from SQLite, confirmed `list_threads` listed the hidden conversations, then `set_thread_resolution(resolved=false)` brought the card back in the gutter.

[Reopened thread card in the gutter](https://cursor.com/agents/bc-c90e4860-c841-4d6d-940a-cbce48c71ef2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freopened_thread_in_gutter.webp)

[dismiss_comment_thread.mp4](https://cursor.com/agents/bc-c90e4860-c841-4d6d-940a-cbce48c71ef2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdismiss_comment_thread.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c90e4860-c841-4d6d-940a-cbce48c71ef2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c90e4860-c841-4d6d-940a-cbce48c71ef2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

