### PR TITLE
Stop the document duplicating itself after a laptop wake

### DIFF
--- a/src/lib/server/external-edit-rebase.test.ts
+++ b/src/lib/server/external-edit-rebase.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, utimesSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as Y from 'yjs';
+import { serializeYDoc } from '$lib/shared/ydoc-codec';
+
+let workspace: string;
+let replayUpdatesInto: (ydoc: Y.Doc, tabId: string) => void;
+
+const TAB = 'research.tex';
+// An em dash: the seeder normalizes it to '-', the serializer emits '-',
+// so the log text can never equal the bytes on disk.
+const FILE_TEXT = '\\section{Intro}\n\nWriting is hard \u2014 very hard.\n';
+
+beforeAll(async () => {
+	workspace = mkdtempSync(join(tmpdir(), 'docwriter-reseed-'));
+	process.env.DOCWRITER_ROOT = workspace;
+	writeFileSync(join(workspace, TAB), FILE_TEXT);
+	({ replayUpdatesInto } = await import('./ydoc-persistence'));
+});
+
+afterAll(() => {
+	rmSync(workspace, { recursive: true, force: true });
+});
+
+/** Bump the file's mtime without changing its bytes — what a cloud-sync
+ * client (Dropbox/iCloud) does when the machine wakes up. */
+function touchFile() {
+	const future = new Date(Date.now() + 60_000);
+	utimesSync(join(workspace, TAB), future, future);
+}
+
+describe('external-edit detection', () => {
+	it('does not duplicate content when a reconnecting client survives a reload', () => {
+		// Cold start: server hydrates the tab and a browser syncs the same doc.
+		const server1 = new Y.Doc();
+		replayUpdatesInto(server1, TAB);
+		const client = new Y.Doc();
+		Y.applyUpdate(client, Y.encodeStateAsUpdate(server1));
+		expect(serializeYDoc(client)).toContain('Writing is hard');
+
+		// Sleep: the WS drops, Hocuspocus unloads the doc. On wake the file's
+		// mtime is newer (cloud sync) but its bytes are unchanged.
+		touchFile();
+
+		// The tab loads again, then the browser reconnects with its old doc.
+		const server2 = new Y.Doc();
+		replayUpdatesInto(server2, TAB);
+		Y.applyUpdate(server2, Y.encodeStateAsUpdate(client));
+		Y.applyUpdate(client, Y.encodeStateAsUpdate(server2));
+
+		const occurrences = serializeYDoc(client).split('Writing is hard').length - 1;
+		expect(occurrences).toBe(1);
+		expect(serializeYDoc(server2)).toBe(serializeYDoc(client));
+	});
+
+	it('adopts a genuine external edit without duplicating the document', () => {
+		const server1 = new Y.Doc();
+		replayUpdatesInto(server1, TAB);
+		const client = new Y.Doc();
+		Y.applyUpdate(client, Y.encodeStateAsUpdate(server1));
+
+		// The user edits the file in another editor while docwriter is asleep.
+		const edited = FILE_TEXT.replace('very hard', 'very very hard');
+		writeFileSync(join(workspace, TAB), edited);
+		touchFile();
+
+		const server2 = new Y.Doc();
+		replayUpdatesInto(server2, TAB);
+		expect(serializeYDoc(server2)).toContain('very very hard');
+
+		// The browser that slept through all of this reconnects.
+		Y.applyUpdate(server2, Y.encodeStateAsUpdate(client));
+		Y.applyUpdate(client, Y.encodeStateAsUpdate(server2));
+
+		const text = serializeYDoc(client);
+		expect(text.split('Writing is hard').length - 1).toBe(1);
+		expect(text).toContain('very very hard');
+		expect(serializeYDoc(server2)).toBe(text);
+		// Disk keeps its own bytes; only the Y.Doc was rebased.
+		expect(readFileSync(join(workspace, TAB), 'utf-8')).toBe(edited);
+	});
+});

--- a/src/lib/server/ydoc-persistence.ts
+++ b/src/lib/server/ydoc-persistence.ts
@@ -5,7 +5,10 @@
  *   - `replayUpdatesInto(ydoc, tabId)` hydrates a fresh Y.Doc from SQLite.
  *     If no rows exist and a workspace file does, seeds the Y.Doc from the
  *     file's content and persists the seed as one `system` row so subsequent
