### PR TITLE
Workspace root guardrail and review-UI reset

### DIFF
--- a/bin/docwriter-dev.js
+++ b/bin/docwriter-dev.js
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { mkdirSync } from 'node:fs';
+import { conflictingCwdState, describeWorkspace, printWorkspaceBanner } from './workspace-identity.js';
 
 const argv = process.argv.slice(2);
 let portArg = null;
@@ -13,6 +14,7 @@ let rootArg = null;
 let apiKey = null;
 let modelArg = null;
 let newSession = false;
+let resetUi = false;
 let showHelp = false;
 
 for (let i = 0; i < argv.length; i++) {
@@ -29,6 +31,8 @@ for (let i = 0; i < argv.length; i++) {
 		modelArg = a.slice(8);
 	} else if (a === '--new-session') {
 		newSession = true;
+	} else if (a === '--reset-ui') {
+		resetUi = true;
 	} else if (a === '-p' || a === '--port') {
 		portArg = argv[++i];
 	} else if (a.startsWith('--port=')) {
@@ -63,6 +67,7 @@ Options:
       --api-key <key>   Anthropic API key (overrides ANTHROPIC_API_KEY)
       --model <name>    Default model: opus | sonnet | haiku
       --new-session     Start with a fresh AI conversation
+      --reset-ui        Clear pending reviews and comment threads, then start
   -h, --help            Show this help
 
 Example:
@@ -80,10 +85,14 @@ mkdirSync(docwriterRoot, { recursive: true });
 const viteArgs = ['dev', '--host', hostArg, '--port', portArg || '5173'];
 if (openBrowser) viteArgs.push('--open');
 
+const workspace = describeWorkspace(docwriterRoot);
+const cwdConflict = conflictingCwdState(docwriterRoot);
+
 console.log(`\n  docwriter dev  http://${hostArg === '0.0.0.0' ? 'localhost' : hostArg}:${portArg || '5173'}`);
-console.log(`  workspace      ${docwriterRoot}`);
+printWorkspaceBanner(workspace, cwdConflict);
 if (modelArg) console.log(`  model          ${modelArg}`);
 if (newSession) console.log('  session        new (cleared persisted context)');
+if (resetUi) console.log('  reset          pending reviews and comment threads');
 console.log('');
 
 const child = spawn(process.execPath, [viteBin, ...viteArgs], {
@@ -91,9 +100,11 @@ const child = spawn(process.execPath, [viteBin, ...viteArgs], {
 	env: {
 		...process.env,
 		DOCWRITER_ROOT: docwriterRoot,
+		DOCWRITER_INVOKE_CWD: process.cwd(),
 		...(apiKey ? { ANTHROPIC_API_KEY: apiKey } : {}),
 		...(modelArg ? { DOCWRITER_DEFAULT_MODEL: modelArg } : {}),
-		...(newSession ? { DOCWRITER_NEW_SESSION: '1' } : {})
+		...(newSession ? { DOCWRITER_NEW_SESSION: '1' } : {}),
+		...(resetUi ? { DOCWRITER_RESET_UI: '1' } : {})
 	},
 	stdio: 'inherit'
 });

--- a/bin/docwriter.js
+++ b/bin/docwriter.js
@@ -16,6 +16,7 @@
  *       --api-key <key>   Anthropic API key (overrides ANTHROPIC_API_KEY env var)
  *       --model <name>    Default model: opus | sonnet | haiku (overrides UI setting)
  *       --new-session     Clear the persisted AI session — start a fresh conversation
+ *       --reset-ui        Clear pending reviews and comment threads, then start
  *   -h, --help            Show this help
  *
  * Auth:
@@ -35,6 +36,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, extname, join, resolve } from 'node:path';
 import { existsSync, mkdirSync, readFileSync, watch as fsWatch } from 'node:fs';
+import { conflictingCwdState, describeWorkspace, printWorkspaceBanner } from './workspace-identity.js';
 
 // ---------------------------------------------------------------------------
 // Argument parsing (no external deps, pure stdlib)
@@ -49,6 +51,7 @@ let rootArg = null;
 let apiKey = null;
 let modelArg = null;
 let newSession = false;
+let resetUi = false;
 let showHelp = false;
 let showVersion = false;
 
@@ -68,6 +71,8 @@ for (let i = 0; i < argv.length; i++) {
 		modelArg = a.slice(8);
 	} else if (a === '--new-session') {
 		newSession = true;
+	} else if (a === '--reset-ui') {
+		resetUi = true;
 	} else if (a === '-p' || a === '--port') {
 		portArg = parseInt(argv[++i] ?? '', 10);
 	} else if (a.startsWith('--port=')) {
@@ -127,6 +132,7 @@ Options:
       --api-key <key>   Anthropic API key (overrides ANTHROPIC_API_KEY)
       --model <name>    Default model: opus | sonnet | haiku
       --new-session     Start a fresh AI conversation (clear persisted session)
+      --reset-ui        Clear pending reviews and comment threads, then start
   -h, --help            Show this help
 
 Auth:
@@ -140,6 +146,7 @@ Examples:
   docwriter --host --watch          # LAN + live reload
   docwriter --model opus            # force Opus for this session
   docwriter --new-session           # fresh conversation on start
+  docwriter --reset-ui ~/writing/book
 `.trim());
 	process.exit(0);
 }
@@ -196,13 +203,17 @@ const wsPort = parseInt(process.env.DOCWRITER_WS_PORT ?? '', 10) || (await getFr
 const hasApiKey = !!(apiKey || process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN);
 const authLabel = hasApiKey ? 'api key' : 'claude.ai subscription';
 
+const workspace = describeWorkspace(docwriterRoot);
+const cwdConflict = conflictingCwdState(docwriterRoot);
+
 console.log(`\n  docwriter  ${origin}`);
-console.log(`  workspace  ${docwriterRoot}`);
+printWorkspaceBanner(workspace, cwdConflict);
 console.log(`  auth       ${authLabel}`);
 if (modelArg) console.log(`  model      ${modelArg}`);
 if (watchFlag) console.log('  watch      on (file changes → browser reload)');
 if (restartFlag) console.log('  restart    on crash');
 if (newSession) console.log('  session    new (cleared persisted context)');
+if (resetUi) console.log('  reset      pending reviews and comment threads');
 console.log('');
 
 // ---------------------------------------------------------------------------
@@ -214,6 +225,7 @@ function spawnServer() {
 		env: {
 			...process.env,
 			DOCWRITER_ROOT: docwriterRoot,
+			DOCWRITER_INVOKE_CWD: process.cwd(),
 			PORT: String(port),
 			HOST: hostArg,
 			ORIGIN: origin,
@@ -227,7 +239,8 @@ function spawnServer() {
 			// CLI model default; render endpoint reads this as fallback.
 			...(modelArg ? { DOCWRITER_DEFAULT_MODEL: modelArg } : {}),
 			// Signals hooks.server.ts to clear the persisted session on startup.
-			...(newSession ? { DOCWRITER_NEW_SESSION: '1' } : {})
+			...(newSession ? { DOCWRITER_NEW_SESSION: '1' } : {}),
+			...(resetUi ? { DOCWRITER_RESET_UI: '1' } : {})
 		},
 		stdio: 'inherit'
 	});

--- a/bin/workspace-identity.js
+++ b/bin/workspace-identity.js
@@ -1,0 +1,34 @@
+/**
+ * CLI-side workspace banner + cwd-conflict warning.
+ * Keep the rules aligned with src/lib/shared/workspace-identity.ts.
+ */
+import { existsSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+
+export function describeWorkspace(root) {
+	const resolved = resolve(root);
+	return {
+		root: resolved,
+		stateDir: join(resolved, '.docwriter'),
+		name: basename(resolved) || resolved
+	};
+}
+
+export function conflictingCwdState(root, cwd = process.cwd()) {
+	const resolvedRoot = resolve(root);
+	const resolvedCwd = resolve(cwd);
+	if (resolvedRoot === resolvedCwd) return null;
+	const cwdStateDir = join(resolvedCwd, '.docwriter');
+	if (!existsSync(cwdStateDir)) return null;
+	return { cwd: resolvedCwd, cwdStateDir };
+}
+
+export function printWorkspaceBanner(identity, conflict) {
+	console.log(`  workspace  ${identity.root}`);
+	console.log(`  state      ${identity.stateDir}`);
+	if (!conflict) return;
+	console.log('');
+	console.log(`  warning    cwd has a separate .docwriter at ${conflict.cwdStateDir}`);
+	console.log(`             This process uses ${identity.stateDir} (the folder you opened).`);
+	console.log(`             Inspecting the wrong folder looks like an empty database.`);
+}

--- a/docs/feature-catalog.json
+++ b/docs/feature-catalog.json
@@ -1,5 +1,5 @@
 {
-  "featureCount": 157,
+  "featureCount": 158,
   "unassignedCount": 0,
   "features": [
     {
@@ -41,7 +41,7 @@
     {
       "id": "connect-provider-04",
       "area": "Models",
-      "feature": "Use Claude Code terminal login (/login) instead of an API key",
+      "feature": "Use Claude or Codex login instead of an API key",
       "targetPage": "connect-provider"
     },
     {
@@ -353,7 +353,7 @@
     {
       "id": "agent-ask-and-steer-09",
       "area": "Agent",
-      "feature": "See auth failure toasts with Claude Code /login steps",
+      "feature": "See failed run toasts with authentication recovery hints",
       "targetPage": "agent/ask-and-steer"
     },
     {
@@ -906,6 +906,12 @@
       "id": "help-recovery-03",
       "area": "Reference",
       "feature": "Use the agent scratch workspace until a new session",
+      "targetPage": "help/recovery"
+    },
+    {
+      "id": "help-recovery-04",
+      "area": "Workspace",
+      "feature": "Clear stuck pending reviews and comment threads without deleting the database",
       "targetPage": "help/recovery"
     },
     {

--- a/docs/feature-catalog.json
+++ b/docs/feature-catalog.json
@@ -1,5 +1,5 @@
 {
-  "featureCount": 158,
+  "featureCount": 160,
   "unassignedCount": 0,
   "features": [
     {
@@ -125,17 +125,23 @@
     {
       "id": "write-files-and-tabs-07",
       "area": "Workspace",
-      "feature": "See a combined pending work badge on tabs",
+      "feature": "Reopen or purge leftover tab state",
       "targetPage": "write/files-and-tabs"
     },
     {
       "id": "write-files-and-tabs-08",
       "area": "Workspace",
-      "feature": "Edit Markdown and other text files",
+      "feature": "See a combined pending work badge on tabs",
       "targetPage": "write/files-and-tabs"
     },
     {
       "id": "write-files-and-tabs-09",
+      "area": "Workspace",
+      "feature": "Edit Markdown and other text files",
+      "targetPage": "write/files-and-tabs"
+    },
+    {
+      "id": "write-files-and-tabs-10",
       "area": "Workspace",
       "feature": "Keep .docwriter visible in the file tree",
       "targetPage": "write/files-and-tabs"
@@ -912,6 +918,12 @@
       "id": "help-recovery-04",
       "area": "Workspace",
       "feature": "Clear stuck pending reviews and comment threads without deleting the database",
+      "targetPage": "help/recovery"
+    },
+    {
+      "id": "help-recovery-05",
+      "area": "Workspace",
+      "feature": "Recover a vanished tab from leftover saved state",
       "targetPage": "help/recovery"
     },
     {

--- a/docs/help/command-line.mdx
+++ b/docs/help/command-line.mdx
@@ -2,7 +2,7 @@
 title: "Command line"
 ---
 
-The directory passed to `docwriter` sets the workspace boundary. Confirm it before you create, rename, or delete files in DocWriter.
+The directory passed to `docwriter` sets the workspace boundary. Confirm it before you create, rename, or delete files in DocWriter. Saved comments, pending reviews, and sessions live in that folder's `.docwriter` directory, not in the directory you ran the command from (unless they are the same). The startup banner prints both paths. If the current directory has a different `.docwriter`, the banner warns you.
 
 ```text
 docwriter [options] [directory]
@@ -17,6 +17,7 @@ docwriter [options] [directory]
 | `--restart` | Start the server again one second after a crash. The active agent run does not resume. |
 | `--root <dir>` | Use this directory as the workspace root. The positional directory does the same job. |
 | `--new-session` | Clear the saved provider conversation at startup. Workspace files remain. |
+| `--reset-ui` | Clear pending reviews and comment threads at startup. Workspace files, rules, hooks, and settings remain. |
 | `--api-key <key>` | Set the Anthropic key for this process. The key can appear in shell history or process information. |
 | `--model <name>` | Set the Claude default model alias for this process. |
 | `--version` | Print the installed version without starting the server. |
@@ -28,6 +29,7 @@ docwriter ~/writing/book
 docwriter --watch ~/writing/paper
 docwriter --no-open --port 9000 ~/writing/notes
 docwriter --host 0.0.0.0 ~/writing/shared
+docwriter --reset-ui ~/writing/book
 ```
 
 In DocWriter, you select among Claude, OpenAI, Codex, Cursor, and Pi through the provider and model controls. The `--api-key` and `--model` flags apply only to Claude.
@@ -38,6 +40,6 @@ Use `--watch` when another program changes workspace files. A reload protects yo
 
 ## Environment
 
-Useful environment values include `DOCWRITER_ROOT`, `DOCWRITER_DEFAULT_MODEL`, `DOCWRITER_NEW_SESSION`, `ANTHROPIC_API_KEY`, and provider keys described in [Connect a provider](/connect-provider).
+Useful environment values include `DOCWRITER_ROOT`, `DOCWRITER_INVOKE_CWD`, `DOCWRITER_DEFAULT_MODEL`, `DOCWRITER_NEW_SESSION`, `DOCWRITER_RESET_UI`, `ANTHROPIC_API_KEY`, and provider keys described in [Connect a provider](/connect-provider).
 
 Environment values can override settings loaded from `~/.docwriter/keys.env`. Restart DocWriter after changing an environment value so the new process uses it. Removing a key can stop provider requests. Your earlier transcripts and provider records remain.

--- a/docs/help/recovery.mdx
+++ b/docs/help/recovery.mdx
@@ -36,9 +36,22 @@ Reply in the related thread or send a new Chat request to ask for a proposal bas
 
 ## A deleted file still appears
 
-Reload DocWriter so it can remove tabs for files that no longer exist. Removing a missing tab from the list only updates what you see. Your workspace file stays unchanged.
+A file that is briefly missing — for example during a compile or a rename — no longer removes that tab from saved state. The tab is hidden until the file is back. Your workspace file stays unchanged.
 
 When you delete a file inside DocWriter, you also lose its comments, pending reviews, and saved AI authorship markers. Browser undo history lasts only while the tab is loaded. Restore the project file and `.docwriter` folder from a backup if you need this information.
+
+## A tab vanished but the file is still there
+
+The most-edited file can disappear from the tab list while its edit history remains in `.docwriter/docwriter.db`. That happens when the tab row was dropped without cleaning up saved updates — for example after an older missing-file cleanup, or after a rename that did not move the history to the new path.
+
+Open **Settings**, then **Workspace**, and look under **Leftover tab state**.
+
+- **Reopen** puts the file back in the tab list and keeps its comments, pending reviews, and edit history.
+- **Purge** forgets that leftover history. The workspace file stays if it is still on disk.
+
+Closing a tab on purpose also leaves history so you can reopen the file later. Use **Purge** only when you want to discard that saved state.
+
+SQLite sequence numbers in `yjs_updates` are global, not per file. Small gaps of one or two numbers are normal after a tab is purged or a short log is replaced. They do not mean the database file is corrupt.
 
 ## A review card will not accept or dismiss
 

--- a/docs/help/recovery.mdx
+++ b/docs/help/recovery.mdx
@@ -44,12 +44,18 @@ When you delete a file inside DocWriter, you also lose its comments, pending rev
 
 The most-edited file can disappear from the tab list while its edit history remains in `.docwriter/docwriter.db`. That happens when the tab row was dropped without cleaning up saved updates — for example after an older missing-file cleanup, or after a rename that did not move the history to the new path.
 
-Open **Settings**, then **Workspace**, and look under **Leftover tab state**.
+Reload DocWriter. Writing tabs that still have a file and were not closed on purpose are put back automatically. Preview files such as PDFs are not.
+
+If the tab is still missing, open **Settings**, then **Workspace**, and look under **Leftover tab state**.
 
 - **Reopen** puts the file back in the tab list and keeps its comments, pending reviews, and edit history.
 - **Purge** forgets that leftover history. The workspace file stays if it is still on disk.
 
 Closing a tab on purpose also leaves history so you can reopen the file later. Use **Purge** only when you want to discard that saved state.
+
+Saved text usually matches the workspace file. A hyphen on disk and an en dash in the editor can come from typography normalization when DocWriter writes the file. That is not data loss.
+
+Large saved updates after an agent pass are often comment threads or pending reviews, not a rewrite of the document text.
 
 SQLite sequence numbers in `yjs_updates` are global, not per file. Small gaps of one or two numbers are normal after a tab is purged or a short log is replaced. They do not mean the database file is corrupt.
 

--- a/docs/help/recovery.mdx
+++ b/docs/help/recovery.mdx
@@ -40,9 +40,23 @@ Reload DocWriter so it can remove tabs for files that no longer exist. Removing 
 
 When you delete a file inside DocWriter, you also lose its comments, pending reviews, and saved AI authorship markers. Browser undo history lasts only while the tab is loaded. Restore the project file and `.docwriter` folder from a backup if you need this information.
 
+## A review card will not accept or dismiss
+
+A pending edit can remain in the gutter even when it has no comment thread. New session clears pending reviews on open tabs, but it keeps comment threads and does not walk closed tabs.
+
+Open **Settings**, then **Workspace**, and choose the smallest reset that matches the problem:
+
+- **Clear pending reviews** removes every unaccepted agent edit. Document text, comments, rules, and settings stay.
+- **Clear comment threads** removes every comment thread. Document text and pending reviews stay.
+- **Reset review UI** removes both.
+
+You can also start DocWriter with `--reset-ui` to clear reviews and comment threads at startup. Workspace files are unchanged. Copy proposal or comment text first if you may need it.
+
+Confirm the folder shown under **Opened folder**. State lives in that folder's `.docwriter` directory. If you started DocWriter with a directory argument, looking at `.docwriter` in the directory you ran the command from can look like an empty database.
+
 ## You need to reset DocWriter
 
-Delete `.docwriter/docwriter.db` only when you want to clear all saved DocWriter state for the workspace. A reset can help when the database is damaged or when you want the workspace to start with new DocWriter state.
+Delete `.docwriter/docwriter.db` only when you want to clear all saved DocWriter state for the workspace. A reset can help when the database is damaged or when you want the workspace to start with new DocWriter state. Try **Settings → Workspace → Reset review UI** first if only the gutter is stuck.
 
 Your project files remain, but you lose open tabs, comments, pending reviews, rules, reviewers, sessions, recent agent activity, and interface settings. The next time you open a file, DocWriter starts from the text in that file.
 

--- a/docs/help/storage-and-backups.mdx
+++ b/docs/help/storage-and-backups.mdx
@@ -4,7 +4,7 @@ title: "Storage and backups"
 
 Before moving, restoring, or deleting a workspace, decide whether you need only the current document text or other saved DocWriter information, such as comments and sessions.
 
-Workspace files contain the document text. The `.docwriter` folder contains comments, pending reviews, sessions, settings, hooks, and temporary agent files.
+Workspace files contain the document text. The `.docwriter` folder contains comments, pending reviews, sessions, settings, hooks, and temporary agent files. That folder is created inside the directory you passed to `docwriter`, not inside the directory you ran the command from. Open **Settings**, then **Workspace**, to confirm the path.
 
 ## Choose what to back up
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -36,6 +36,8 @@ docwriter ~/writing/my-project
 
 When you start DocWriter, your browser opens and the app binds to `127.0.0.1` by default. You can open and preview only files inside the folder you chose, so select the folder that contains the whole writing project. Hooks and shell commands can access other paths allowed by your operating system account.
 
+The terminal prints the opened folder and the `.docwriter` state path. Comments and pending reviews are stored there. If you inspect `.docwriter` in the directory you ran the command from, you may be looking at a different workspace.
+
 If the browser does not open, use the local address printed in the terminal. The first address is usually `http://127.0.0.1:7723`.
 
 ## Confirm the editor works

--- a/docs/write/files-and-tabs.mdx
+++ b/docs/write/files-and-tabs.mdx
@@ -6,7 +6,9 @@ Use the file tree and tabs to keep every part of a writing project in one worksp
 
 ## Work inside one folder
 
-The folder passed to `docwriter` is the workspace root. Choose a folder that contains the files for the writing project. The file tree and preview tools stay inside this folder.
+The folder passed to `docwriter` is the workspace root. Choose a folder that contains the files for the writing project. The file tree and preview tools stay inside this folder. The file tree shows that folder's name. Open **Settings**, then **Workspace**, to see the full path and the `.docwriter` state directory.
+
+If you run `docwriter ~/writing/book` from another directory, state is created at `~/writing/book/.docwriter`. The `.docwriter` folder next to your current directory is a different workspace.
 
 ## Create and organize files
 

--- a/docs/write/files-and-tabs.mdx
+++ b/docs/write/files-and-tabs.mdx
@@ -42,4 +42,4 @@ DocWriter hides large implementation folders such as `.git`, `node_modules`, `.s
 
 ## Deleted files
 
-When you delete a file in DocWriter, you also remove its comments, pending reviews, and saved AI authorship markers. Deleting a file outside DocWriter removes the matching tab after you reload.
+When you delete a file in DocWriter, you also remove its comments, pending reviews, and saved AI authorship markers. If a file is missing only for a moment, its tab stays in saved state and comes back when the file returns. If a tab disappeared while the file is still in the folder, use **Settings → Workspace → Leftover tab state** to reopen it.

--- a/docs/write/files-and-tabs.mdx
+++ b/docs/write/files-and-tabs.mdx
@@ -42,4 +42,4 @@ DocWriter hides large implementation folders such as `.git`, `node_modules`, `.s
 
 ## Deleted files
 
-When you delete a file in DocWriter, you also remove its comments, pending reviews, and saved AI authorship markers. If a file is missing only for a moment, its tab stays in saved state and comes back when the file returns. If a tab disappeared while the file is still in the folder, use **Settings → Workspace → Leftover tab state** to reopen it.
+When you delete a file in DocWriter, you also remove its comments, pending reviews, and saved AI authorship markers. If a file is missing only for a moment, its tab stays in saved state and comes back when the file returns. If a writing tab disappeared while the file is still in the folder, reload once — DocWriter puts that tab back unless you closed it on purpose. Use **Settings → Workspace → Leftover tab state** to reopen a closed tab or to forget leftover history.

--- a/docs/write/pdfs-and-other-files.mdx
+++ b/docs/write/pdfs-and-other-files.mdx
@@ -37,6 +37,6 @@ You can preview PDF, HTML, SVG, common image formats, Markdown, and plain text. 
 
 ## Large and binary files
 
-DocWriter copies imported binary data without decoding it as text, so importing a large image or PDF does not change its contents. When the agent or another tool reads a text file through DocWriter, each response is limited to 2 MB. You will see a notice when the response contains only part of the file.
+DocWriter copies imported binary data without decoding it as text, so importing a large image or PDF does not change its contents. Opening a PDF or other preview file does not store that file as a text document in saved DocWriter state. When the agent or another tool reads a text file through DocWriter, each response is limited to 2 MB. You will see a notice when the response contains only part of the file.
 
 Read [Generated previews](/customize/generated-previews) for hook output matching and live reload.

--- a/scripts/generate-feature-catalog.mjs
+++ b/scripts/generate-feature-catalog.mjs
@@ -221,7 +221,8 @@ const pageFeatures = {
 	'help/recovery': [
 		['Reference', 'Restart automatically after a server crash', C, 'CLI'],
 		['Reference', 'Recover from a server restart or WebSocket mismatch', M, 'No troubleshooting page'],
-		['Reference', 'Use the agent scratch workspace until a new session', M, 'No page']
+		['Reference', 'Use the agent scratch workspace until a new session', M, 'No page'],
+		['Workspace', 'Clear stuck pending reviews and comment threads without deleting the database', C, 'Recovery']
 	],
 	'help/privacy-and-safety': [
 		['Workspace', 'Block paths and symlinks outside the workspace', T, 'Tabs mentions the boundary without a safety page'],

--- a/scripts/generate-feature-catalog.mjs
+++ b/scripts/generate-feature-catalog.mjs
@@ -39,6 +39,7 @@ const pageFeatures = {
 		['Workspace', 'Open and restore tabs', C, 'Tabs'],
 		['Workspace', 'Rename a tab, copy its path, or delete its file', T, 'Tabs omits context menu actions'],
 		['Workspace', 'Close a tab without deleting its file', C, 'Tabs'],
+		['Workspace', 'Reopen or purge leftover tab state', C, 'Files and tabs'],
 		['Workspace', 'See a combined pending work badge on tabs', T, 'Tabs covers pending edits but not unresolved comments'],
 		['Workspace', 'Edit Markdown and other text files', C, 'Editor and Tabs'],
 		['Workspace', 'Keep .docwriter visible in the file tree', T, 'Tabs mentions obsolete state.json examples']
@@ -222,7 +223,8 @@ const pageFeatures = {
 		['Reference', 'Restart automatically after a server crash', C, 'CLI'],
 		['Reference', 'Recover from a server restart or WebSocket mismatch', M, 'No troubleshooting page'],
 		['Reference', 'Use the agent scratch workspace until a new session', M, 'No page'],
-		['Workspace', 'Clear stuck pending reviews and comment threads without deleting the database', C, 'Recovery']
+		['Workspace', 'Clear stuck pending reviews and comment threads without deleting the database', C, 'Recovery'],
+		['Workspace', 'Recover a vanished tab from leftover saved state', C, 'Recovery']
 	],
 	'help/privacy-and-safety': [
 		['Workspace', 'Block paths and symlinks outside the workspace', T, 'Tabs mentions the boundary without a safety page'],

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,8 @@
  * Handles one-shot CLI flags that are communicated via environment variables:
  *   DOCWRITER_NEW_SESSION=1   — clear the persisted SDK session ID so the
  *                               next render starts a fresh conversation.
+ *   DOCWRITER_RESET_UI=1      — clear pending reviews and comment threads
+ *                               on every tab that has saved CRDT state.
  */
 import type { Handle } from '@sveltejs/kit';
 import { randomUUID } from 'node:crypto';
@@ -13,6 +15,7 @@ import { installBundledSkills } from '$lib/server/skills-install';
 import { createWsServer } from '$lib/server/ws-server';
 import { loadGlobalKeys, loadRepoEnv } from '$lib/server/api-keys';
 import { failInterruptedStyleRun } from '$lib/server/style-analysis/interrupted-run';
+import { resetWorkspaceUiState } from '$lib/server/reset-ui-state';
 
 // Load repo .env, then ~/.docwriter/keys.env into process.env so provider API
 // keys are available before any render path reads process.env.<KEY>. The
@@ -81,6 +84,17 @@ if (process.env.DOCWRITER_NEW_SESSION === '1') {
 		}
 	} catch {
 		// Fresh workspace or early DB init failure — ignore.
+	}
+}
+
+if (process.env.DOCWRITER_RESET_UI === '1') {
+	try {
+		const result = await resetWorkspaceUiState({ reviews: true, comments: true });
+		console.log(
+			`[docwriter] --reset-ui: cleared ${result.reviewsCleared} review${result.reviewsCleared === 1 ? '' : 's'} and ${result.commentsCleared} comment thread${result.commentsCleared === 1 ? '' : 's'} across ${result.tabs.length} tab${result.tabs.length === 1 ? '' : 's'}`
+		);
+	} catch (err) {
+		console.error('[docwriter] --reset-ui failed:', err);
 	}
 }
 

--- a/src/lib/components/FileTree.svelte
+++ b/src/lib/components/FileTree.svelte
@@ -54,6 +54,8 @@
 	let treeEl: HTMLDivElement | null = $state(null);
 	let createInput: HTMLInputElement | null = $state(null);
 	let treeError = $state('');
+	let workspaceName = $state<string | null>(null);
+	let workspaceRoot = $state<string | null>(null);
 
 	async function fetchEntries(path: string): Promise<FileEntry[]> {
 		const res = await fetch(`/api/files?path=${encodeURIComponent(path)}`, {
@@ -111,7 +113,19 @@
 		return FileText;
 	}
 
-	onMount(() => void loadRoot());
+	onMount(() => {
+		void loadRoot();
+		void fetch('/api/workspace')
+			.then((res) => (res.ok ? res.json() : null))
+			.then((data) => {
+				if (!data || typeof data.name !== 'string') return;
+				workspaceName = data.name;
+				workspaceRoot = typeof data.root === 'string' ? data.root : null;
+			})
+			.catch(() => {
+				/* banner is optional */
+			});
+	});
 
 	/** Re-fetch the root list and every currently-expanded folder. Called
 	 * from the parent when something outside the FileTree (typically the
@@ -502,7 +516,12 @@
 	ondrop={onDropRoot}
 >
 	<div class="tree-header-row">
-		<div class="tree-header">Files</div>
+		<div class="tree-heading">
+			<div class="tree-header">Files</div>
+			{#if workspaceName}
+				<div class="tree-workspace" title={workspaceRoot ?? workspaceName}>{workspaceName}</div>
+			{/if}
+		</div>
 		<div class="tree-actions">
 			<button class="tree-action-btn" title="New file" onclick={() => beginCreate('file')}>
 				<FilePlus2 size={13} />
@@ -673,12 +692,27 @@
 		font-size: 13px;
 		color: var(--text);
 	}
+	.tree-heading {
+		min-width: 0;
+		flex: 1;
+	}
 	.tree-header {
 		font-size: 12px;
 		font-weight: 600;
 		color: var(--text-faint);
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
+	}
+	.tree-workspace {
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--text-muted);
+		letter-spacing: 0;
+		text-transform: none;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		margin-top: 1px;
 	}
 	.tree-header-row {
 		display: flex;

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -47,6 +47,8 @@
 
 <script lang="ts">
 	import { Check, ChevronRight } from 'lucide-svelte';
+	import { get } from 'svelte/store';
+	import { dialogQueue } from '$lib/dialogs';
 
 	interface Props {
 		menus: MenuSpec[];
@@ -124,9 +126,13 @@
 	$effect(() => {
 		if (openMenu === null) return;
 		function onDown(e: MouseEvent) {
+			// A confirm dialog is rendered at document root. Clicks on it
+			// must not dismiss the Settings panel that opened it.
+			if (get(dialogQueue).length > 0) return;
 			if (menuBarEl && !menuBarEl.contains(e.target as Node)) closeAll();
 		}
 		function onKey(e: KeyboardEvent) {
+			if (get(dialogQueue).length > 0) return;
 			if (e.key === 'Escape') closeAll();
 		}
 		document.addEventListener('mousedown', onDown);

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -9,10 +9,21 @@
 		yjsUpdate: string | null;
 	}
 
+	interface LeftoverTab {
+		tabId: string;
+		kind: 'closed' | 'missing';
+		hasUpdates: boolean;
+		hasLastSeen: boolean;
+		listed: boolean;
+		updateCount: number;
+		lastActivity: number | null;
+	}
+
 	interface Props {
 		onApplied?: (tabs: TabResetResult[]) => void;
+		onTabsChanged?: () => void | Promise<void>;
 	}
-	let { onApplied }: Props = $props();
+	let { onApplied, onTabsChanged }: Props = $props();
 
 	interface WorkspaceInfo {
 		root: string;
@@ -20,18 +31,22 @@
 		name: string;
 		cwd: string;
 		warning: string | null;
+		leftovers?: LeftoverTab[];
 	}
 
 	let info = $state<WorkspaceInfo | null>(null);
+	let leftovers = $state<LeftoverTab[]>([]);
 	let error = $state<string | null>(null);
 	let status = $state<string | null>(null);
-	let busy = $state<'reviews' | 'comments' | 'both' | null>(null);
+	let busy = $state<'reviews' | 'comments' | 'both' | string | null>(null);
 
 	async function load() {
 		try {
 			const res = await fetch('/api/workspace');
 			if (!res.ok) throw new Error(`Failed to load workspace (${res.status})`);
-			info = (await res.json()) as WorkspaceInfo;
+			const data = (await res.json()) as WorkspaceInfo;
+			info = data;
+			leftovers = data.leftovers ?? [];
 			error = null;
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
@@ -93,6 +108,56 @@
 		} finally {
 			busy = null;
 		}
+	}
+
+	async function leftoverAction(kind: 'reopen_tab' | 'purge_tab', tabId: string) {
+		if (kind === 'purge_tab') {
+			const ok = await showConfirm(
+				`Remove leftover DocWriter state for "${tabId}"? The workspace file stays if it is still on disk. Comments, pending reviews, and the CRDT history for this path are deleted.`,
+				{ title: 'Purge leftover tab', confirmLabel: 'Purge', danger: true }
+			);
+			if (!ok) return;
+		}
+		busy = `${kind}:${tabId}`;
+		error = null;
+		status = null;
+		try {
+			const res = await fetch('/api/workspace', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ action: kind, tabId })
+			});
+			const data = (await res.json().catch(() => ({}))) as {
+				ok?: boolean;
+				error?: string;
+				leftovers?: LeftoverTab[];
+			};
+			if (!res.ok || !data.ok) {
+				throw new Error(data.error || `Request failed (${res.status})`);
+			}
+			leftovers = data.leftovers ?? [];
+			await onTabsChanged?.();
+			status =
+				kind === 'reopen_tab'
+					? `Reopened ${tabId}.`
+					: `Purged leftover state for ${tabId}.`;
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			busy = null;
+		}
+	}
+
+	function leftoverHint(item: LeftoverTab): string {
+		const updates =
+			item.updateCount === 1 ? '1 saved update' : `${item.updateCount} saved updates`;
+		if (item.kind === 'closed') {
+			return `File is still on disk. ${updates}.`;
+		}
+		if (item.listed) {
+			return `Listed as a tab, but the file is missing. ${updates}.`;
+		}
+		return `Not in the tab list and the file is missing. ${updates}.`;
 	}
 </script>
 
@@ -179,10 +244,83 @@
 				</button>
 			</div>
 		</div>
+
+		<div class="settings-section">
+			<div class="setting-label">Leftover tab state</div>
+			<div class="setting-hint">
+				Closing a tab keeps its edit history so you can reopen it. If a
+				tab disappeared from the list while the file is still here —
+				often after a rename or a brief missing-file race — reopen it
+				from this list. Purge only when you want to forget that
+				history.
+			</div>
+			{#if leftovers.length === 0}
+				<div class="muted">No leftover tab state.</div>
+			{:else}
+				<ul class="leftover-list">
+					{#each leftovers as item (item.tabId)}
+						<li class="leftover">
+							<div class="leftover-path" title={item.tabId}>{item.tabId}</div>
+							<div class="leftover-meta">{leftoverHint(item)}</div>
+							<div class="leftover-actions">
+								{#if item.kind === 'closed'}
+									<button
+										class="btn"
+										type="button"
+										disabled={busy !== null}
+										onclick={() => void leftoverAction('reopen_tab', item.tabId)}
+									>
+										{busy === `reopen_tab:${item.tabId}` ? 'Opening…' : 'Reopen'}
+									</button>
+								{/if}
+								<button
+									class="btn danger"
+									type="button"
+									disabled={busy !== null}
+									onclick={() => void leftoverAction('purge_tab', item.tabId)}
+								>
+									{busy === `purge_tab:${item.tabId}` ? 'Purging…' : 'Purge'}
+								</button>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
 	{/if}
 </div>
 
 <style>
+	.leftover-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.leftover {
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		padding: 8px;
+		background: var(--bg-surface);
+	}
+	.leftover-path {
+		font-family: ui-monospace, monospace;
+		font-size: 11.5px;
+		word-break: break-all;
+		margin-bottom: 3px;
+	}
+	.leftover-meta {
+		font-size: 11.5px;
+		color: var(--text-muted);
+		line-height: 1.4;
+		margin-bottom: 6px;
+	}
+	.leftover-actions {
+		display: flex;
+		gap: 6px;
+	}
 	.settings-panel {
 		width: 360px;
 		max-width: calc(100vw - 32px);

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -1,0 +1,313 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { showConfirm } from '$lib/dialogs';
+
+	interface TabResetResult {
+		tabId: string;
+		reviewsCleared: number;
+		commentsCleared: number;
+		yjsUpdate: string | null;
+	}
+
+	interface Props {
+		onApplied?: (tabs: TabResetResult[]) => void;
+	}
+	let { onApplied }: Props = $props();
+
+	interface WorkspaceInfo {
+		root: string;
+		stateDir: string;
+		name: string;
+		cwd: string;
+		warning: string | null;
+	}
+
+	let info = $state<WorkspaceInfo | null>(null);
+	let error = $state<string | null>(null);
+	let status = $state<string | null>(null);
+	let busy = $state<'reviews' | 'comments' | 'both' | null>(null);
+
+	async function load() {
+		try {
+			const res = await fetch('/api/workspace');
+			if (!res.ok) throw new Error(`Failed to load workspace (${res.status})`);
+			info = (await res.json()) as WorkspaceInfo;
+			error = null;
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	onMount(() => {
+		void load();
+	});
+
+	async function resetUi(
+		kind: 'reviews' | 'comments' | 'both',
+		confirm: { title: string; message: string }
+	) {
+		const ok = await showConfirm(confirm.message, {
+			title: confirm.title,
+			confirmLabel: 'Clear',
+			danger: true
+		});
+		if (!ok) return;
+		busy = kind;
+		error = null;
+		status = null;
+		try {
+			const res = await fetch('/api/workspace', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					action: 'reset_ui',
+					reviews: kind === 'reviews' || kind === 'both',
+					comments: kind === 'comments' || kind === 'both'
+				})
+			});
+			const data = (await res.json().catch(() => ({}))) as {
+				ok?: boolean;
+				error?: string;
+				reviewsCleared?: number;
+				commentsCleared?: number;
+				tabs?: TabResetResult[];
+			};
+			if (!res.ok || !data.ok) {
+				throw new Error(data.error || `Reset failed (${res.status})`);
+			}
+			onApplied?.(data.tabs ?? []);
+			const parts: string[] = [];
+			if (kind === 'reviews' || kind === 'both') {
+				parts.push(
+					`${data.reviewsCleared ?? 0} pending review${(data.reviewsCleared ?? 0) === 1 ? '' : 's'}`
+				);
+			}
+			if (kind === 'comments' || kind === 'both') {
+				parts.push(
+					`${data.commentsCleared ?? 0} comment thread${(data.commentsCleared ?? 0) === 1 ? '' : 's'}`
+				);
+			}
+			status = `Cleared ${parts.join(' and ')}. Workspace files are unchanged.`;
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			busy = null;
+		}
+	}
+</script>
+
+<div class="settings-panel" role="dialog">
+	<div class="settings-header">
+		<span class="settings-title">Workspace</span>
+	</div>
+
+	{#if error}
+		<div class="error">{error}</div>
+	{/if}
+
+	{#if !info}
+		<div class="muted">Loading…</div>
+	{:else}
+		<div class="intro">
+			DocWriter state for this folder lives in <code>.docwriter</code>, not in the
+			directory you ran the command from (unless they are the same).
+		</div>
+
+		<div class="field">
+			<div class="field-label">Opened folder</div>
+			<div class="field-value" title={info.root}>{info.root}</div>
+		</div>
+		<div class="field">
+			<div class="field-label">State directory</div>
+			<div class="field-value" title={info.stateDir}>{info.stateDir}</div>
+		</div>
+
+		{#if info.warning}
+			<div class="warning">{info.warning}</div>
+		{/if}
+
+		{#if status}
+			<div class="status">{status}</div>
+		{/if}
+
+		<div class="settings-section">
+			<div class="setting-label">Reset review UI</div>
+			<div class="setting-hint">
+				Clear stuck pending reviews or comment threads without deleting the
+				database or your files. Use this when Accept, Reject, or Dismiss no
+				longer works. New session does not remove comment threads.
+			</div>
+			<div class="actions">
+				<button
+					class="btn"
+					type="button"
+					disabled={busy !== null}
+					onclick={() =>
+						void resetUi('reviews', {
+							title: 'Clear pending reviews',
+							message:
+								'Remove every pending agent edit in this workspace. Document text, comments, rules, and settings stay. You cannot recover a cleared proposal unless you undo immediately.'
+						})}
+				>
+					{busy === 'reviews' ? 'Clearing…' : 'Clear pending reviews'}
+				</button>
+				<button
+					class="btn"
+					type="button"
+					disabled={busy !== null}
+					onclick={() =>
+						void resetUi('comments', {
+							title: 'Clear comment threads',
+							message:
+								'Remove every comment thread in this workspace. Document text, pending reviews, rules, and settings stay. This cannot be undone after later edits replace undo history.'
+						})}
+				>
+					{busy === 'comments' ? 'Clearing…' : 'Clear comment threads'}
+				</button>
+				<button
+					class="btn danger"
+					type="button"
+					disabled={busy !== null}
+					onclick={() =>
+						void resetUi('both', {
+							title: 'Reset review UI',
+							message:
+								'Remove every pending review and comment thread in this workspace. Document text, rules, hooks, and settings stay. This is the recovery step when gutter cards will not accept or dismiss.'
+						})}
+				>
+					{busy === 'both' ? 'Resetting…' : 'Reset review UI'}
+				</button>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.settings-panel {
+		width: 360px;
+		max-width: calc(100vw - 32px);
+		box-sizing: border-box;
+		padding: 14px 16px 16px;
+		font-family: 'Inter', -apple-system, sans-serif;
+		font-size: 13px;
+		color: var(--text);
+	}
+	.settings-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 10px;
+	}
+	.settings-title {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+	.intro,
+	.setting-hint {
+		font-size: 12px;
+		color: var(--text-muted);
+		line-height: 1.5;
+		margin-bottom: 12px;
+		word-break: break-word;
+		overflow-wrap: anywhere;
+	}
+	.intro code {
+		font-family: ui-monospace, monospace;
+		font-size: 11px;
+		background: var(--bg-surface);
+		padding: 1px 4px;
+		border-radius: 4px;
+	}
+	.field {
+		margin-bottom: 10px;
+	}
+	.field-label {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		margin-bottom: 2px;
+	}
+	.field-value {
+		font-family: ui-monospace, monospace;
+		font-size: 11.5px;
+		line-height: 1.45;
+		word-break: break-all;
+		color: var(--text);
+	}
+	.warning,
+	.error,
+	.status {
+		font-size: 12px;
+		line-height: 1.45;
+		border-radius: 6px;
+		padding: 7px 8px;
+		margin-bottom: 12px;
+		word-break: break-word;
+		overflow-wrap: anywhere;
+	}
+	.warning {
+		color: #92400e;
+		background: #fffbeb;
+		border: 1px solid #fde68a;
+	}
+	.error {
+		color: #b91c1c;
+		background: #fef2f2;
+	}
+	.status {
+		color: #166534;
+		background: #f0fdf4;
+	}
+	.muted {
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+	.settings-section {
+		margin-top: 14px;
+		padding-top: 12px;
+		border-top: 1px solid var(--border-light);
+	}
+	.setting-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text);
+		margin-bottom: 4px;
+	}
+	.actions {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.btn {
+		border: 1px solid var(--border-light);
+		background: var(--bg-surface);
+		color: var(--text);
+		font: inherit;
+		font-size: 12.5px;
+		font-weight: 500;
+		padding: 7px 10px;
+		border-radius: 6px;
+		cursor: pointer;
+		text-align: left;
+	}
+	.btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+	}
+	.btn:disabled {
+		opacity: 0.55;
+		cursor: default;
+	}
+	.btn.danger {
+		color: #b91c1c;
+		border-color: #fecaca;
+		background: #fef2f2;
+	}
+	.btn.danger:hover:not(:disabled) {
+		background: #fee2e2;
+	}
+</style>

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -15,6 +15,7 @@
 		hasUpdates: boolean;
 		hasLastSeen: boolean;
 		listed: boolean;
+		intentionallyClosed: boolean;
 		updateCount: number;
 		lastActivity: number | null;
 	}
@@ -151,11 +152,11 @@
 	function leftoverHint(item: LeftoverTab): string {
 		const updates =
 			item.updateCount === 1 ? '1 saved update' : `${item.updateCount} saved updates`;
-		if (item.kind === 'closed') {
-			return `File is still on disk. ${updates}.`;
+		if (item.kind === 'closed' && item.intentionallyClosed) {
+			return `You closed this tab. ${updates}.`;
 		}
-		if (item.listed) {
-			return `Listed as a tab, but the file is missing. ${updates}.`;
+		if (item.kind === 'closed') {
+			return `Dropped from the tab list; the file is still here. ${updates}.`;
 		}
 		return `Not in the tab list and the file is missing. ${updates}.`;
 	}
@@ -248,11 +249,10 @@
 		<div class="settings-section">
 			<div class="setting-label">Leftover tab state</div>
 			<div class="setting-hint">
-				Closing a tab keeps its edit history so you can reopen it. If a
-				tab disappeared from the list while the file is still here —
-				often after a rename or a brief missing-file race — reopen it
-				from this list. Purge only when you want to forget that
-				history.
+				A dropped writing tab is put back automatically when you reload.
+				This list is for tabs you closed on purpose, preview files with
+				leftover history, or paths whose files are gone. Reopen keeps
+				the history. Purge forgets it.
 			</div>
 			{#if leftovers.length === 0}
 				<div class="muted">No leftover tab state.</div>

--- a/src/lib/editor/TiptapEditor.svelte
+++ b/src/lib/editor/TiptapEditor.svelte
@@ -649,7 +649,8 @@
 		const relSnapshot = snapshotFeedbackRelPositions();
 		trackActionUsage(action.label);
 		if (!action.pinned) {
-			recentActions.update((prev) => [action, ...prev.filter((x) => x.id !== action.id)].slice(0, 6));
+			const used = { ...action, usedAt: Date.now() };
+			recentActions.update((prev) => [used, ...prev.filter((x) => x.id !== used.id)].slice(0, 6));
 		}
 		closeFeedbackPopup();
 		// Restore the mode for the trigger build — closeFeedbackPopup reset
@@ -679,7 +680,8 @@
 			label: fb,
 			icon: 'message-square',
 			pinned: false,
-			color: '#7c3aed'
+			color: '#7c3aed',
+			usedAt: Date.now()
 		};
 		trackActionUsage(customAction.label);
 		recentActions.update((prev) => [customAction, ...prev.filter((x) => x.label !== customAction.label)].slice(0, 6));

--- a/src/lib/server/closed-tabs.ts
+++ b/src/lib/server/closed-tabs.ts
@@ -1,0 +1,38 @@
+/**
+ * Intentional tab closes, persisted so leftover CRDT history is not
+ * treated as an accidental drop from the `tabs` table.
+ */
+import { kvGet, kvSet } from './db-writes';
+import { isValidTabId } from './document-files';
+
+const KEY = 'closedTabs';
+
+export function getClosedTabIds(): string[] {
+	const raw = kvGet(KEY);
+	if (!raw) return [];
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((id): id is string => typeof id === 'string' && isValidTabId(id));
+	} catch {
+		return [];
+	}
+}
+
+function writeClosedTabIds(ids: Iterable<string>): void {
+	kvSet(KEY, JSON.stringify([...new Set(ids)].sort()));
+}
+
+export function markTabClosed(tabId: string): void {
+	if (!isValidTabId(tabId)) return;
+	writeClosedTabIds([...getClosedTabIds(), tabId]);
+}
+
+export function markTabOpened(tabId: string): void {
+	writeClosedTabIds(getClosedTabIds().filter((id) => id !== tabId));
+}
+
+export function renameClosedTab(fromId: string, toId: string): void {
+	if (fromId === toId) return;
+	writeClosedTabIds(getClosedTabIds().map((id) => (id === fromId ? toId : id)));
+}

--- a/src/lib/server/db-writes.ts
+++ b/src/lib/server/db-writes.ts
@@ -211,7 +211,7 @@ export function dbClearSessionState() {
 }
 
 export function dbReplaceRecentActions(
-	actions: Array<{ label: string }> | undefined
+	actions: Array<{ label: string; usedAt?: number }> | undefined
 ) {
 	try {
 		const db = getDb();
@@ -222,7 +222,11 @@ export function dbReplaceRecentActions(
 			const insert = db.prepare(
 				'INSERT INTO recent_actions (label, used_at) VALUES (?, ?)'
 			);
-			for (const a of actions) insert.run(a.label, now);
+			for (const a of actions) {
+				const usedAt =
+					typeof a.usedAt === 'number' && Number.isFinite(a.usedAt) ? a.usedAt : now;
+				insert.run(a.label, usedAt);
+			}
 		})();
 	} catch (err) {
 		logDbError('replaceRecentActions', err);
@@ -279,6 +283,23 @@ export function kvDelete(key: string) {
 	} catch (err) {
 		logDbError('kvDelete:' + key, err);
 	}
+}
+
+/** Keys in `kv` that start with `prefix`, in key order. */
+export function kvKeysWithPrefix(prefix: string): string[] {
+	try {
+		const rows = getDb()
+			.prepare(`SELECT key FROM kv WHERE key LIKE ? ESCAPE '\\' ORDER BY key`)
+			.all(escapeLikePrefix(prefix) + '%') as Array<{ key: string }>;
+		return rows.map((row) => row.key);
+	} catch (err) {
+		logDbError('kvKeysWithPrefix:' + prefix, err);
+		return [];
+	}
+}
+
+function escapeLikePrefix(prefix: string): string {
+	return prefix.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 }
 
 export function dbAppendConversationEvent(

--- a/src/lib/server/document-files.ts
+++ b/src/lib/server/document-files.ts
@@ -85,7 +85,14 @@ const TEXT_EXTENSIONS = new Set([
 	'conf',
 	'gitignore',
 	'gitattributes',
-	'rst'
+	'rst',
+	'tex',
+	'ltx',
+	'latex',
+	'bib',
+	'bibtex',
+	'sty',
+	'cls'
 ]);
 
 /** A tab id is a workspace-relative path (e.g. "drafts/chapter-1.md" or

--- a/src/lib/server/last-seen.ts
+++ b/src/lib/server/last-seen.ts
@@ -1,12 +1,31 @@
 import * as Y from 'yjs';
-import { kvSet } from './db-writes';
+import { kvDelete, kvGet, kvKeysWithPrefix, kvSet } from './db-writes';
 import { materializePendingReviewText } from '$lib/review-rounds';
 import { serializeYDoc, readReviewRounds } from '$lib/shared/ydoc-codec';
 
-const LAST_SEEN_PREFIX = 'last_seen:';
+export const LAST_SEEN_PREFIX = 'last_seen:';
 
 export function lastSeenKey(tabId: string): string {
 	return LAST_SEEN_PREFIX + tabId;
+}
+
+export function listLastSeenTabIds(): string[] {
+	return kvKeysWithPrefix(LAST_SEEN_PREFIX).map((key) => key.slice(LAST_SEEN_PREFIX.length));
+}
+
+export function deleteLastSeen(tabId: string): void {
+	kvDelete(lastSeenKey(tabId));
+}
+
+export function migrateLastSeen(fromId: string, toId: string): void {
+	if (fromId === toId) return;
+	const value = kvGet(lastSeenKey(fromId));
+	if (value !== null) {
+		kvSet(lastSeenKey(toId), value);
+		kvDelete(lastSeenKey(fromId));
+		return;
+	}
+	kvDelete(lastSeenKey(fromId));
 }
 
 /** Agent-facing markdown for a tab: committed Y.Doc text plus any pending

--- a/src/lib/server/leftover-tabs.ts
+++ b/src/lib/server/leftover-tabs.ts
@@ -5,21 +5,25 @@
  * migrate) leave the same leftovers — surface them for reopen / purge.
  */
 import { existsSync } from 'fs';
-import { classifyGhostTabs, type GhostTab } from '$lib/shared/tab-reconcile';
+import { classifyGhostTabs, tabsToAutoRestore, type GhostTab } from '$lib/shared/tab-reconcile';
+import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import { isValidTabId, tabFile } from './document-files';
 import { getTabsState, setTabsState } from './runtime-state';
+import { getClosedTabIds, markTabOpened } from './closed-tabs';
 import { listLastSeenTabIds } from './last-seen';
 import { listYjsTabIds, yjsTabStats } from './ydoc-persistence';
 import { destroyTabState } from './ws-server';
 
 export interface LeftoverTab extends GhostTab {
 	listed: boolean;
+	intentionallyClosed: boolean;
 	updateCount: number;
 	lastActivity: number | null;
 }
 
 export function listLeftoverTabs(): LeftoverTab[] {
 	const stored = getTabsState();
+	const closed = new Set(getClosedTabIds());
 	const ghosts = classifyGhostTabs({
 		openTabIds: stored.order,
 		yjsTabIds: listYjsTabIds(),
@@ -32,11 +36,30 @@ export function listLeftoverTabs(): LeftoverTab[] {
 			return {
 				...ghost,
 				listed: false,
+				intentionallyClosed: closed.has(ghost.tabId),
 				updateCount: stats.updateCount,
 				lastActivity: stats.lastActivity
 			};
 		})
 		.sort((a, b) => a.tabId.localeCompare(b.tabId));
+}
+
+/** Put dropped text tabs back in `tabs` when the file is still on disk
+ * and the user never recorded a close. Does not change the active tab. */
+export function healOrphanedTabs(): string[] {
+	const stored = getTabsState();
+	const restore = tabsToAutoRestore({
+		leftovers: listLeftoverTabs(),
+		intentionallyClosed: getClosedTabIds(),
+		shouldSkip: isBinaryOrPreviewPath
+	});
+	if (restore.length === 0) return [];
+	const order = [...stored.order];
+	for (const id of restore) {
+		if (!order.includes(id)) order.push(id);
+	}
+	setTabsState({ order, active: stored.active });
+	return restore;
 }
 
 export function reopenLeftoverTab(tabId: string): { order: string[]; active: string | null } {
@@ -50,6 +73,7 @@ export function reopenLeftoverTab(tabId: string): { order: string[]; active: str
 	if (!state.order.includes(tabId)) state.order.push(tabId);
 	state.active = tabId;
 	setTabsState(state);
+	markTabOpened(tabId);
 	return state;
 }
 
@@ -58,6 +82,7 @@ export async function purgeLeftoverTab(tabId: string): Promise<{ order: string[]
 		throw new Error('Invalid tab id');
 	}
 	await destroyTabState(tabId);
+	markTabOpened(tabId);
 	const stored = getTabsState();
 	const order = stored.order.filter((id) => id !== tabId);
 	let active = stored.active === tabId ? null : stored.active;

--- a/src/lib/server/leftover-tabs.ts
+++ b/src/lib/server/leftover-tabs.ts
@@ -1,0 +1,68 @@
+/**
+ * Tabs that still have CRDT / last_seen state but are not currently
+ * visible. Close is supposed to leave this data so reopen is cheap.
+ * Accidental drops from the `tabs` table (or a rename that did not
+ * migrate) leave the same leftovers — surface them for reopen / purge.
+ */
+import { existsSync } from 'fs';
+import { classifyGhostTabs, type GhostTab } from '$lib/shared/tab-reconcile';
+import { isValidTabId, tabFile } from './document-files';
+import { getTabsState, setTabsState } from './runtime-state';
+import { listLastSeenTabIds } from './last-seen';
+import { listYjsTabIds, yjsTabStats } from './ydoc-persistence';
+import { destroyTabState } from './ws-server';
+
+export interface LeftoverTab extends GhostTab {
+	listed: boolean;
+	updateCount: number;
+	lastActivity: number | null;
+}
+
+export function listLeftoverTabs(): LeftoverTab[] {
+	const stored = getTabsState();
+	const ghosts = classifyGhostTabs({
+		openTabIds: stored.order,
+		yjsTabIds: listYjsTabIds(),
+		lastSeenTabIds: listLastSeenTabIds(),
+		fileExists: (id) => existsSync(tabFile(id))
+	});
+	return ghosts
+		.map((ghost) => {
+			const stats = yjsTabStats(ghost.tabId);
+			return {
+				...ghost,
+				listed: false,
+				updateCount: stats.updateCount,
+				lastActivity: stats.lastActivity
+			};
+		})
+		.sort((a, b) => a.tabId.localeCompare(b.tabId));
+}
+
+export function reopenLeftoverTab(tabId: string): { order: string[]; active: string | null } {
+	if (!isValidTabId(tabId)) {
+		throw new Error('Invalid tab id');
+	}
+	if (!existsSync(tabFile(tabId))) {
+		throw new Error(`File "${tabId}" is not on disk`);
+	}
+	const state = getTabsState();
+	if (!state.order.includes(tabId)) state.order.push(tabId);
+	state.active = tabId;
+	setTabsState(state);
+	return state;
+}
+
+export async function purgeLeftoverTab(tabId: string): Promise<{ order: string[]; active: string | null }> {
+	if (!isValidTabId(tabId)) {
+		throw new Error('Invalid tab id');
+	}
+	await destroyTabState(tabId);
+	const stored = getTabsState();
+	const order = stored.order.filter((id) => id !== tabId);
+	let active = stored.active === tabId ? null : stored.active;
+	if (!active && order.length > 0) active = order[0];
+	const next = { order, active };
+	setTabsState(next);
+	return next;
+}

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -57,6 +57,7 @@ import { isValidTabId, tabFile, WORKSPACE_ROOT } from './document-files';
 import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import { resolveWorkspacePath } from './workspace-path';
 import { getRules, getTabsState, setTabsState } from './runtime-state';
+import { markTabOpened } from './closed-tabs';
 import { writeTextAtomic } from './file-utils';
 import { findOverlappingFreeze, freezeQuoteFromRule } from '$lib/freeze';
 
@@ -622,6 +623,7 @@ export function ensureWorkspaceTabOpen(
 		// and the user opens it when they're ready.
 		setTabsState(state);
 	}
+	markTabOpened(tabId);
 
 	return { ok: true, tabId, existedOnDisk: fileExists };
 }

--- a/src/lib/server/mcp-doc-tools.ts
+++ b/src/lib/server/mcp-doc-tools.ts
@@ -54,6 +54,7 @@ import type {
 } from '$lib/types';
 import { formatListedThreads } from '$lib/shared/list-threads';
 import { isValidTabId, tabFile, WORKSPACE_ROOT } from './document-files';
+import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import { resolveWorkspacePath } from './workspace-path';
 import { getRules, getTabsState, setTabsState } from './runtime-state';
 import { writeTextAtomic } from './file-utils';
@@ -547,6 +548,14 @@ export function ensureWorkspaceTabOpen(
 ): EnsureTabResult {
 	const existingTabId = resolveTabFromPath(path);
 	if (existingTabId && isOpenTab(existingTabId)) {
+		if (isBinaryOrPreviewPath(existingTabId)) {
+			return {
+				ok: false,
+				error: toolError(
+					`${path} is a preview or binary file. Open it in the PDF or image viewer; do not edit it with write_doc or edit_doc.`
+				)
+			};
+		}
 		return {
 			ok: true,
 			tabId: existingTabId,
@@ -560,6 +569,14 @@ export function ensureWorkspaceTabOpen(
 			ok: false,
 			error: toolError(
 				`${path} is not a valid workspace-relative path. Use a path inside the workspace (e.g. "drafts/chapter-1.md") or under .docwriter/agent/scratch/.`
+			)
+		};
+	}
+	if (isBinaryOrPreviewPath(tabId)) {
+		return {
+			ok: false,
+			error: toolError(
+				`${path} is a preview or binary file. Open it in the PDF or image viewer; do not edit it with write_doc or edit_doc.`
 			)
 		};
 	}

--- a/src/lib/server/reset-ui-state.ts
+++ b/src/lib/server/reset-ui-state.ts
@@ -1,0 +1,56 @@
+/**
+ * Reset pending reviews and/or comment threads across workspace tabs.
+ *
+ * Uses the live Hocuspocus document when the WS server is up so connected
+ * browsers receive the same Yjs update. Falls back to a throwaway replay
+ * via `withLiveDoc` (startup / `--reset-ui` before any client connects).
+ */
+import * as Y from 'yjs';
+import { applyUiReset, type UiResetOptions, type UiResetResult } from '$lib/shared/reset-ui-state';
+import { listPersistedTabIds } from './ydoc-persistence';
+import { getTabsState } from './runtime-state';
+import { withLiveDoc } from './ws-server';
+
+export interface TabUiResetResult extends UiResetResult {
+	tabId: string;
+	yjsUpdate: string | null;
+}
+
+export interface WorkspaceUiResetResult {
+	tabs: TabUiResetResult[];
+	reviewsCleared: number;
+	commentsCleared: number;
+}
+
+export async function resetTabUiState(
+	tabId: string,
+	options: UiResetOptions = {}
+): Promise<TabUiResetResult> {
+	return withLiveDoc(tabId, (ydoc) => {
+		const before = Y.encodeStateVector(ydoc);
+		const cleared = applyUiReset(ydoc, options);
+		if (cleared.reviewsCleared === 0 && cleared.commentsCleared === 0) {
+			return { tabId, yjsUpdate: null, ...cleared };
+		}
+		const yjsUpdate = Buffer.from(Y.encodeStateAsUpdate(ydoc, before)).toString('base64');
+		return { tabId, yjsUpdate, ...cleared };
+	});
+}
+
+export async function resetWorkspaceUiState(
+	options: UiResetOptions & { tabId?: string } = {}
+): Promise<WorkspaceUiResetResult> {
+	const tabIds = options.tabId
+		? [options.tabId]
+		: [...new Set([...listPersistedTabIds(), ...getTabsState().order])].sort();
+	const tabs: TabUiResetResult[] = [];
+	let reviewsCleared = 0;
+	let commentsCleared = 0;
+	for (const tabId of tabIds) {
+		const result = await resetTabUiState(tabId, options);
+		tabs.push(result);
+		reviewsCleared += result.reviewsCleared;
+		commentsCleared += result.commentsCleared;
+	}
+	return { tabs, reviewsCleared, commentsCleared };
+}

--- a/src/lib/server/reset-ui-state.ts
+++ b/src/lib/server/reset-ui-state.ts
@@ -7,6 +7,7 @@
  */
 import * as Y from 'yjs';
 import { applyUiReset, type UiResetOptions, type UiResetResult } from '$lib/shared/reset-ui-state';
+import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import { listPersistedTabIds } from './ydoc-persistence';
 import { getTabsState } from './runtime-state';
 import { withLiveDoc } from './ws-server';
@@ -42,11 +43,14 @@ export async function resetWorkspaceUiState(
 ): Promise<WorkspaceUiResetResult> {
 	const tabIds = options.tabId
 		? [options.tabId]
-		: [...new Set([...listPersistedTabIds(), ...getTabsState().order])].sort();
+		: [...new Set([...listPersistedTabIds(), ...getTabsState().order])]
+				.filter((id) => !isBinaryOrPreviewPath(id))
+				.sort();
 	const tabs: TabUiResetResult[] = [];
 	let reviewsCleared = 0;
 	let commentsCleared = 0;
 	for (const tabId of tabIds) {
+		if (isBinaryOrPreviewPath(tabId)) continue;
 		const result = await resetTabUiState(tabId, options);
 		tabs.push(result);
 		reviewsCleared += result.reviewsCleared;

--- a/src/lib/server/runtime-state.ts
+++ b/src/lib/server/runtime-state.ts
@@ -109,21 +109,23 @@ export function getRecentActions(): Array<{
 	icon: string;
 	pinned: boolean;
 	color: string;
+	usedAt: number;
 }> {
 	const rows = getDb()
-		.prepare('SELECT rowid, label FROM recent_actions ORDER BY rowid ASC')
-		.all() as Array<{ rowid: number; label: string }>;
+		.prepare('SELECT rowid, label, used_at FROM recent_actions ORDER BY rowid ASC')
+		.all() as Array<{ rowid: number; label: string; used_at: number }>;
 	return rows.map((row) => ({
 		id: `custom_${row.rowid}`,
 		label: row.label,
 		icon: 'message-square',
 		pinned: false,
-		color: '#7c3aed'
+		color: '#7c3aed',
+		usedAt: row.used_at
 	}));
 }
 
 export function setRecentActions(
-	actions: Array<{ label: string }> | undefined
+	actions: Array<{ label: string; usedAt?: number }> | undefined
 ) {
 	dbReplaceRecentActions(actions);
 }

--- a/src/lib/server/tab-rename.ts
+++ b/src/lib/server/tab-rename.ts
@@ -1,0 +1,36 @@
+/**
+ * Keep SQLite + in-memory tab identity aligned after a file rename.
+ */
+import { listYjsTabIds, renameTabUpdates } from './ydoc-persistence';
+import { listLastSeenTabIds, migrateLastSeen } from './last-seen';
+import { getTabsState, setTabsState } from './runtime-state';
+import { unloadTabDocument } from './ws-server';
+
+export async function migrateRenamedTab(fromId: string, toId: string): Promise<void> {
+	if (fromId === toId) return;
+	renameTabUpdates(fromId, toId);
+	migrateLastSeen(fromId, toId);
+	await unloadTabDocument(fromId);
+}
+
+/** After a file-tree rename or folder move, remaps every tab id (open or
+ * leftover) that lived at or under `fromPath`. */
+export async function migrateTabsUnderPath(fromPath: string, toPath: string): Promise<void> {
+	if (!fromPath || fromPath === toPath) return;
+	const prefix = `${fromPath}/`;
+	const known = new Set([...getTabsState().order, ...listYjsTabIds(), ...listLastSeenTabIds()]);
+	const remaps: Array<[string, string]> = [];
+	for (const id of known) {
+		if (id === fromPath) remaps.push([id, toPath]);
+		else if (id.startsWith(prefix)) remaps.push([id, `${toPath}${id.slice(fromPath.length)}`]);
+	}
+	for (const [fromId, toId] of remaps) {
+		await migrateRenamedTab(fromId, toId);
+	}
+	if (remaps.length === 0) return;
+	const mapped = new Map(remaps);
+	const state = getTabsState();
+	state.order = [...new Set(state.order.map((id) => mapped.get(id) ?? id))];
+	if (state.active && mapped.has(state.active)) state.active = mapped.get(state.active) ?? state.active;
+	setTabsState(state);
+}

--- a/src/lib/server/tab-rename.ts
+++ b/src/lib/server/tab-rename.ts
@@ -5,11 +5,13 @@ import { listYjsTabIds, renameTabUpdates } from './ydoc-persistence';
 import { listLastSeenTabIds, migrateLastSeen } from './last-seen';
 import { getTabsState, setTabsState } from './runtime-state';
 import { unloadTabDocument } from './ws-server';
+import { renameClosedTab } from './closed-tabs';
 
 export async function migrateRenamedTab(fromId: string, toId: string): Promise<void> {
 	if (fromId === toId) return;
 	renameTabUpdates(fromId, toId);
 	migrateLastSeen(fromId, toId);
+	renameClosedTab(fromId, toId);
 	await unloadTabDocument(fromId);
 }
 

--- a/src/lib/server/workspace-identity.ts
+++ b/src/lib/server/workspace-identity.ts
@@ -1,0 +1,40 @@
+/**
+ * Live workspace identity for this process. Uses DOCWRITER_ROOT / cwd the
+ * same way document-files.ts does, plus a cwd-conflict check so the UI
+ * can explain a "empty SQLite" mix-up.
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+	describeWorkspace,
+	findConflictingStateDir,
+	formatConflictWarning,
+	type WorkspaceConflict,
+	type WorkspaceIdentity
+} from '$lib/shared/workspace-identity';
+import { WORKSPACE_ROOT } from './document-files';
+
+export interface WorkspaceInfo extends WorkspaceIdentity {
+	cwd: string;
+	conflict: WorkspaceConflict | null;
+	warning: string | null;
+}
+
+export function getWorkspaceInfo(): WorkspaceInfo {
+	const identity = describeWorkspace(WORKSPACE_ROOT);
+	// The HTTP server's process.cwd() is the install / package root. The
+	// CLI forwards the directory the user invoked from so this warning
+	// matches the folder they are looking at in the terminal.
+	const cwd = resolve(process.env.DOCWRITER_INVOKE_CWD || process.cwd());
+	const conflict = findConflictingStateDir({
+		root: identity.root,
+		cwd,
+		cwdHasState: existsSync(describeWorkspace(cwd).stateDir)
+	});
+	return {
+		...identity,
+		cwd,
+		conflict,
+		warning: conflict ? formatConflictWarning(identity, conflict) : null
+	};
+}

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -123,7 +123,7 @@ export function flushTabMarkdownNow(tabId: string) {
 /** Run a write-transaction against the live Hocuspocus Document. Falls back
  * to a throwaway Y.Doc + direct SQLite append when the server isn't up (test
  * harness / startup race). */
-async function withLiveDoc<T>(
+export async function withLiveDoc<T>(
 	tabId: string,
 	mutate: (doc: Y.Doc) => T
 ): Promise<T> {

--- a/src/lib/server/ws-server.ts
+++ b/src/lib/server/ws-server.ts
@@ -27,7 +27,8 @@ import {
 	applyEditToFragment
 } from '$lib/shared/ydoc-codec';
 import { applyPendingReviewRound } from '$lib/review-rounds';
-import { touchLastSeen } from '$lib/server/last-seen';
+import { deleteLastSeen, touchLastSeen } from '$lib/server/last-seen';
+import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import {
 	appendUpdate,
 	replayUpdatesInto,
@@ -68,6 +69,7 @@ export function createWsServer(port: number): Server {
 			throw new Error('server-instance-mismatch');
 		},
 		async onLoadDocument({ documentName: tabId, document }) {
+			if (isBinaryOrPreviewPath(tabId)) return document;
 			const ydoc = document as unknown as Y.Doc;
 			const fragment = ydoc.getXmlFragment(FRAGMENT_NAME);
 			if (fragment.length === 0) {
@@ -407,29 +409,36 @@ export async function setThreadResolution(
 
 // ── Tab destruction ──────────────────────────────────────────────────────
 
+/** Close WS clients and drop the in-memory Hocuspocus Document without
+ * deleting SQLite history. Used after a rename so the new path hydrates
+ * from the migrated `yjs_updates` rows. */
+export async function unloadTabDocument(tabId: string): Promise<void> {
+	const server = globalHolder().__docwriterWsServer;
+	if (!server?.hocuspocus) return;
+	try {
+		server.hocuspocus.closeConnections(tabId);
+	} catch (err) {
+		console.error(`[docwriter] closeConnections failed for "${tabId}":`, err);
+	}
+	const doc = server.hocuspocus.documents.get(tabId);
+	if (doc) {
+		try {
+			await server.hocuspocus.unloadDocument(doc);
+		} catch (err) {
+			console.error(`[docwriter] unloadDocument failed for "${tabId}":`, err);
+		}
+		server.hocuspocus.documents.delete(tabId);
+	}
+}
+
 /** Fully tear down server-side state for a tab whose file was just deleted:
  * disconnect any WS clients, unload the Hocuspocus Document, and drop the
  * persisted CRDT log. Without this, reopening the same path would replay
  * stale updates from SQLite and silently resurrect the deleted content. */
 export async function destroyTabState(tabId: string): Promise<void> {
-	const server = globalHolder().__docwriterWsServer;
-	if (server?.hocuspocus) {
-		try {
-			server.hocuspocus.closeConnections(tabId);
-		} catch (err) {
-			console.error(`[docwriter] closeConnections failed for "${tabId}":`, err);
-		}
-		const doc = server.hocuspocus.documents.get(tabId);
-		if (doc) {
-			try {
-				await server.hocuspocus.unloadDocument(doc);
-			} catch (err) {
-				console.error(`[docwriter] unloadDocument failed for "${tabId}":`, err);
-			}
-			server.hocuspocus.documents.delete(tabId);
-		}
-	}
+	await unloadTabDocument(tabId);
 	purgeTabUpdates(tabId);
+	deleteLastSeen(tabId);
 }
 
 // Re-export so legacy imports resolve.

--- a/src/lib/server/ydoc-persistence.ts
+++ b/src/lib/server/ydoc-persistence.ts
@@ -18,6 +18,7 @@ import { dirname } from 'path';
 import * as Y from 'yjs';
 import { getDb } from './db';
 import { tabFile } from './document-files';
+import { isBinaryOrPreviewPath, looksLikeBinaryText } from '$lib/shared/file-kinds';
 import { serializeYDoc, seedYDoc, SYSTEM_ORIGIN } from '$lib/shared/ydoc-codec';
 
 /** Filesystem mtime can lag our `Date.now()` row-insert by a few hundred ms
@@ -29,6 +30,8 @@ const EXTERNAL_EDIT_SKEW_MS = 2_000;
  * is applied with its original origin (preserved per row) so any origin-aware
  * observer sees the same origins it would live. */
 export function replayUpdatesInto(ydoc: Y.Doc, tabId: string): void {
+	if (isBinaryOrPreviewPath(tabId)) return;
+
 	const db = getDb();
 	let rows = db
 		.prepare(`SELECT payload, origin, created FROM yjs_updates WHERE tab_id = ? ORDER BY seq`)
@@ -53,7 +56,7 @@ export function replayUpdatesInto(ydoc: Y.Doc, tabId: string): void {
 		const workspacePath = tabFile(tabId);
 		if (!existsSync(workspacePath)) return;
 		const content = readFileSync(workspacePath, 'utf-8');
-		if (!content) return;
+		if (!content || looksLikeBinaryText(content)) return;
 		ydoc.transact(() => seedYDoc(ydoc, content), SYSTEM_ORIGIN);
 		const update = Y.encodeStateAsUpdate(ydoc);
 		db.prepare(
@@ -68,6 +71,7 @@ function diskNewerThanLog(
 	tabId: string,
 	rows: Array<{ payload: Buffer; origin: string; created: number }>
 ): boolean {
+	if (isBinaryOrPreviewPath(tabId)) return false;
 	const workspacePath = tabFile(tabId);
 	if (!existsSync(workspacePath)) return false;
 	let st;
@@ -168,6 +172,7 @@ function runFlushTick() {
 }
 
 function writeTabFile(tabId: string, ydoc: Y.Doc) {
+	if (isBinaryOrPreviewPath(tabId)) return;
 	const content = serializeYDoc(ydoc);
 	// Skip no-op rewrites: a pending review round dirties the tab without
 	// changing the committed text, and rewriting would bump mtime → CLI
@@ -217,6 +222,56 @@ export function purgeTabUpdates(tabId: string) {
 	lastWrittenContent.delete(tabId);
 	lastWrittenByPath.delete(tabFile(tabId));
 	getDb().prepare(`DELETE FROM yjs_updates WHERE tab_id = ?`).run(tabId);
+}
+
+/** Move the CRDT log and flush cache when a tab path changes. Target rows
+ * (a race that opened the new path first) are dropped so the original
+ * history wins. */
+export function renameTabUpdates(fromId: string, toId: string): void {
+	if (fromId === toId) return;
+	const db = getDb();
+	const fromCount = (
+		db.prepare(`SELECT COUNT(*) AS n FROM yjs_updates WHERE tab_id = ?`).get(fromId) as {
+			n: number;
+		}
+	).n;
+	if (fromCount === 0) return;
+	db.transaction(() => {
+		db.prepare(`DELETE FROM yjs_updates WHERE tab_id = ?`).run(toId);
+		db.prepare(`UPDATE yjs_updates SET tab_id = ? WHERE tab_id = ?`).run(toId, fromId);
+	})();
+	dirtyTabs.delete(fromId);
+	const content = lastWrittenContent.get(fromId);
+	if (content !== undefined) {
+		lastWrittenContent.set(toId, content);
+		lastWrittenContent.delete(fromId);
+	}
+	const fromPath = tabFile(fromId);
+	const written = lastWrittenByPath.get(fromPath);
+	if (written !== undefined) {
+		lastWrittenByPath.set(tabFile(toId), written);
+		lastWrittenByPath.delete(fromPath);
+	}
+}
+
+export function listYjsTabIds(): string[] {
+	return (
+		getDb()
+			.prepare(`SELECT DISTINCT tab_id FROM yjs_updates ORDER BY tab_id`)
+			.all() as Array<{ tab_id: string }>
+	).map((row) => row.tab_id);
+}
+
+export function yjsTabStats(tabId: string): { updateCount: number; lastActivity: number | null } {
+	const row = getDb()
+		.prepare(
+			`SELECT COUNT(*) AS updateCount, MAX(created) AS lastActivity FROM yjs_updates WHERE tab_id = ?`
+		)
+		.get(tabId) as { updateCount: number; lastActivity: number | null };
+	return {
+		updateCount: row?.updateCount ?? 0,
+		lastActivity: row?.lastActivity ?? null
+	};
 }
 
 /** Tab ids that have a CRDT log and/or an open-tabs row. Recovery walks

--- a/src/lib/server/ydoc-persistence.ts
+++ b/src/lib/server/ydoc-persistence.ts
@@ -218,3 +218,15 @@ export function purgeTabUpdates(tabId: string) {
 	lastWrittenByPath.delete(tabFile(tabId));
 	getDb().prepare(`DELETE FROM yjs_updates WHERE tab_id = ?`).run(tabId);
 }
+
+/** Tab ids that have a CRDT log and/or an open-tabs row. Recovery walks
+ * this set so a stuck review on a closed tab is still cleared. */
+export function listPersistedTabIds(): string[] {
+	const fromUpdates = getDb()
+		.prepare(`SELECT DISTINCT tab_id FROM yjs_updates`)
+		.all() as Array<{ tab_id: string }>;
+	const fromTabs = getDb()
+		.prepare(`SELECT tab_id FROM tabs`)
+		.all() as Array<{ tab_id: string }>;
+	return [...new Set([...fromUpdates, ...fromTabs].map((row) => row.tab_id))].sort();
+}

--- a/src/lib/shared/file-kinds.test.ts
+++ b/src/lib/shared/file-kinds.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isBinaryOrPreviewPath, isPdfPath, looksLikeBinaryText } from './file-kinds';
+
+describe('isBinaryOrPreviewPath', () => {
+	it('treats PDFs and images as preview files', () => {
+		expect(isPdfPath('cv.pdf')).toBe(true);
+		expect(isBinaryOrPreviewPath('cv.pdf')).toBe(true);
+		expect(isBinaryOrPreviewPath('figures/plot.png')).toBe(true);
+	});
+
+	it('keeps writing sources as text tabs', () => {
+		expect(isBinaryOrPreviewPath('research_2026.tex')).toBe(false);
+		expect(isBinaryOrPreviewPath('dblp.bib')).toBe(false);
+		expect(isBinaryOrPreviewPath('chapter.md')).toBe(false);
+	});
+
+	it('detects embedded NUL bytes from a binary-as-text read', () => {
+		expect(looksLikeBinaryText('hello\0world')).toBe(true);
+		expect(looksLikeBinaryText('%PDF-1.7 text-like header')).toBe(false);
+	});
+});

--- a/src/lib/shared/file-kinds.ts
+++ b/src/lib/shared/file-kinds.ts
@@ -10,3 +10,50 @@ export function extensionOf(path: string): string | null {
 export function isPdfPath(path: string): boolean {
 	return extensionOf(path) === 'pdf';
 }
+
+/** Preview / binary files that must never become a Y.Doc tab. Opening one
+ * as a tab is fine for PDF preview, but seeding SQLite from the bytes
+ * stores a huge `system` update and can stall Accept/Reject. */
+const BINARY_OR_PREVIEW_EXTENSIONS = new Set([
+	'pdf',
+	'png',
+	'jpg',
+	'jpeg',
+	'gif',
+	'webp',
+	'ico',
+	'bmp',
+	'tif',
+	'tiff',
+	'avif',
+	'heic',
+	'mp3',
+	'mp4',
+	'wav',
+	'mov',
+	'zip',
+	'gz',
+	'tgz',
+	'wasm',
+	'eot',
+	'ttf',
+	'otf',
+	'woff',
+	'woff2',
+	'exe',
+	'dylib',
+	'so',
+	'class',
+	'jar'
+]);
+
+export function isBinaryOrPreviewPath(path: string): boolean {
+	const ext = extensionOf(path);
+	return ext !== null && BINARY_OR_PREVIEW_EXTENSIONS.has(ext);
+}
+
+/** UTF-8 reads of PDFs and other binaries often embed NUL bytes. Never
+ * seed a Y.Doc from that content even if the extension check is missed. */
+export function looksLikeBinaryText(content: string): boolean {
+	return content.includes('\0');
+}

--- a/src/lib/shared/reset-ui-state.test.ts
+++ b/src/lib/shared/reset-ui-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { applyUiReset } from './reset-ui-state';
+import { getCommentsMap, getReviewArray, seedYDoc, serializeYDoc } from './ydoc-codec';
+import type { CommentThread, PendingReviewRound } from '$lib/types';
+
+function seedDoc(text: string): Y.Doc {
+	const doc = new Y.Doc();
+	seedYDoc(doc, text);
+	return doc;
+}
+
+function editRound(id: string, threadId?: string): PendingReviewRound {
+	return {
+		id,
+		timestamp: 1,
+		operation: { type: 'edit', oldString: 'hello', newString: 'hello world' },
+		...(threadId ? { feedbackThreadId: threadId } : {})
+	};
+}
+
+function thread(id: string): CommentThread {
+	return {
+		id,
+		anchor: { quote: 'hello', occurrenceIndex: 0 },
+		messages: [{ id: 'msg_1', author: 'agent', text: 'nits', timestamp: 1 }],
+		resolved: false,
+		createdAt: 1
+	};
+}
+
+describe('applyUiReset', () => {
+	it('clears pending reviews and comment threads without touching document text', () => {
+		const doc = seedDoc('hello\nworld');
+		getReviewArray(doc).push([editRound('r1'), editRound('r2', 'thread_1')]);
+		getCommentsMap(doc).set('thread_1', thread('thread_1'));
+
+		const result = applyUiReset(doc);
+
+		expect(result).toEqual({ reviewsCleared: 2, commentsCleared: 1 });
+		expect(getReviewArray(doc).length).toBe(0);
+		expect(getCommentsMap(doc).size).toBe(0);
+		expect(serializeYDoc(doc)).toBe('hello\nworld');
+	});
+
+	it('can clear only reviews or only comments', () => {
+		const doc = seedDoc('hello');
+		getReviewArray(doc).push([editRound('r1')]);
+		getCommentsMap(doc).set('thread_1', thread('thread_1'));
+
+		expect(applyUiReset(doc, { reviews: true, comments: false })).toEqual({
+			reviewsCleared: 1,
+			commentsCleared: 0
+		});
+		expect(getReviewArray(doc).length).toBe(0);
+		expect(getCommentsMap(doc).has('thread_1')).toBe(true);
+
+		expect(applyUiReset(doc, { reviews: false, comments: true })).toEqual({
+			reviewsCleared: 0,
+			commentsCleared: 1
+		});
+		expect(getCommentsMap(doc).size).toBe(0);
+	});
+
+	it('is a no-op when there is nothing to clear', () => {
+		const doc = seedDoc('hello');
+		expect(applyUiReset(doc)).toEqual({ reviewsCleared: 0, commentsCleared: 0 });
+		expect(serializeYDoc(doc)).toBe('hello');
+	});
+});

--- a/src/lib/shared/reset-ui-state.ts
+++ b/src/lib/shared/reset-ui-state.ts
@@ -1,0 +1,50 @@
+/**
+ * Clear pending reviews and/or comment threads from a tab Y.Doc.
+ *
+ * Recovery helper: stuck gutter cards (a loose edit with no thread, a stale
+ * proposal that will not accept) live in the CRDT, not in a separate table.
+ * This mutates those maps in place and leaves document text, rules, hooks,
+ * and settings untouched.
+ */
+import * as Y from 'yjs';
+import { getCommentsMap, getReviewArray, USER_ORIGIN } from './ydoc-codec';
+
+export interface UiResetOptions {
+	reviews?: boolean;
+	comments?: boolean;
+}
+
+export interface UiResetResult {
+	reviewsCleared: number;
+	commentsCleared: number;
+}
+
+export function applyUiReset(ydoc: Y.Doc, options: UiResetOptions = {}): UiResetResult {
+	const clearReviews = options.reviews !== false;
+	const clearComments = options.comments !== false;
+	const reviewArr = getReviewArray(ydoc);
+	const commentsMap = getCommentsMap(ydoc);
+	const reviewsCleared = clearReviews ? reviewArr.length : 0;
+	let commentsCleared = 0;
+	if (clearComments) {
+		commentsMap.forEach(() => {
+			commentsCleared += 1;
+		});
+	}
+	if (reviewsCleared === 0 && commentsCleared === 0) {
+		return { reviewsCleared: 0, commentsCleared: 0 };
+	}
+	ydoc.transact(() => {
+		if (clearReviews && reviewArr.length > 0) {
+			reviewArr.delete(0, reviewArr.length);
+		}
+		if (clearComments && commentsCleared > 0) {
+			const keys: string[] = [];
+			commentsMap.forEach((_value, key) => {
+				keys.push(key);
+			});
+			for (const key of keys) commentsMap.delete(key);
+		}
+	}, USER_ORIGIN);
+	return { reviewsCleared, commentsCleared };
+}

--- a/src/lib/shared/tab-reconcile.test.ts
+++ b/src/lib/shared/tab-reconcile.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { classifyGhostTabs, resolveTabRename, visibleTabsState } from './tab-reconcile';
+import {
+	classifyGhostTabs,
+	resolveTabRename,
+	tabsToAutoRestore,
+	visibleTabsState
+} from './tab-reconcile';
 
 describe('visibleTabsState', () => {
 	it('hides missing files without requiring a persisted drop', () => {
@@ -36,6 +41,22 @@ describe('classifyGhostTabs', () => {
 				hasLastSeen: true
 			}
 		]);
+	});
+});
+
+describe('tabsToAutoRestore', () => {
+	it('re-inserts a dropped research tab and skips a user-closed one', () => {
+		expect(
+			tabsToAutoRestore({
+				leftovers: [
+					{ tabId: 'research_2026.tex', kind: 'closed' },
+					{ tabId: 'teaching_2026.tex', kind: 'closed' },
+					{ tabId: 'cv.pdf', kind: 'missing' }
+				],
+				intentionallyClosed: ['teaching_2026.tex'],
+				shouldSkip: (id) => id.endsWith('.pdf')
+			})
+		).toEqual(['research_2026.tex']);
 	});
 });
 

--- a/src/lib/shared/tab-reconcile.test.ts
+++ b/src/lib/shared/tab-reconcile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { classifyGhostTabs, resolveTabRename, visibleTabsState } from './tab-reconcile';
+
+describe('visibleTabsState', () => {
+	it('hides missing files without requiring a persisted drop', () => {
+		const visible = visibleTabsState(
+			{ order: ['research_2026.tex', 'teaching_2026.tex'], active: 'research_2026.tex' },
+			(id) => id === 'teaching_2026.tex'
+		);
+		expect(visible).toEqual({
+			order: ['teaching_2026.tex'],
+			active: 'teaching_2026.tex'
+		});
+	});
+});
+
+describe('classifyGhostTabs', () => {
+	it('flags a heavily-edited tab that left the tabs table while the file remains', () => {
+		const ghosts = classifyGhostTabs({
+			openTabIds: ['teaching_2026.tex', 'aditya_statement_2026.tex'],
+			yjsTabIds: ['research_2026.tex', 'teaching_2026.tex', 'cv.pdf'],
+			lastSeenTabIds: ['research_2026.tex', 'cv.pdf'],
+			fileExists: (id) => id !== 'cv.pdf'
+		});
+		expect(ghosts).toEqual([
+			{
+				tabId: 'cv.pdf',
+				kind: 'missing',
+				hasUpdates: true,
+				hasLastSeen: true
+			},
+			{
+				tabId: 'research_2026.tex',
+				kind: 'closed',
+				hasUpdates: true,
+				hasLastSeen: true
+			}
+		]);
+	});
+});
+
+describe('resolveTabRename', () => {
+	it('treats a file-tree move as already done when only the new path exists', () => {
+		expect(resolveTabRename(false, true)).toBe('already-moved');
+		expect(resolveTabRename(true, false)).toBe('rename');
+		expect(resolveTabRename(false, false)).toBe('source-missing');
+		expect(resolveTabRename(true, true)).toBe('target-exists');
+	});
+});

--- a/src/lib/shared/tab-reconcile.ts
+++ b/src/lib/shared/tab-reconcile.ts
@@ -57,6 +57,26 @@ export function classifyGhostTabs(input: {
 	return out;
 }
 
+/** Tabs that still have a file and were dropped from `tabs` without a
+ * recorded close. Historical workspaces have no close list, so a vanished
+ * research file is restored. After this ships, an intentional close is
+ * recorded and is not put back. */
+export function tabsToAutoRestore(input: {
+	leftovers: ReadonlyArray<{ tabId: string; kind: GhostTabKind }>;
+	intentionallyClosed: readonly string[];
+	shouldSkip?: (tabId: string) => boolean;
+}): string[] {
+	const closed = new Set(input.intentionallyClosed);
+	return input.leftovers
+		.filter(
+			(item) =>
+				item.kind === 'closed' &&
+				!closed.has(item.tabId) &&
+				!input.shouldSkip?.(item.tabId)
+		)
+		.map((item) => item.tabId);
+}
+
 export type TabRenameResolution = 'rename' | 'already-moved' | 'source-missing' | 'target-exists';
 
 /** File-tree rename moves the file first, then PATCH /api/tabs. Treat

--- a/src/lib/shared/tab-reconcile.ts
+++ b/src/lib/shared/tab-reconcile.ts
@@ -1,0 +1,73 @@
+/**
+ * Tab-list vs CRDT-log reconciliation. Pure helpers so we can test the
+ * "file briefly missing" and "closed tab still has updates" cases without
+ * opening SQLite.
+ */
+
+export interface TabsStateLike {
+	order: string[];
+	active: string | null;
+}
+
+/** Tabs whose files currently exist. Does not mutate the stored list —
+ * a missing file must not delete the row, or a compile/rename race drops
+ * the tab while thousands of yjs_updates remain. */
+export function visibleTabsState(
+	stored: TabsStateLike,
+	fileExists: (tabId: string) => boolean
+): TabsStateLike {
+	const order = stored.order.filter((id) => fileExists(id));
+	let active = stored.active && order.includes(stored.active) ? stored.active : null;
+	if (!active && order.length > 0) active = order[0];
+	return { order, active };
+}
+
+export type GhostTabKind = 'closed' | 'missing';
+
+export interface GhostTab {
+	tabId: string;
+	kind: GhostTabKind;
+	hasUpdates: boolean;
+	hasLastSeen: boolean;
+}
+
+/** Tab ids that have CRDT or last_seen state but are not in the open-tab
+ * list. `closed` = file still there (reopen). `missing` = leftover after
+ * a delete/rename that did not migrate persistence. */
+export function classifyGhostTabs(input: {
+	openTabIds: readonly string[];
+	yjsTabIds: readonly string[];
+	lastSeenTabIds: readonly string[];
+	fileExists: (tabId: string) => boolean;
+}): GhostTab[] {
+	const open = new Set(input.openTabIds);
+	const yjs = new Set(input.yjsTabIds);
+	const seen = new Set(input.lastSeenTabIds);
+	const ids = [...new Set([...input.yjsTabIds, ...input.lastSeenTabIds])].sort();
+	const out: GhostTab[] = [];
+	for (const tabId of ids) {
+		if (open.has(tabId)) continue;
+		out.push({
+			tabId,
+			kind: input.fileExists(tabId) ? 'closed' : 'missing',
+			hasUpdates: yjs.has(tabId),
+			hasLastSeen: seen.has(tabId)
+		});
+	}
+	return out;
+}
+
+export type TabRenameResolution = 'rename' | 'already-moved' | 'source-missing' | 'target-exists';
+
+/** File-tree rename moves the file first, then PATCH /api/tabs. Treat
+ * "source gone, target present" as already moved so the CRDT log can
+ * follow the new path instead of 404ing and orphaning the old tab id. */
+export function resolveTabRename(
+	fromExists: boolean,
+	toExists: boolean
+): TabRenameResolution {
+	if (fromExists && toExists) return 'target-exists';
+	if (fromExists) return 'rename';
+	if (toExists) return 'already-moved';
+	return 'source-missing';
+}

--- a/src/lib/shared/workspace-identity.test.ts
+++ b/src/lib/shared/workspace-identity.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+	describeWorkspace,
+	findConflictingStateDir,
+	formatConflictWarning,
+	resolveWorkspaceRoot
+} from './workspace-identity';
+
+describe('resolveWorkspaceRoot', () => {
+	it('uses a positional / --root argument over cwd', () => {
+		expect(
+			resolveWorkspaceRoot({
+				rootArg: '/writing/book',
+				cwd: '/repos/docwriter'
+			})
+		).toBe('/writing/book');
+	});
+
+	it('resolves a relative folder argument against cwd', () => {
+		expect(
+			resolveWorkspaceRoot({
+				rootArg: 'notes',
+				cwd: '/home/ada'
+			})
+		).toBe('/home/ada/notes');
+	});
+
+	it('falls back to DOCWRITER_ROOT, then cwd', () => {
+		expect(
+			resolveWorkspaceRoot({
+				envRoot: '/from/env',
+				cwd: '/repos/docwriter'
+			})
+		).toBe('/from/env');
+		expect(resolveWorkspaceRoot({ cwd: '/repos/docwriter' })).toBe('/repos/docwriter');
+	});
+});
+
+describe('describeWorkspace', () => {
+	it('puts .docwriter inside the opened folder, not the invoke cwd', () => {
+		const identity = describeWorkspace('/writing/book');
+		expect(identity.root).toBe('/writing/book');
+		expect(identity.stateDir).toBe('/writing/book/.docwriter');
+		expect(identity.name).toBe('book');
+	});
+});
+
+describe('findConflictingStateDir', () => {
+	it('warns when cwd has its own .docwriter and is not the workspace', () => {
+		const conflict = findConflictingStateDir({
+			root: '/writing/book',
+			cwd: '/repos/docwriter',
+			cwdHasState: true
+		});
+		expect(conflict).toEqual({
+			cwd: '/repos/docwriter',
+			cwdStateDir: '/repos/docwriter/.docwriter'
+		});
+		const identity = describeWorkspace('/writing/book');
+		expect(formatConflictWarning(identity, conflict!)).toContain(
+			'/repos/docwriter/.docwriter'
+		);
+		expect(formatConflictWarning(identity, conflict!)).toContain(
+			'/writing/book/.docwriter'
+		);
+	});
+
+	it('is silent when cwd is the workspace or has no .docwriter', () => {
+		expect(
+			findConflictingStateDir({
+				root: '/writing/book',
+				cwd: '/writing/book',
+				cwdHasState: true
+			})
+		).toBeNull();
+		expect(
+			findConflictingStateDir({
+				root: '/writing/book',
+				cwd: '/repos/docwriter',
+				cwdHasState: false
+			})
+		).toBeNull();
+	});
+});

--- a/src/lib/shared/workspace-identity.ts
+++ b/src/lib/shared/workspace-identity.ts
@@ -1,0 +1,141 @@
+/**
+ * Workspace root vs. DocWriter state directory.
+ *
+ * `docwriter ~/writing/book` (or `--root`) opens that folder as the
+ * workspace. SQLite, comments, and pending reviews live in
+ * `<workspace>/.docwriter`, not in the directory you invoked the command
+ * from. Looking at the wrong `.docwriter` looks like an empty database.
+ */
+
+export interface WorkspaceIdentity {
+	/** Absolute workspace root. */
+	root: string;
+	/** Absolute `.docwriter` directory for this workspace. */
+	stateDir: string;
+	/** Last path segment, for compact UI labels. */
+	name: string;
+}
+
+export interface WorkspaceConflict {
+	cwd: string;
+	cwdStateDir: string;
+}
+
+export interface ResolveWorkspaceRootInput {
+	rootArg?: string | null;
+	envRoot?: string | null;
+	cwd: string;
+}
+
+/** Same precedence as `bin/docwriter.js`: positional/`--root`, then
+ * `DOCWRITER_ROOT`, then cwd. */
+export function resolveWorkspaceRoot(input: ResolveWorkspaceRootInput): string {
+	const raw = (input.rootArg && input.rootArg.trim()) || (input.envRoot && input.envRoot.trim()) || input.cwd;
+	return resolveAgainst(input.cwd, raw);
+}
+
+export function describeWorkspace(root: string): WorkspaceIdentity {
+	const normalized = normalizePath(root);
+	return {
+		root: normalized,
+		stateDir: joinPath(normalized, '.docwriter'),
+		name: lastSegment(normalized) || normalized
+	};
+}
+
+/** When the process cwd is a different folder that also has `.docwriter`,
+ * inspecting cwd looks like the live state is missing. */
+export function findConflictingStateDir(input: {
+	root: string;
+	cwd: string;
+	cwdHasState: boolean;
+}): WorkspaceConflict | null {
+	const root = normalizePath(input.root);
+	const cwd = normalizePath(input.cwd);
+	if (root === cwd) return null;
+	if (!input.cwdHasState) return null;
+	return {
+		cwd,
+		cwdStateDir: joinPath(cwd, '.docwriter')
+	};
+}
+
+export function formatConflictWarning(
+	identity: WorkspaceIdentity,
+	conflict: WorkspaceConflict
+): string {
+	return [
+		`cwd has a separate .docwriter at ${conflict.cwdStateDir}.`,
+		`This process uses ${identity.stateDir} (the folder you opened).`,
+		'Inspecting the wrong folder looks like an empty database.'
+	].join(' ');
+}
+
+export function formatStartupWarningLines(
+	identity: WorkspaceIdentity,
+	conflict: WorkspaceConflict
+): string[] {
+	return [
+		`cwd has a separate .docwriter at ${conflict.cwdStateDir}`,
+		`This process uses ${identity.stateDir} (the folder you opened).`,
+		'Inspecting the wrong folder looks like an empty database.'
+	];
+}
+
+function isAbsolutePath(path: string): boolean {
+	return path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+/** `path.resolve` for the cases we care about: an absolute target wins;
+ * a relative target is joined onto the base. */
+function resolveAgainst(base: string, target: string): string {
+	if (isAbsolutePath(target)) return normalizePath(target);
+	return joinPath(base, target);
+}
+
+function joinPath(base: string, ...parts: string[]): string {
+	const raw = [base, ...parts].join('/');
+	return normalizePath(raw);
+}
+
+function lastSegment(path: string): string {
+	const trimmed = path.replace(/[\\/]+$/, '');
+	const parts = trimmed.split(/[\\/]/).filter(Boolean);
+	return parts[parts.length - 1] ?? '';
+}
+
+/** POSIX-style normalize that also collapses `a/../b` and treats a
+ * relative second argument as relative to the first (when the second is
+ * not absolute). */
+function normalizePath(path: string): string {
+	const windowsAbs = /^[A-Za-z]:[\\/]/.test(path);
+	const posixAbs = path.startsWith('/');
+	const sep = windowsAbs || path.includes('\\') ? '\\' : '/';
+	const split = path.replace(/\\/g, '/').split('/');
+	const out: string[] = [];
+	for (const part of split) {
+		if (part === '' || part === '.') {
+			if (part === '' && out.length === 0) out.push('');
+			continue;
+		}
+		if (part === '..') {
+			if (out.length > 0 && out[out.length - 1] !== '..' && out[out.length - 1] !== '') {
+				out.pop();
+				continue;
+			}
+			if (posixAbs || windowsAbs) continue;
+		}
+		out.push(part);
+	}
+	let joined = out.join('/');
+	if (windowsAbs) {
+		joined = joined.replace(/\//g, '\\');
+		if (!/^[A-Za-z]:\\/.test(joined) && /^[A-Za-z]:$/.test(out[0] ?? '')) {
+			joined = `${out[0]}\\`;
+		}
+	} else if (posixAbs && !joined.startsWith('/')) {
+		joined = '/' + joined;
+	}
+	if (joined.length > 1 && joined.endsWith(sep)) joined = joined.slice(0, -1);
+	return joined || (posixAbs ? '/' : '.');
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -134,6 +134,9 @@ export interface Action {
 	icon: string; // lucide icon name
 	pinned: boolean;
 	color: string;
+	/** When the action was last used. Persisted so a full-list rewrite
+	 * does not flatten every row to the same timestamp. */
+	usedAt?: number;
 }
 
 /** Threaded comment anchored to a passage in a tab.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -832,12 +832,15 @@
 		}
 	}
 
-	/** Reconcile open tabs after a FileTree rename. */
+	/** Reconcile open tabs after a FileTree rename or folder move. */
 	async function onFileTreeRenamed(fromPath: string, toPath: string) {
 		const existing = getCurrentTabList();
-		if (existing.includes(fromPath)) {
+		const prefix = `${fromPath}/`;
+		const affected = existing.filter((id) => id === fromPath || id.startsWith(prefix));
+		for (const id of affected) {
+			const newId = id === fromPath ? toPath : `${toPath}${id.slice(fromPath.length)}`;
 			try {
-				await renameTabAction(fromPath, toPath);
+				await renameTabAction(id, newId);
 			} catch (e) {
 				console.error('Renaming open tab failed:', e);
 			}
@@ -3472,7 +3475,7 @@
 	{/snippet}
 
 	{#snippet workspacePanelSnippet()}
-		<WorkspacePanel onApplied={applyWorkspaceUiReset} />
+		<WorkspacePanel onApplied={applyWorkspaceUiReset} onTabsChanged={loadTabs} />
 	{/snippet}
 
 	<div class="toolbar">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3475,7 +3475,12 @@
 	{/snippet}
 
 	{#snippet workspacePanelSnippet()}
-		<WorkspacePanel onApplied={applyWorkspaceUiReset} onTabsChanged={loadTabs} />
+		<WorkspacePanel
+			onApplied={applyWorkspaceUiReset}
+			onTabsChanged={() => {
+				void loadTabs();
+			}}
+		/>
 	{/snippet}
 
 	<div class="toolbar">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,7 @@
 	import HooksPanel from '$lib/components/HooksPanel.svelte';
 	import SkillsPanel from '$lib/components/SkillsPanel.svelte';
 	import ApiKeysPanel from '$lib/components/ApiKeysPanel.svelte';
+	import WorkspacePanel from '$lib/components/WorkspacePanel.svelte';
 	import CustomModelDialog from '$lib/components/CustomModelDialog.svelte';
 	import SessionBrowser from '$lib/components/SessionBrowser.svelte';
 	import { themes, applyTheme } from '$lib/themes';
@@ -2357,6 +2358,28 @@
 		submitInFlight = false;
 	}
 
+	function applyWorkspaceUiReset(
+		tabs: Array<{ tabId: string; yjsUpdate: string | null; reviewsCleared: number; commentsCleared: number }>
+	) {
+		for (const tab of tabs) {
+			if (!tab.yjsUpdate) continue;
+			applyUpdateToTab(tab.tabId, tab.yjsUpdate);
+		}
+		const reviews = tabs.reduce((n, t) => n + t.reviewsCleared, 0);
+		const comments = tabs.reduce((n, t) => n + t.commentsCleared, 0);
+		if (reviews === 0 && comments === 0) return;
+		pushHistory({
+			type: 'user_action',
+			timestamp: Date.now(),
+			description:
+				reviews && comments
+					? `Reset review UI (${reviews} pending review${reviews === 1 ? '' : 's'}, ${comments} comment thread${comments === 1 ? '' : 's'})`
+					: reviews
+						? `Cleared ${reviews} pending review${reviews === 1 ? '' : 's'}`
+						: `Cleared ${comments} comment thread${comments === 1 ? '' : 's'}`
+		});
+	}
+
 	async function newSession() {
 		if (rendering) cancelRender();
 		// Drop any queued submissions before they can fire from
@@ -2649,7 +2672,8 @@
 				{ kind: 'panel', label: 'Agent behavior', panelKey: 'agentSettings' },
 				{ kind: 'panel', label: 'Intended audience', panelKey: 'audience' },
 				{ kind: 'panel', label: 'Skills', panelKey: 'skills' },
-				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' }
+				{ kind: 'panel', label: 'Hooks', panelKey: 'hooks' },
+				{ kind: 'panel', label: 'Workspace', panelKey: 'workspace' }
 			]
 		}
 	]);
@@ -3383,7 +3407,8 @@
 					audience: audiencePanelSnippet,
 					hooks: hooksPanelSnippet,
 					skills: skillsPanelSnippet,
-					apiKeys: apiKeysPanelSnippet
+					apiKeys: apiKeysPanelSnippet,
+					workspace: workspacePanelSnippet
 				}}
 			/>
 			<ModelPicker
@@ -3444,6 +3469,10 @@
 
 	{#snippet apiKeysPanelSnippet()}
 		<ApiKeysPanel />
+	{/snippet}
+
+	{#snippet workspacePanelSnippet()}
+		<WorkspacePanel onApplied={applyWorkspaceUiReset} />
 	{/snippet}
 
 	<div class="toolbar">

--- a/src/routes/api/files/+server.ts
+++ b/src/routes/api/files/+server.ts
@@ -22,6 +22,9 @@ import { join, dirname } from 'path';
 import { resolveWorkspacePath } from '$lib/server/workspace-path';
 import { getTabsState, setTabsState } from '$lib/server/runtime-state';
 import { destroyTabState } from '$lib/server/ws-server';
+import { migrateTabsUnderPath } from '$lib/server/tab-rename';
+import { listLastSeenTabIds } from '$lib/server/last-seen';
+import { listYjsTabIds } from '$lib/server/ydoc-persistence';
 
 /** Names we always hide from the tree — noise that obscures the writing
  * workspace. `.docwriter/` is intentionally NOT here; the user wants to
@@ -119,6 +122,7 @@ export const PATCH: RequestHandler = async ({ request }) => {
 	if (existsSync(absTo)) throw error(409, `Target exists: ${to}`);
 	mkdirSync(dirname(absTo), { recursive: true });
 	renameSync(absFrom, absTo);
+	await migrateTabsUnderPath(from, to);
 	return json({ ok: true, from, to });
 };
 
@@ -137,8 +141,11 @@ export const DELETE: RequestHandler = async ({ url }) => {
 	// recreating the same path later resurrects the deleted content from
 	// the stale yjs_updates log.
 	const prefix = wasDir ? `${relPath}/` : null;
+	const matches = (id: string) => id === relPath || (prefix !== null && id.startsWith(prefix));
 	const state = getTabsState();
-	const doomed = state.order.filter((id) => id === relPath || (prefix && id.startsWith(prefix)));
+	const doomed = [
+		...new Set([...state.order, ...listYjsTabIds(), ...listLastSeenTabIds()].filter(matches))
+	];
 	if (doomed.length > 0) {
 		for (const id of doomed) {
 			await destroyTabState(id);

--- a/src/routes/api/files/+server.ts
+++ b/src/routes/api/files/+server.ts
@@ -25,6 +25,7 @@ import { destroyTabState } from '$lib/server/ws-server';
 import { migrateTabsUnderPath } from '$lib/server/tab-rename';
 import { listLastSeenTabIds } from '$lib/server/last-seen';
 import { listYjsTabIds } from '$lib/server/ydoc-persistence';
+import { markTabOpened } from '$lib/server/closed-tabs';
 
 /** Names we always hide from the tree — noise that obscures the writing
  * workspace. `.docwriter/` is intentionally NOT here; the user wants to
@@ -149,6 +150,7 @@ export const DELETE: RequestHandler = async ({ url }) => {
 	if (doomed.length > 0) {
 		for (const id of doomed) {
 			await destroyTabState(id);
+			markTabOpened(id);
 		}
 		const remaining = state.order.filter((id) => !doomed.includes(id));
 		let active = state.active && doomed.includes(state.active) ? null : state.active;

--- a/src/routes/api/render/+server.ts
+++ b/src/routes/api/render/+server.ts
@@ -24,6 +24,7 @@ import { readCommentThreads, readReviewRounds } from '$lib/shared/ydoc-codec';
 import type { CommentThread } from '$lib/types';
 import { formatDismissedThreadsHint } from '$lib/shared/list-threads';
 import { replayUpdatesInto } from '$lib/server/ydoc-persistence';
+import { isBinaryOrPreviewPath } from '$lib/shared/file-kinds';
 import { registerPendingAskUser } from '$lib/server/ask-user-state';
 import { unifiedLineDiff } from '$lib/diff';
 import { listStyleReferences } from '$lib/server/references';
@@ -51,6 +52,7 @@ import type { Reviewer } from '$lib/shared/reviewers';
  * Document (what clients are synced to); falls back to a throwaway Y.Doc
  * hydrated from SQLite when no client is connected. */
 function readLiveTabMarkdown(tabId: string): string {
+	if (isBinaryOrPreviewPath(tabId)) return '';
 	const holder = globalThis as unknown as {
 		__docwriterWsServer?: {
 			hocuspocus?: { documents?: { get(name: string): unknown } };
@@ -73,6 +75,7 @@ function readLiveTabMarkdown(tabId: string): string {
 /** Snapshot of a tab's comment threads. Prefer the Hocuspocus in-memory
  * Document; fall back to a throwaway doc hydrated from SQLite. */
 function readLiveTabCommentThreads(tabId: string): CommentThread[] {
+	if (isBinaryOrPreviewPath(tabId)) return [];
 	const holder = globalThis as unknown as {
 		__docwriterWsServer?: {
 			hocuspocus?: { documents?: { get(name: string): unknown } };
@@ -95,6 +98,7 @@ function readLiveTabCommentThreads(tabId: string): CommentThread[] {
  * the agent knows a reply there is feedback on an edit it should *revise*,
  * not a discussion to chat back on. */
 function readLiveTabPendingEditThreadIds(tabId: string): Set<string> {
+	if (isBinaryOrPreviewPath(tabId)) return new Set();
 	const holder = globalThis as unknown as {
 		__docwriterWsServer?: {
 			hocuspocus?: { documents?: { get(name: string): unknown } };
@@ -827,7 +831,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		// baseline from kv. The agent gets a prompt built off this snapshot
 		// and post-render we write each tab's (new) current content back
 		// into kv so the next render diffs cleanly.
-		const tabsForPrompt: TabPromptInfo[] = allTabIds.map((id) => ({
+		const textTabIds = allTabIds.filter((id) => !isBinaryOrPreviewPath(id));
+		const tabsForPrompt: TabPromptInfo[] = textTabIds.map((id) => ({
 			tabId: id,
 			currentMd: readLiveTabMarkdown(id),
 			lastSeenMd: kvGet(lastSeenKey(id)),
@@ -1101,7 +1106,7 @@ export const POST: RequestHandler = async ({ request }) => {
 					) {
 						const retryPrompt = buildMultiTabPrompt(
 							active,
-							allTabIds.map((id) => ({
+							textTabIds.map((id) => ({
 								tabId: id,
 								currentMd: readLiveTabMarkdown(id),
 								lastSeenMd: kvGet(lastSeenKey(id)),
@@ -1141,7 +1146,7 @@ export const POST: RequestHandler = async ({ request }) => {
 				// user edited mid-render gets its fresh content baked in,
 				// and a tab the agent edited gets its post-edit content.
 				try {
-					for (const id of allTabIds) {
+					for (const id of textTabIds) {
 						const now = readLiveTabMarkdown(id);
 						kvSet(lastSeenKey(id), now);
 					}

--- a/src/routes/api/tabs/+server.ts
+++ b/src/routes/api/tabs/+server.ts
@@ -10,14 +10,16 @@ import {
 import { getTabsState, setTabsState } from '$lib/server/runtime-state';
 import { writeTextAtomic } from '$lib/server/file-utils';
 import { destroyTabState } from '$lib/server/ws-server';
+import { migrateRenamedTab } from '$lib/server/tab-rename';
+import { resolveTabRename, visibleTabsState } from '$lib/shared/tab-reconcile';
 
 /** GET /api/tabs  →  { order, active, tabs: string[] }
  *
- * The tabs list is the source of truth now (was: scan notes/). If a
- * tab's file no longer exists on disk (user deleted it externally), we
- * drop it from the list. */
+ * Hide tabs whose files are currently missing. Do not persist that filter:
+ * a compile/sync/rename race used to DELETE the `tabs` row while thousands
+ * of `yjs_updates` stayed behind. */
 export const GET: RequestHandler = async () => {
-	const state = reconcileTabsState();
+	const state = visibleOpenTabs();
 	return json({
 		order: state.order,
 		active: state.active,
@@ -47,12 +49,12 @@ export const POST: RequestHandler = async ({ request }) => {
 		await destroyTabState(id);
 	}
 
-	const state = reconcileTabsState();
+	const state = getTabsState();
 	if (!state.order.includes(id)) state.order.push(id);
 	state.active = id;
 	setTabsState(state);
 
-	return json({ ok: true, id, active: id, order: state.order });
+	return json({ ok: true, id, active: id, order: visibleOpenTabs().order });
 };
 
 /** DELETE /api/tabs?id=<path>[&deleteFile=true]
@@ -83,58 +85,56 @@ export const DELETE: RequestHandler = async ({ url }) => {
 	let active = stored.active === id ? null : stored.active;
 	if (!active && order.length > 0) active = order[0];
 	setTabsState({ order, active });
-	return json({ ok: true, order, active });
+	const visible = visibleOpenTabs();
+	return json({ ok: true, order: visible.order, active: visible.active });
 };
 
 /** PATCH /api/tabs  body: { id, newId? , active? }  →  rename or focus.
  *
- * `active: true` just switches focus. `newId` renames the file, the
- * agent shadow (if present), and updates order + active pointer. */
+ * `active: true` just switches focus. `newId` renames the file and
+ * migrates the CRDT log + last_seen key so the tab does not vanish. */
 export const PATCH: RequestHandler = async ({ request }) => {
 	const body = await request.json();
 	const id = String(body?.id || '').trim();
 	if (!isValidTabId(id)) throw error(400, 'Invalid tab id');
 
-	let state = reconcileTabsState();
-
 	if (body?.newId) {
 		const newId = String(body.newId).trim();
 		if (!isValidTabId(newId)) throw error(400, 'Invalid new tab id');
-		if (id === newId) return json({ ok: true, id, order: state.order, active: state.active });
+		if (id === newId) {
+			const visible = visibleOpenTabs();
+			return json({ ok: true, id, order: visible.order, active: visible.active });
+		}
 		const from = tabFile(id);
 		const to = tabFile(newId);
-		if (!existsSync(from)) throw error(404, `Tab "${id}" not found`);
-		if (existsSync(to)) throw error(409, `"${newId}" already exists.`);
-		mkdirSync(dirname(to), { recursive: true });
-		renameSync(from, to);
+		const resolution = resolveTabRename(existsSync(from), existsSync(to));
+		if (resolution === 'source-missing') throw error(404, `Tab "${id}" not found`);
+		if (resolution === 'target-exists') throw error(409, `"${newId}" already exists.`);
+		if (resolution === 'rename') {
+			mkdirSync(dirname(to), { recursive: true });
+			renameSync(from, to);
+		}
+		await migrateRenamedTab(id, newId);
+		const state = getTabsState();
 		state.order = state.order.map((t) => (t === id ? newId : t));
+		if (!state.order.includes(newId)) state.order.push(newId);
 		if (state.active === id) state.active = newId;
 		setTabsState(state);
-		return json({ ok: true, id: newId, order: state.order, active: state.active });
+		const visible = visibleOpenTabs();
+		return json({ ok: true, id: newId, order: visible.order, active: visible.active });
 	}
 
 	if (body?.active === true) {
+		const state = getTabsState();
 		if (!state.order.includes(id)) throw error(404, `Tab "${id}" not found`);
 		state.active = id;
 		setTabsState(state);
 	}
 
-	return json({ ok: true, id, order: state.order, active: state.active });
+	const visible = visibleOpenTabs();
+	return json({ ok: true, id, order: visible.order, active: visible.active });
 };
 
-/** Reconcile the persisted tabs list against what's on disk. Drops any
- * entry whose file no longer exists (e.g. the user deleted it in their
- * terminal); resolves a dangling `active` pointer. */
-function reconcileTabsState() {
-	const stored = getTabsState();
-	const order = stored.order.filter((id) => existsSync(tabFile(id)));
-	let active = stored.active && order.includes(stored.active) ? stored.active : null;
-	if (!active && order.length > 0) active = order[0];
-
-	const cleaned = { order, active };
-	const changed =
-		cleaned.order.join('|') !== stored.order.join('|') ||
-		cleaned.active !== stored.active;
-	if (changed) setTabsState(cleaned);
-	return cleaned;
+function visibleOpenTabs() {
+	return visibleTabsState(getTabsState(), (id) => existsSync(tabFile(id)));
 }

--- a/src/routes/api/tabs/+server.ts
+++ b/src/routes/api/tabs/+server.ts
@@ -12,6 +12,8 @@ import { writeTextAtomic } from '$lib/server/file-utils';
 import { destroyTabState } from '$lib/server/ws-server';
 import { migrateRenamedTab } from '$lib/server/tab-rename';
 import { resolveTabRename, visibleTabsState } from '$lib/shared/tab-reconcile';
+import { markTabClosed, markTabOpened } from '$lib/server/closed-tabs';
+import { healOrphanedTabs } from '$lib/server/leftover-tabs';
 
 /** GET /api/tabs  →  { order, active, tabs: string[] }
  *
@@ -19,6 +21,7 @@ import { resolveTabRename, visibleTabsState } from '$lib/shared/tab-reconcile';
  * a compile/sync/rename race used to DELETE the `tabs` row while thousands
  * of `yjs_updates` stayed behind. */
 export const GET: RequestHandler = async () => {
+	healOrphanedTabs();
 	const state = visibleOpenTabs();
 	return json({
 		order: state.order,
@@ -53,6 +56,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	if (!state.order.includes(id)) state.order.push(id);
 	state.active = id;
 	setTabsState(state);
+	markTabOpened(id);
 
 	return json({ ok: true, id, active: id, order: visibleOpenTabs().order });
 };
@@ -77,6 +81,7 @@ export const DELETE: RequestHandler = async ({ url }) => {
 		// Otherwise reopening the same path would replay stale updates and
 		// resurrect the deleted content.
 		await destroyTabState(id);
+		markTabOpened(id);
 	}
 
 	// Drop from order even if the file still exists (close semantics).
@@ -85,6 +90,7 @@ export const DELETE: RequestHandler = async ({ url }) => {
 	let active = stored.active === id ? null : stored.active;
 	if (!active && order.length > 0) active = order[0];
 	setTabsState({ order, active });
+	if (!deleteFile) markTabClosed(id);
 	const visible = visibleOpenTabs();
 	return json({ ok: true, order: visible.order, active: visible.active });
 };

--- a/src/routes/api/workspace/+server.ts
+++ b/src/routes/api/workspace/+server.ts
@@ -1,10 +1,10 @@
 /**
  * Workspace identity and review-UI recovery.
  *
- *   GET  — folder currently open, where `.docwriter` lives, and a warning
- *          when the invoke cwd has a different `.docwriter`.
- *   POST — clear pending reviews and/or comment threads without deleting
- *          the database or workspace files.
+ *   GET  — folder currently open, where `.docwriter` lives, leftover tab
+ *          state, and a warning when the invoke cwd has a different
+ *          `.docwriter`.
+ *   POST — reset_ui / reopen_tab / purge_tab.
  */
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
@@ -12,17 +12,43 @@ import { isValidTabId } from '$lib/server/document-files';
 import { getWorkspaceInfo } from '$lib/server/workspace-identity';
 import { resetWorkspaceUiState } from '$lib/server/reset-ui-state';
 import { getTabsState } from '$lib/server/runtime-state';
+import { listLeftoverTabs, purgeLeftoverTab, reopenLeftoverTab } from '$lib/server/leftover-tabs';
 
 export const GET: RequestHandler = async () => {
 	return json({
 		...getWorkspaceInfo(),
-		activeTabId: getTabsState().active
+		activeTabId: getTabsState().active,
+		leftovers: listLeftoverTabs()
 	});
 };
 
 export const POST: RequestHandler = async ({ request }) => {
 	const body = await request.json().catch(() => ({}));
-	if (body?.action !== 'reset_ui') {
+	const action = typeof body?.action === 'string' ? body.action : '';
+
+	if (action === 'reopen_tab') {
+		const tabId = String(body?.tabId || '').trim();
+		if (!isValidTabId(tabId)) throw error(400, 'Invalid tab id');
+		try {
+			const state = reopenLeftoverTab(tabId);
+			return json({ ok: true, ...state, leftovers: listLeftoverTabs() });
+		} catch (err) {
+			throw error(400, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	if (action === 'purge_tab') {
+		const tabId = String(body?.tabId || '').trim();
+		if (!isValidTabId(tabId)) throw error(400, 'Invalid tab id');
+		try {
+			const state = await purgeLeftoverTab(tabId);
+			return json({ ok: true, ...state, leftovers: listLeftoverTabs() });
+		} catch (err) {
+			throw error(400, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	if (action !== 'reset_ui') {
 		throw error(400, 'Unknown workspace action');
 	}
 	const reviews = body.reviews !== false;
@@ -40,5 +66,5 @@ export const POST: RequestHandler = async ({ request }) => {
 		tabId = body.tabId;
 	}
 	const result = await resetWorkspaceUiState({ reviews, comments, tabId });
-	return json({ ok: true, ...result });
+	return json({ ok: true, leftovers: listLeftoverTabs(), ...result });
 };

--- a/src/routes/api/workspace/+server.ts
+++ b/src/routes/api/workspace/+server.ts
@@ -1,0 +1,44 @@
+/**
+ * Workspace identity and review-UI recovery.
+ *
+ *   GET  — folder currently open, where `.docwriter` lives, and a warning
+ *          when the invoke cwd has a different `.docwriter`.
+ *   POST — clear pending reviews and/or comment threads without deleting
+ *          the database or workspace files.
+ */
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { isValidTabId } from '$lib/server/document-files';
+import { getWorkspaceInfo } from '$lib/server/workspace-identity';
+import { resetWorkspaceUiState } from '$lib/server/reset-ui-state';
+import { getTabsState } from '$lib/server/runtime-state';
+
+export const GET: RequestHandler = async () => {
+	return json({
+		...getWorkspaceInfo(),
+		activeTabId: getTabsState().active
+	});
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	const body = await request.json().catch(() => ({}));
+	if (body?.action !== 'reset_ui') {
+		throw error(400, 'Unknown workspace action');
+	}
+	const reviews = body.reviews !== false;
+	const comments = body.comments !== false;
+	if (!reviews && !comments) {
+		throw error(400, 'Choose reviews and/or comments to clear');
+	}
+	let tabId: string | undefined;
+	if (body.scope === 'active') {
+		const active = getTabsState().active;
+		if (!active) throw error(400, 'No active tab');
+		tabId = active;
+	} else if (typeof body.tabId === 'string') {
+		if (!isValidTabId(body.tabId)) throw error(400, 'Invalid tab id');
+		tabId = body.tabId;
+	}
+	const result = await resetWorkspaceUiState({ reviews, comments, tabId });
+	return json({ ok: true, ...result });
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related problems from a DocWriter stress-test:

1. **Wrong `.docwriter` folder.** `docwriter <folder>` writes state in `<folder>/.docwriter`, not the invoke cwd. Inspecting the cwd database looks empty.
2. **Logical SQLite leftovers** in a real workspace (integrity_check passed): `research_2026.tex` missing from `tabs` while its Yjs history is intact; `cv.pdf` similarly leftover.

A later autopsy confirmed **no document text loss**. CRDT and disk match aside from typography normalization (hyphen vs en dash). The 16:19 burst was comment/review map metadata (dozens of threads), not runaway text. Flattened `recent_actions` timestamps match a crash flush.

### Workspace root guardrail

- Startup banner prints opened folder **and** `.docwriter` path.
- **Settings → Workspace** for paths, review-UI reset, and leftover tab recovery.

### Tab persistence

- Hide missing files on GET **without** deleting the `tabs` row.
- Migrate `yjs_updates` + `last_seen` on rename/folder move.
- Never seed Y.Docs from PDFs or other preview files.
- Persist per-action `usedAt`.
- **Auto-restore** writing tabs that still have a file and were never closed (`research_2026.tex` on reload). Intentional closes are recorded in `closedTabs` and stay closed. Preview leftovers (`cv.pdf`) are not auto-opened; Purge them from Settings if needed.

## Test plan

- [x] Unit tests including `tabsToAutoRestore` (71 passed)
- [x] `npm run check`
- [x] API checks for missing-file race, rename migration, PDF non-seed, usedAt
- [x] GET `/api/tabs` re-inserts a dropped `.tex` and leaves a user-closed tab closed; PDFs are not auto-opened

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31151810-89f2-4d95-a578-f9a8a1d202b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31151810-89f2-4d95-a578-f9a8a1d202b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