- *     loads skip the disk read.
+ *     loads skip the disk read. If the file changed behind our back, the
+ *     replayed doc is rebased onto it with one more `system` update — the
+ *     log is never purged, so the tab's CRDT identity is stable across
+ *     unloads.
  *   - `markTabDirty(tabId)` queues a tab for the next global flush.
  *   - `flushMarkdownNow(tabId, ydoc)` force-flushes one tab synchronously.
  *
@@ -18,7 +21,13 @@ import { dirname } from 'path';
 import * as Y from 'yjs';
 import { getDb } from './db';
 import { tabFile } from './document-files';
-import { serializeYDoc, seedYDoc, SYSTEM_ORIGIN } from '$lib/shared/ydoc-codec';
+import {
+	serializeYDoc,
+	seedYDoc,
+	normalizeTypography,
+	replaceYDocText,
+	SYSTEM_ORIGIN
+} from '$lib/shared/ydoc-codec';
 
 /** Filesystem mtime can lag our `Date.now()` row-insert by a few hundred ms
  * (and HFS+ quantizes to 1s), so we require a couple seconds of slack before
@@ -27,24 +36,41 @@ const EXTERNAL_EDIT_SKEW_MS = 2_000;
 
 /** Hydrate a fresh Y.Doc from SQLite by replaying its update log. Each update
  * is applied with its original origin (preserved per row) so any origin-aware
- * observer sees the same origins it would live. */
+ * observer sees the same origins it would live.
+ *
+ * If the workspace file was edited behind our back while the tab was
+ * unloaded, disk wins — but the log is NOT thrown away. The external text is
+ * applied as one more `system` update ON TOP of the replayed history, so the
+ * tab's CRDT identity survives. That matters because a browser can outlive an
+ * unload (a laptop sleeping drops the WebSocket without restarting the
+ * server): when it reconnects it still holds the pre-unload items. Against a
+ * doc that kept its identity, that reconnect is a no-op merge. Against a
+ * freshly seeded doc — same text, brand-new item ids — Yjs has no way to know
+ * the two copies are the same prose and keeps both, appending a second copy of
+ * the document to itself on every wake. */
 export function replayUpdatesInto(ydoc: Y.Doc, tabId: string): void {
 	const db = getDb();
-	let rows = db
+	const rows = db
 		.prepare(`SELECT payload, origin, created FROM yjs_updates WHERE tab_id = ? ORDER BY seq`)
 		.all(tabId) as Array<{ payload: Buffer; origin: string; created: number }>;
-
-	if (rows.length > 0 && diskNewerThanLog(tabId, rows)) {
-		console.log(
-			`[docwriter] tab "${tabId}" was edited externally since last sync; disk wins, purging stale Y.Doc log`
-		);
-		db.prepare(`DELETE FROM yjs_updates WHERE tab_id = ?`).run(tabId);
-		rows = [];
-	}
 
 	if (rows.length > 0) {
 		for (const row of rows) {
 			ydoc.transact(() => Y.applyUpdate(ydoc, new Uint8Array(row.payload)), row.origin);
+		}
+		const external = externalEditText(tabId, rows, ydoc);
+		if (external !== null) {
+			console.log(
+				`[docwriter] tab "${tabId}" was edited externally since last sync; disk wins, rebasing Y.Doc onto the file`
+			);
+			const before = Y.encodeStateVector(ydoc);
+			ydoc.transact(() => replaceYDocText(ydoc, external), SYSTEM_ORIGIN);
+			const update = Y.encodeStateAsUpdate(ydoc, before);
+			// Persist the adoption ourselves: this may be running inside
+			// Hocuspocus's `onLoadDocument`, before its own onChange listener
+			// is attached. If onChange does fire too, the extra row carries
+			// the same items and replays idempotently.
+			if (update.length > 0) appendUpdate(tabId, update, SYSTEM_ORIGIN);
 		}
 		return;
 	}
@@ -64,37 +90,41 @@ export function replayUpdatesInto(ydoc: Y.Doc, tabId: string): void {
 	}
 }
 
-function diskNewerThanLog(
+/** The file's text when it was edited outside docwriter since the log's last
+ * write, else null. `ydoc` must already hold the replayed log.
+ *
+ * Both sides are compared through `normalizeTypography`, the same
+ * transformation the seeder and serializer apply. Without it a file holding
+ * an em dash (or a curly quote, or an ellipsis) never matches its own Y.Doc —
+ * the doc canonicalizes those to ASCII, the file keeps them — so every mtime
+ * bump, including the content-free ones a cloud-sync client makes on wake,
+ * would read as an external edit. */
+function externalEditText(
 	tabId: string,
-	rows: Array<{ payload: Buffer; origin: string; created: number }>
-): boolean {
+	rows: Array<{ created: number }>,
+	ydoc: Y.Doc
+): string | null {
 	const workspacePath = tabFile(tabId);
-	if (!existsSync(workspacePath)) return false;
+	if (!existsSync(workspacePath)) return null;
 	let st;
 	try {
 		st = statSync(workspacePath);
 	} catch {
-		return false;
+		return null;
 	}
 	const maxCreated = rows.reduce((max, r) => (r.created > max ? r.created : max), 0);
-	if (st.mtimeMs <= maxCreated + EXTERNAL_EDIT_SKEW_MS) return false;
+	if (st.mtimeMs <= maxCreated + EXTERNAL_EDIT_SKEW_MS) return null;
 
 	let diskContent: string;
 	try {
 		diskContent = readFileSync(workspacePath, 'utf-8');
 	} catch {
-		return false;
+		return null;
 	}
-	const scratch = new Y.Doc();
-	try {
-		for (const row of rows) {
-			scratch.transact(() => Y.applyUpdate(scratch, new Uint8Array(row.payload)), row.origin);
-		}
-		const logContent = serializeYDoc(scratch);
-		return logContent.replace(/\n$/, '') !== diskContent.replace(/\n$/, '');
-	} finally {
-		scratch.destroy();
-	}
+	const logContent = serializeYDoc(ydoc);
+	const diskText = normalizeTypography(diskContent);
+	if (logContent.replace(/\n$/, '') === diskText.replace(/\n$/, '')) return null;
+	return diskContent;
 }
 
 export function appendUpdate(tabId: string, update: Uint8Array, origin: string) {


### PR DESCRIPTION
## Problem

Reported in Slack: every time the laptop wakes, docwriter appends another full copy of `research_2026.tex` to itself (27 KB → 108 KB after two wakes).

Two things compound in `replayUpdatesInto` (`src/lib/server/ydoc-persistence.ts`):

1. **A reseed broke CRDT identity while a browser still held the old doc.** When the workspace file's mtime was newer than the tab's update log and the bytes differed, the server deleted the whole `yjs_updates` log and seeded a brand-new `Y.Doc` from disk. A laptop sleeping drops the WebSocket without restarting the server, so the instance-id fence in `onAuthenticate` never fires. Hocuspocus unloads the doc, the reload reseeds the same prose under fresh item ids, and the browser reconnects carrying the pre-unload items. Yjs cannot tell the two copies are the same text and keeps both. The 500 ms flush then writes the doubled text to disk. Once per wake: 1x → 2x → 4x.

2. **The "edited externally" check false-positived on typography.** It compared the file's raw bytes against `serializeYDoc(...)`, which runs `normalizeTypography` (em dash → `-`, curly quotes → `'`, `…` → `...`, NBSP → space). A `.tex` file containing any of those could never equal its own doc's serialization, so *any* mtime bump counted as an external edit, including the content-free touches a cloud-sync client makes on wake.

## Fix

- **Rebase instead of reseed.** Replay the log (identity intact), then apply the on-disk text as one more `SYSTEM_ORIGIN` update via `replaceYDocText`, persisted explicitly because this can run inside `onLoadDocument` before Hocuspocus attaches its `onChange` listener (a second row from `onChange`, if it fires, carries the same items and replays idempotently). Disk still wins; the log is never purged. Side benefit: comment threads and pending rounds survive an external edit instead of being wiped with the log.
- **Compare both sides normalized** in the external-edit check, so typography-only differences stop reading as edits.

## Test

`src/lib/server/external-edit-rebase.test.ts` covers both a content-free mtime bump and a genuine external edit, each with a stale client reconnecting afterwards. Both tests fail on `main` (`expected 2 to be 1`, the duplication reproduced exactly) and pass here.

- `npm run test:unit`: 57 passed
- `npm run check`: 0 errors

## Not covered

The fix stops further growth but does not shrink an already-duplicated file. Restore the pre-duplication version from version history while docwriter is closed, then reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeWteoz8B6UqGQJmKr2X9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeWteoz8B6UqGQJmKr2X9K)_